### PR TITLE
Additional PSBT error handling

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -480,11 +480,19 @@ class Controller:
         if raw_pbst == "nodata":
             return Path.MAIN_MENU
         if raw_pbst == "invalid":
-            self.menu_view.draw_modal(["QR Format Unexpected", "Check Wallet in Settings"], "", "RIGHT to EXIT")
+            self.menu_view.draw_modal(["QR Format Unexpected", "Check Wallet in Settings"], "", "Right to Exit")
+            input = self.buttons.wait_for([B.KEY_RIGHT])
+            return Path.MAIN_MENU
+        if raw_pbst == "invalidpsbt":
+            self.menu_view.draw_modal(["PSBT UR 2.0 Decoding Error", "try again"], "", "Right to Exit")
             input = self.buttons.wait_for([B.KEY_RIGHT])
             return Path.MAIN_MENU
         self.menu_view.draw_modal(["Parsing PSBT ..."])
-        self.wallet.parse_psbt(raw_pbst)
+        parse_status = self.wallet.parse_psbt(raw_pbst)
+        if parse_status == False:
+            self.menu_view.draw_modal(["PSBT Parsing Failed"], "", "Right to Exit")
+            input = self.buttons.wait_for([B.KEY_RIGHT])
+            return Path.MAIN_MENU
 
         # show transaction information before sign
         self.signing_tools_view.display_transaction_information(self.wallet)

--- a/src/seedsigner/models/blue_wallet.py
+++ b/src/seedsigner/models/blue_wallet.py
@@ -124,7 +124,7 @@ class BlueWallet(Wallet):
     def set_qr_density(self, density):
         self.cur_qr_density = density
         if density == Wallet.QRLOW:
-            self.qrsize = 70
+            self.qrsize = 20
         elif density == Wallet.QRMEDIUM:
             self.qrsize = 100
         elif density == Wallet.QRHIGH:

--- a/src/seedsigner/models/specter_desktop_wallet.py
+++ b/src/seedsigner/models/specter_desktop_wallet.py
@@ -21,11 +21,12 @@ class SpecterDesktopWallet(Wallet):
         return "Specter Desktop"
 
     def parse_psbt(self, raw_psbt) -> bool:
-
-        base64_psbt = a2b_base64(raw_psbt)
-        self.tx = psbt.PSBT.parse(base64_psbt)
-
-        self._parse_psbt()
+        try:
+            base64_psbt = a2b_base64(raw_psbt)
+            self.tx = psbt.PSBT.parse(base64_psbt)
+            self._parse_psbt()
+        except Exception:
+            return False
 
         return True
 


### PR DESCRIPTION
this should prevent at least an animated qr scan from causing seedsigner to freeze/crash for sparrow and specter.