### PR TITLE
Test known dice rolls to verify that mnemonic matches and remove special case for dice roll six

### DIFF
--- a/src/seedsigner/views/seed_tools_view.py
+++ b/src/seedsigner/views/seed_tools_view.py
@@ -795,10 +795,7 @@ class SeedToolsView(View):
 
     def dice_arrow_press(self):
         self.roll_number += 1
-        if self.dice_selected == 6:
-            self.roll_data += "0"
-        else:
-            self.roll_data += str(self.dice_selected)
+        self.roll_data += str(self.dice_selected)
 
         # Reset for the next UI render
         if self.roll_number > 45:

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -30,3 +30,43 @@ def test_calculate_checksum():
     mnemonic = mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist=bip39.WORDLIST)
     assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
+
+
+def test_verify_against_coldcard_sample():
+    """ https://coldcard.com/docs/verifying-dice-roll-math """
+    dice_rolls = "123456"
+    expected = "mirror reject rookie talk pudding throw happy era myth already payment own sentence push head sting video explain letter bomb casual hotel rather garment"
+
+    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
+    actual = " ".join(mnemonic)
+    assert bip39.mnemonic_is_valid(actual)
+    assert actual == expected
+
+
+
+def test_known_dice_rolls():
+    """ Given 99 known dice rolls, the resulting mnemonic should be valid and match the expected. """
+    dice_rolls = "522222222222222222222222222222222222222222222555555555555555555555555555555555555555555555555555555"
+    expected = "resource timber firm banner horror pupil frozen main pear direct pioneer broken grid core insane begin sister pony end debate task silk empty curious"
+
+    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
+    actual = " ".join(mnemonic)
+    assert bip39.mnemonic_is_valid(actual)
+    assert actual == expected
+
+    dice_rolls = "222222222222222222222222222222222222222222222555555555555555555555555555555555555555555555555555555"
+    expected = "garden uphold level clog sword globe armor issue two cute scorpion improve verb artwork blind tail raw butter combine move produce foil feature wave"
+
+    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
+    actual = " ".join(mnemonic)
+    assert bip39.mnemonic_is_valid(actual)
+    assert actual == expected
+
+    dice_rolls = "222222222222222222222222222222222222222222222555555555555555555555555555555555555555555555555555556"
+    expected = "lizard broken love tired depend eyebrow excess lonely advance father various cram ignore panic feed plunge miss regret boring unique galaxy fan detail fly"
+
+    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
+    actual = " ".join(mnemonic)
+    assert bip39.mnemonic_is_valid(actual)
+    assert actual == expected
+


### PR DESCRIPTION
The unit test dice rolls were chosen to be convenient to also manually verify on the device. See https://github.com/SeedSigner/seedsigner/pull/88 why number 2 and 5 are good dice rolls for this. The last test case hilights the issue with an older version of the generator where valid values where in the integer range [0, 5] and thus 6 was transformed to 0.