### PR TITLE
Single sig change address verification 

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -690,6 +690,15 @@ class PSBTChangeDetailsScreen(ButtonListScreen):
                 screen_x=GUIConstants.EDGE_PADDING,
                 screen_y=self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING,
             ))
+        elif self.is_multisig == False and self.is_change_addr_verified == False:
+            self.components.append(IconTextLine(
+                icon_name=SeedSignerCustomIconConstants.CIRCLE_EXCLAMATION,
+                icon_color=GUIConstants.DIRE_WARNING_COLOR,
+                value_text="Failed verification!",
+                is_text_centered=False,
+                screen_x=GUIConstants.EDGE_PADDING,
+                screen_y=self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING,
+            ))
         else:
             pass
 

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -106,6 +106,11 @@ class Seed:
         root = bip32.HDKey.from_seed(self.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(network)]["xprv"])
         return hexlify(root.child(0).fingerprint).decode('utf-8')
         
+    def get_xpub(self, wallet_path: str = '/', network: str = SettingsConstants.MAINNET):
+        root = bip32.HDKey.from_seed(self.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(network)]["xprv"])
+        xprv = root.derive(wallet_path)
+        xpub = xprv.to_public()
+        return xpub
     
     ### override operators    
     def __eq__(self, other):

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -305,10 +305,28 @@ class PSBTChangeDetailsView(View):
             button_data = [VERIFY_MULTISIG, NEXT]
         else:
             # Single sig
-            # TODO: Generate address from seed at derivation_path and compare with
-            # change_data["address"]
-            # Save for Nick
-            is_change_addr_verified = True
+            
+            try:
+                # convert change address to script pubkey to get script type
+                pubkey = script.address_to_scriptpubkey(change_data["address"])
+                script_type = pubkey.script_type()
+                
+                # extract derivation path to get wallet and change derivation
+                change_path = '/'.join(derivation_path.split("/")[-2:])
+                wallet_path = '/'.join(derivation_path.split("/")[:-2])
+                
+                xpub = self.controller.psbt_seed.get_xpub(wallet_path=wallet_path, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+                
+                # take script type and call script method to generate address from seed / derivation
+                scriptcall = getattr(script, script_type)
+                calc_address = scriptcall(xpub.derive(change_path).key).address(network=NETWORKS[network])
+                
+                if change_data["address"] == calc_address:
+                    is_change_addr_verified = True
+                
+            except:
+                is_change_addr_verified = False
+
             button_data = [NEXT]
 
         selected_menu_num = psbt_screens.PSBTChangeDetailsScreen(

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -333,7 +333,7 @@ class PSBTChangeDetailsView(View):
             except:
                 is_change_addr_verified = False
                 
-                button_data = [NEXT]
+            button_data = [NEXT]
 
         if is_change_addr_verified == False and psbt_parser.is_multisig == False:
             

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -281,6 +281,7 @@ class PSBTChangeDetailsView(View):
         derivation_path_addr_index = int(derivation_path.split("/")[-1])
 
         NEXT = "Next"
+        EXIT = "Exit"
 
         if is_change_derivation_path:
             title = "Your Change"
@@ -331,9 +332,26 @@ class PSBTChangeDetailsView(View):
                 
             except:
                 is_change_addr_verified = False
+                
+                button_data = [NEXT]
 
+        if is_change_addr_verified == False and psbt_parser.is_multisig == False:
+            
+            button_data = [EXIT, NEXT]
+            
+            selected_menu_num = WarningScreen(
+                title="Change Address",
+                status_icon_name=SeedSignerCustomIconConstants.CIRCLE_EXCLAMATION,
+                status_headline="Address Failed Verification",
+                text="Change address verification failed with single sig seed.",
+                button_data=[EXIT, NEXT],
+            ).display()
+            
+            if button_data[selected_menu_num] == EXIT:
+                return Destination(MainMenuView, clear_history=True)
+                
             button_data = [NEXT]
-
+                
         selected_menu_num = psbt_screens.PSBTChangeDetailsScreen(
             title=title,
             button_data=button_data,
@@ -359,6 +377,7 @@ class PSBTChangeDetailsView(View):
             
         elif button_data[selected_menu_num] == VERIFY_MULTISIG:
             return Destination(NotYetImplementedView)
+            
 
 
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -1,4 +1,6 @@
 from embit.psbt import PSBT
+from embit import script
+from embit.networks import NETWORKS
 
 from seedsigner.models.encode_qr import EncodeQR
 from seedsigner.models.qr_type import QRType
@@ -302,6 +304,8 @@ class PSBTChangeDetailsView(View):
                 # button_data = [VERIFY_MULTISIG, NEXT]
 
             # Temp value while awaiting above
+            # TODO: complete multi sig change address verification
+
             button_data = [VERIFY_MULTISIG, NEXT]
         else:
             # Single sig
@@ -319,7 +323,8 @@ class PSBTChangeDetailsView(View):
                 
                 # take script type and call script method to generate address from seed / derivation
                 scriptcall = getattr(script, script_type)
-                calc_address = scriptcall(xpub.derive(change_path).key).address(network=NETWORKS[network])
+                network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+                calc_address = scriptcall(xpub.derive(change_path).key).address(network=NETWORKS[SettingsConstants.map_network_to_embit(network)])
                 
                 if change_data["address"] == calc_address:
                     is_change_addr_verified = True


### PR DESCRIPTION
For single sig case, when the PSBT indicates an output address is change (has same pubkey as input) then it takes the extra step of validating the output address is change from the seed. This happens by taking the seed and derivation path included on the PSBT to generate the address. When the change address matches the output address, is_change_addr_verified is set to true.