### PR TITLE
fixes and menu workflow adjustments

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -287,7 +287,6 @@ class Controller:
         return Path.MAIN_MENU
 
     def show_delete_a_passphrase_tool(self):
-        print("delete a passphrase")
         if self.storage.num_of_passphrase_seeds() == 0:
             self.menu_view.draw_modal(["No stored seeds with", "passphrase found"], "Error", "Right to Continue")
             self.buttons.wait_for([B.KEY_RIGHT])
@@ -337,8 +336,7 @@ class Controller:
             elif ret_val == Path.SEED_WORD_24:
                 seed_phrase = self.seed_tools_view.display_gather_words_screen(24)
             elif ret_val == Path.SEED_WORD_QR:
-                # TODO Add Functionality here? or maybe return to another seed tools menu?
-                return Path.SIGNING_TOOLS_SUB_MENU
+                seed_phrase = self.seed_tools_view.read_seed_phrase_qr()
             else:
                 return Path.SIGNING_TOOLS_SUB_MENU
 
@@ -353,6 +351,20 @@ class Controller:
                 input = self.buttons.wait_for([B.KEY_RIGHT])
                 return Path.MAIN_MENU
 
+            r = self.menu_view.display_generic_selection_menu(["Yes", "No"], "Optional Passphrase?")
+            if r == 1:
+                # display a tool to pick letters/numbers to make a passphrase
+                passphrase = self.seed_tools_view.display_gather_passphrase_screen()
+                if len(passphrase) == 0 or passphrase == "-1":
+                    passphrase = ""
+                    self.menu_view.draw_modal(["No passphrase added", "to seed words"], "", "Left to Exit, Right to Continue")
+                    input = self.buttons.wait_for([B.KEY_RIGHT, B.KEY_LEFT])
+                    if input == B.KEY_LEFT:
+                        return Path.MAIN_MENU
+                else:
+                    self.menu_view.draw_modal(["Optional passphrase", "added to seed words", passphrase], "", "Right to Continue")
+                    self.buttons.wait_for([B.KEY_RIGHT])
+
         # display seed phrase
         while True:
             r = self.seed_tools_view.display_seed_phrase(seed_phrase, passphrase, "Right to Continue")
@@ -362,8 +374,11 @@ class Controller:
                 # Cancel
                 return Path.SIGNING_TOOLS_SUB_MENU
 
-        self.signing_tools_view.draw_modal(["Generating xpub QR ..."])
+        self.signing_tools_view.draw_modal(["Loading xPub Info ..."])
         self.wallet.set_seed_phrase(seed_phrase, passphrase)
+        self.signing_tools_view.display_xpub_info(self.wallet)
+        self.buttons.wait_for([B.KEY_RIGHT])
+        self.signing_tools_view.draw_modal(["Generating xPub QR ..."])
         self.signing_tools_view.display_xpub_qr(self.wallet)
         return Path.MAIN_MENU
 
@@ -392,8 +407,7 @@ class Controller:
             elif ret_val == Path.SEED_WORD_24:
                 seed_phrase = self.seed_tools_view.display_gather_words_screen(24)
             elif ret_val == Path.SEED_WORD_QR:
-                # TODO Add Functionality here? or maybe return to another seed tools menu?
-                return Path.SIGNING_TOOLS_SUB_MENU
+                seed_phrase = self.seed_tools_view.read_seed_phrase_qr()
             else:
                 return Path.SIGNING_TOOLS_SUB_MENU
 
@@ -407,6 +421,20 @@ class Controller:
                 self.menu_view.draw_modal(["Seed Invalid", "check seed phrase", "and try again"], "", "Right to Continue")
                 input = self.buttons.wait_for([B.KEY_RIGHT])
                 return Path.MAIN_MENU
