### PR TITLE
Add warning screen when PSBT change can not be detected because of legacy script type

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -147,7 +147,7 @@ class PSBTUnsupportedScriptTypeWarningView(View):
     def run(self):
         selected_menu_num = WarningScreen(
             status_headline="Unsupported Script Type!",
-            text="This PSBT inputs have an unsupported script type. Verify your change addresses.",
+            text="PSBT has unsupported input script type, please verify your change addresses.",
             button_data=["Continue"],
         ).display()
         

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -134,6 +134,8 @@ class PSBTOverviewView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
+        # expecting p2sh (legacy multisig) and p2pkh to have no policy set
+        # skip change warning and psbt math view
         if psbt_parser.policy == None:
             return Destination(PSBTUnsupportedScriptTypeWarningView)
         
@@ -155,8 +157,9 @@ class PSBTUnsupportedScriptTypeWarningView(View):
             return Destination(BackStackView)
         
         # Only one exit point
+        # skip PSBTMathView
         return Destination(
-            PSBTMathView,
+            PSBTAddressDetailsView, view_args={"address_num": 0},
             skip_current_view=True,  # Prevent going BACK to WarningViews
         )
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -134,13 +134,31 @@ class PSBTOverviewView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        if psbt_parser.change_amount == 0:
+        if psbt_parser.policy == None:
+            return Destination(PSBTUnsupportedScriptTypeWarningView)
+        
+        elif psbt_parser.change_amount == 0:
             return Destination(PSBTNoChangeWarningView)
 
         else:
             return Destination(PSBTMathView)
 
-
+class PSBTUnsupportedScriptTypeWarningView(View):
+    def run(self):
+        selected_menu_num = WarningScreen(
+            status_headline="Unsupported Script Type!",
+            text="This PSBT inputs have an unsupported script type. Verify your change addresses.",
+            button_data=["Continue"],
+        ).display()
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        
+        # Only one exit point
+        return Destination(
+            PSBTMathView,
+            skip_current_view=True,  # Prevent going BACK to WarningViews
+        )
 
 class PSBTNoChangeWarningView(View):
     def run(self):


### PR DESCRIPTION
When the input script type is unable to be detected, then change outputs and amounts is unable to be calculated. So instead of showing a no change warning, this message will be shown instead: "PSBT has unsupported input script type, please verify your change addresses."