### PR TITLE
Add info about GPIO pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To build a SeedSigner, you will need:
 * Pi Zero-conpatible camera (tested to work with the Aokin / AuviPal 5MP 1080p with OV5647 Sensor)
 
 Notes:
-* You will need to solder the 20 GPIO pins to the Raspberry Pi Zero board. If you don't want to solder, purchase "GPIO Hammer Headers" for a solderless experience.
+* You will need to solder the 40 GPIO pins (20 pins per row) to the Raspberry Pi Zero board. If you don't want to solder, purchase "GPIO Hammer Headers" for a solderless experience.
 * Other cameras with the above sensor module should work, but may not fit in the Orange Pill enclosure
 * Choose the Waveshare screen carefully; make sure to purchase the model that has a resolution of 240x240 pixels
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To build a SeedSigner, you will need:
 * Pi Zero-conpatible camera (tested to work with the Aokin / AuviPal 5MP 1080p with OV5647 Sensor)
 
 Notes:
+* You will need to solder the 20 GPIO pins to the Raspberry Pi Zero board. If you don't want to solder, purchase "GPIO Hammer Headers" for a solderless experience.
 * Other cameras with the above sensor module should work, but may not fit in the Orange Pill enclosure
 * Choose the Waveshare screen carefully; make sure to purchase the model that has a resolution of 240x240 pixels
 


### PR DESCRIPTION
Remember that GPIO pins need to be soldered. Remind of solderless alternative.
Good to be at the shopping list, since users forget about it if not. Happened to me recently when helping a friend (I forgot to tell him about the pins - even having done the process a couple of months back)