+
+            r = self.menu_view.display_generic_selection_menu(["Yes", "No"], "Optional Passphrase?")
+            if r == 1:
+                # display a tool to pick letters/numbers to make a passphrase
+                passphrase = self.seed_tools_view.display_gather_passphrase_screen()
+                if len(passphrase) == 0 or passphrase == "-1":
+                    passphrase = ""
+                    self.menu_view.draw_modal(["No passphrase added", "to seed words"], "", "Left to Exit, Right to Continue")
+                    input = self.buttons.wait_for([B.KEY_RIGHT, B.KEY_LEFT])
+                    if input == B.KEY_LEFT:
+                        return Path.MAIN_MENU
+                else:
+                    self.menu_view.draw_modal(["Optional passphrase", "added to seed words", passphrase], "", "Right to Continue")
+                    self.buttons.wait_for([B.KEY_RIGHT])
 
         # display seed phrase
         while True:

--- a/src/seedsigner/helpers/buttons.py
+++ b/src/seedsigner/helpers/buttons.py
@@ -35,6 +35,7 @@ class Buttons:
     def wait_for(self, keys = [], check_release = True, release_keys = []) -> int:
         if not release_keys:
             release_keys = keys
+        self.override_ind = False
         while True:
             for i in keys:
                 if check_release == False or ((check_release == True and i in release_keys and B.release_lock == True) or check_release == True and i not in release_keys):
@@ -55,12 +56,19 @@ class Buttons:
         B.release_lock = True
         return
 
-    def trigger_override(self) -> bool:
+    def trigger_override(self, force_release = False) -> bool:
+        if force_release == True:
+            B.release_lock = True
+
         if self.override_ind == False:
             self.override_ind = True
             return True
 
         return False
+
+    def force_release(self) -> bool:
+        B.release_lock = True
+        return True
 
     def check_for_low(self, key) -> bool:
         if self.GPIO.input(key) == self.GPIO.LOW:

--- a/src/seedsigner/views/menu_view.py
+++ b/src/seedsigner/views/menu_view.py
@@ -24,12 +24,12 @@ class MenuView(View):
     def display_main_menu(self, sub_menu = None) -> int:
         ret_val = 0
         input = 0
-        lines = ["Seed Tools", "Signing Tools", "Settings", "Power OFF Device"]
+        lines = ["Seed Tools", "Sign a Transaction", "Settings", "Power Off"]
 
         if sub_menu == Path.SEED_TOOLS_SUB_MENU:
             return self.display_seed_tools_menu()
         elif sub_menu == Path.SIGNING_TOOLS_SUB_MENU:
-            return self.display_signing_tools_menu()
+            return Path.SIGN_TRANSACTION
         elif sub_menu == Path.SETTINGS_SUB_MENU:
             return self.display_settings_menu()
         else:
@@ -49,7 +49,7 @@ class MenuView(View):
                 if self.selected_menu_num == 1:
                     ret_val = self.display_seed_tools_menu()
                 elif self.selected_menu_num == 2:
-                    ret_val = self.display_signing_tools_menu()
+                    ret_val = Path.SIGN_TRANSACTION
                 elif self.selected_menu_num == 3:
                     ret_val = self.display_settings_menu()
                 elif self.selected_menu_num == 4:
@@ -70,7 +70,7 @@ class MenuView(View):
             else:
                 seed_storage_line = "View Seeds (temp)"
 
-        lines = ["... [ Return to Main ]", "Generate Word 12 / 24", "Create a Seed w/ Dice", seed_storage_line, "Add Passphrase", "Delete Passphrase"]
+        lines = ["... [ Return to Main ]", "Input a Seed", "Add/Remove Passphrase", "Generate an xPub", "Generate Work 12/24", "Generate a Seed with Dice"]
         self.draw_menu(lines, 1)
         input = 0
 
@@ -85,15 +85,15 @@ class MenuView(View):
                 if self.selected_menu_num == 1:
                     return Path.MAIN_MENU
                 elif self.selected_menu_num == 2:
