### PR TITLE
Add instructions to validate/install official image

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ https://youtu.be/aIIc2DiZYcI
 
 ---------------
 
+## OFFICIAL IMAGE INSTALLATION:
+There is available an official image you can use to quick start. Instructions [here](docs/official_image_installation.md).
+
+---------------
+
 ## MANUAL BUILD INSTRUCTIONS:
 Begin by preparing a copy of the Raspberry Pi Lite operating system (https://www.raspberrypi.org/software/operating-systems/) on a MicroSD card. Their [Raspberry Pi Imager](https://www.raspberrypi.org/software/) tool makes this easy.
 

--- a/docs/official_image_installation.md
+++ b/docs/official_image_installation.md
@@ -9,12 +9,16 @@ gpg --import seedsigner_pubkey.gpg
 ```
 3. Download the latest release of the image at the [releases page](https://github.com/SeedSigner/seedsigner/releases). It will look something like seedsigner_x_x_x.img.zip
 4. Download the related gpg file in the same folder. It will look like seedsigner_x_x_x.img.zip.txt.gpg
-5. Verify the downloaded file with the command (adjust the file name to the file you just downloaded):
+5. Decrypt the gpg file to see the file name and the check sum of the released file:
 ```
- gpg --verify seedsigner_x_x_x.img.zip.txt.gpg
+ gpg --decrypt seedsigner_x_x_x.img.zip.txt.gpg
 ```
 6. You can trust the file if the output of the previous command has a message like:
 ```
 Good signature from "seedsigner <btc.hardware.solutions@gmail.com>"
 ```
-7. If everything went ok you can unzip the file and use your preferred software to burn a MicroSD with the image extracted.
+7. Now check the hash of the release file with:
+```
+ sha256sum seedsigner_x_x_x.img.zip
+```
+8. The output of the last command should be identical to the hash contained in the output of step 5.

--- a/docs/official_image_installation.md
+++ b/docs/official_image_installation.md
@@ -1,0 +1,20 @@
+# Using provided OS image file
+
+If you want to avoid the long process of installation, you should at least validate you are downloading the official image. You will need gpg installed.
+
+1. Save the public key file [seedsigner_pubkey.gpg](https://raw.githubusercontent.com/seedsigner/seedsigner/main/seedsigner_pubkey.gpg) as seedsigner_pubkey.gpg
+2. Import the public key
+```
+gpg --import seedsigner_pubkey.gpg
+```
+3. Download the latest release of the image at the [releases page](https://github.com/SeedSigner/seedsigner/releases). It will look something like seedsigner_x_x_x.img.zip
+4. Download the related gpg file in the same folder. It will look like seedsigner_x_x_x.img.zip.txt.gpg
+5. Verify the downloaded file with the command (adjust the file name to the file you just downloaded):
+```
+ gpg --verify seedsigner_x_x_x.img.zip.txt.gpg
+```
+6. You can trust the file if the output of the previous command has a message like:
+```
+Good signature from "seedsigner <btc.hardware.solutions@gmail.com>"
+```
+7. If everything went ok you can unzip the file and use your preferred software to burn a MicroSD with the image extracted.


### PR DESCRIPTION
I just have been through the process of installing and I thought it would be good to have instructions on how to validate the image. This process was done in a mac OS, but I believe it would work on linux as well. Unfortunately I don't have a windows machine to validate the process.