### PR TITLE
Addr verify single sig fix

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -477,7 +477,7 @@ class DecodeQR:
     def is_bitcoin_address(s):
         if re.search(r'^bitcoin\:.*', s, re.IGNORECASE):
             return True
-        elif re.search(r'^((bc1|tb1|[123]|[mn])[a-zA-HJ-NP-Z0-9]{25,62})$', s):
+        elif re.search(r'^((bc1|tb1|bcr|[123]|[mn])[a-zA-HJ-NP-Z0-9]{25,62})$', s):
             # TODO: Handle regtest bcrt?
             return True
         else:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1413,6 +1413,7 @@ class SeedAddressVerificationView(View):
             descriptor=self.controller.multisig_wallet_descriptor,
             script_type=self.script_type,
             network=embit_network,
+            derivation_path=self.derivation_path,
             threadsafe_counter=self.threadsafe_counter,
             verified_index=self.verified_index,
             verified_index_is_change=self.verified_index_is_change,
@@ -1482,7 +1483,7 @@ class SeedAddressVerificationView(View):
 
 
     class BruteForceAddressVerificationThread(BaseThread):
-        def __init__(self, address: str, seed: Seed, descriptor: Descriptor, script_type: str, network: str, threadsafe_counter: ThreadsafeCounter, verified_index: ThreadsafeCounter, verified_index_is_change: ThreadsafeCounter):
+        def __init__(self, address: str, seed: Seed, descriptor: Descriptor, script_type: str, network: str, derivation_path: str, threadsafe_counter: ThreadsafeCounter, verified_index: ThreadsafeCounter, verified_index_is_change: ThreadsafeCounter):
             """
                 Either seed or descriptor will be None
             """
@@ -1492,6 +1493,7 @@ class SeedAddressVerificationView(View):
             self.descriptor = descriptor
             self.script_type = script_type
             self.network = network
+            self.derivation_path = derivation_path
             self.threadsafe_counter = threadsafe_counter
             self.verified_index = verified_index
             self.verified_index_is_change = verified_index_is_change


### PR DESCRIPTION
Most likely in past refactoring or the addition support for multisig broke single sig address verification. Derivation path was missing in scope of creating the xpub. I also added support for bcr addresses prefix in the decode_qr function for regtest. 