### PR TITLE
Randomise dice reset

### DIFF
--- a/src/seedsigner/views/seed_tools_view.py
+++ b/src/seedsigner/views/seed_tools_view.py
@@ -804,7 +804,11 @@ class SeedToolsView(View):
             self.roll_data += str(self.dice_selected)
 
         # Reset for the next UI render
-        self.dice_selected = 5
+        if self.dice_selected > 3:
+            self.dice_selected = 5
+        else:
+            self.dice_selected = 2
+            
         if self.roll_number < 100:
             self.draw_dice(self.dice_selected)
 

--- a/src/seedsigner/views/seed_tools_view.py
+++ b/src/seedsigner/views/seed_tools_view.py
@@ -804,7 +804,7 @@ class SeedToolsView(View):
             self.roll_data += str(self.dice_selected)
 
         # Reset for the next UI render
-        if self.dice_selected > 3:
+        if self.roll_number > 45:
             self.dice_selected = 5
         else:
             self.dice_selected = 2


### PR DESCRIPTION
At present, the selected dice value resets to 5 after each input of a dice roll. 

To minimise the number of user inputs during seed generation via this method, the default value should randomly oscillate between 2 and 5. From the default 5 location, two inputs are required to reach 1/3 (but only one input to reach 4/6), whereas from a default 2 location two inputs are required to reach 4/6 (but only one to 1/3). By randomly selecting either 2/5 default with 50/50 probability for either selection, statistically the number of user inputs required will be minimised during the process of seed generation by dice rolls.

This PR proposes a very simple method to randomly select a 2/5 default, based on the value of the previous input. This method is sufficiently random to benefit the user provided that the assumption that the dice used to generate the seed is unbiased, is accurate.