-                    return Path.GEN_LAST_WORD
-                elif self.selected_menu_num == 3:
-                    return Path.DICE_GEN_SEED
-                elif self.selected_menu_num == 4:
                     return Path.SAVE_SEED
-                elif self.selected_menu_num == 5:
+                elif self.selected_menu_num == 3:
                     return Path.PASSPHRASE_SEED
+                elif self.selected_menu_num == 4:
+                    return Path.GEN_XPUB
+                elif self.selected_menu_num == 5:
+                    return Path.GEN_LAST_WORD
                 elif self.selected_menu_num == 6:
-                    return Path.DELETE_PASSPHRASE
+                    return Path.DICE_GEN_SEED
 
     ### Signing Tools Menu
 
@@ -121,12 +121,12 @@ class MenuView(View):
     ### Settings Menu
 
     def display_settings_menu(self) -> int:
-        lines = ["... [ Return to Main ]", "Input / Output Tests", "Current Network: <network>", "Wallet: <wallet>", "Wallet Policy: <policy>", "QR Density: <density>", "Version Info", "Donate to SeedSigner"]
+        lines = ["... [ Return to Main ]", "Input / Output Tests", "Wallet: <wallet>", "Wallet Policy: <policy>", "Current Network: <network>", "QR Density: <density>", "Version Info", "Donate to SeedSigner"]
         input = 0
         
-        lines[2] = lines[2].replace("<network>", self.controller.wallet.get_network())
-        lines[3] = lines[3].replace("<wallet>", self.controller.wallet.get_name())
-        lines[4] = lines[4].replace("<policy>", self.controller.wallet.get_wallet_policy_name())
+        lines[2] = lines[2].replace("<wallet>", self.controller.wallet.get_name())
+        lines[3] = lines[3].replace("<policy>", self.controller.wallet.get_wallet_policy_name())
+        lines[4] = lines[4].replace("<network>", self.controller.wallet.get_network())
         lines[5] = lines[5].replace("<density>", self.controller.wallet.get_qr_density_name())
 
         # Draw Menu
@@ -146,11 +146,11 @@ class MenuView(View):
                 elif self.selected_menu_num == 2:
                     return Path.IO_TEST_TOOL
                 elif self.selected_menu_num == 3:
-                    return Path.CURRENT_NETWORK
-                elif self.selected_menu_num == 4:
                     return Path.WALLET
-                elif self.selected_menu_num == 5:
+                elif self.selected_menu_num == 4:
                     return Path.WALLET_POLICY
+                elif self.selected_menu_num == 5:
+                    return Path.CURRENT_NETWORK
                 elif self.selected_menu_num == 6:
                     return Path.QR_DENSITY_SETTING
                 elif self.selected_menu_num == 7:

--- a/src/seedsigner/views/menu_view.py
+++ b/src/seedsigner/views/menu_view.py
@@ -98,7 +98,7 @@ class MenuView(View):
     ### Signing Tools Menu
 
     def display_signing_tools_menu(self) -> None:
-        lines = ["... [ Return to Main ]", "Generate XPUB", "Sign a Transaction"]
+        lines = ["... [ Return to Main ]", "Generate xPub", "Sign a Transaction"]
         self.draw_menu(lines, 1)
         input = 0
 
@@ -130,6 +130,7 @@ class MenuView(View):
         lines[5] = lines[5].replace("<density>", self.controller.wallet.get_qr_density_name())
 
         # Draw Menu
+        self.selected_menu_num = 1
         self.draw_menu(lines, 1)
 
         # Wait for Button Input (specifically menu selection/press)
@@ -161,7 +162,8 @@ class MenuView(View):
     ### Generic Single Menu Selection (returns 1,2,3,4,5,6 ...)
 
     def display_generic_selection_menu(self, lines = [], title = None, bottom = None) -> int:
-        self.draw_menu(lines, 1, title, bottom)
+        self.selected_menu_num = 1
+        self.draw_menu(lines, 1, title, bottom, True)
 
         while True:
             input = self.buttons.wait_for([B.KEY_UP, B.KEY_DOWN, B.KEY_PRESS])
@@ -271,7 +273,7 @@ class MenuView(View):
 
     ### Generic Draw Menu Method
 
-    def draw_menu(self, lines, selected_menu_num = 1, title = None, bottom = None) -> None:
+    def draw_menu(self, lines, selected_menu_num = 1, title = None, bottom = None, force_redraw = False) -> None:
         if title == None:
             t = "SeedSigner  v" + self.controller.VERSION
         else:
@@ -297,7 +299,7 @@ class MenuView(View):
         else:
             b = bottom
 
-        if lines != self.menu_lines or selected_menu_num != self.selected_menu_num:
+        if lines != self.menu_lines or selected_menu_num != self.selected_menu_num or force_redraw == True:
             #Menu has changed, redraw
 
             View.draw.rectangle((0, 0, View.canvas_width, View.canvas_height), outline=0, fill=0)

--- a/src/seedsigner/views/seed_tools_view.py
+++ b/src/seedsigner/views/seed_tools_view.py
@@ -197,10 +197,12 @@ class SeedToolsView(View):
     ### Display Gather PassPhrase Screen
     ###
 
-    def display_gather_passphrase_screen(self, slot_num = 0) -> str:
+    def display_gather_passphrase_screen(self, existing_passphrase = "") -> str:
         self.reset()
         self.pass_letter = "a"
         self.pass_case_toggle = "lower"
+        if existing_passphrase != "":
+            self.passphrase = existing_passphrase
         self.draw_gather_passphrase()
 
         # Wait for Button Input (specifically menu selection/press)

--- a/src/seedsigner/views/signing_tools_view.py
+++ b/src/seedsigner/views/signing_tools_view.py
@@ -18,17 +18,9 @@ class SigningToolsView(View):
 
     def display_xpub_qr(self, wallet):
         xpubstring = wallet.import_qr()
-        (fingerprint, derivation, xpub) = wallet.get_xpub_info()
-        
         print(xpubstring)
 
         xpub_images = wallet.make_xpub_qr_codes(xpubstring)
-
-        # display finger
-        derivation_display = "Derivation: " + derivation
-        xpub_display = xpub[0:8] + "..." + xpub[-10:]
-        self.draw_modal(["Master Fingerprint: ", fingerprint, derivation_display, xpub_display], "Xpub Info", "Right to Continue")
-        self.buttons.wait_for([B.KEY_RIGHT])
 
         cnt = 0
         step = False
@@ -64,6 +56,12 @@ class SigningToolsView(View):
                     cnt -= 1
                     if cnt < 0:
                         cnt = len(xpub_images) - 1
+
+    def display_xpub_info(self, wallet):
+        (fingerprint, derivation, xpub) = wallet.get_xpub_info()
+        derivation_display = "Derivation: " + derivation
+        xpub_display = xpub[0:7] + "..." + xpub[-9:]
+        self.draw_modal(["Master Fingerprint: ", fingerprint, derivation_display, xpub_display], "Xpub Info", "Right to Continue")
 
     ###
     ### Sign Transaction


### PR DESCRIPTION
- add prompt for optional passphrase when entering seed for xpub and sign transaction
- add Loading xPub Info beforing displaying xPub info and moving QR gen after
- fix for double click after scan seed qr
- changed Generate XPUB to Generate xPub (hard to tell for the generic abbreviation is for extended public key)
- fixed draw menu bug when showing same menu twice
- added force redraw option to draw_menu function
- Updated passphrase exit/save button to be Exit (not sure about this) need help on wording and workflow
- Updated Scan Seed QR scanning screen to match other screens (moved left to cancel to bottom)
- fixed scan seed qr bug that returned object reference to seed words, causing invalid or empty seed words occationally