### PR TITLE
Make gpg commands version agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ After downloading the .zip file, extract the seedsigner .img file, and write it 
 You can verify the data integrity and authenticity of the latest release with as little as three commands (though moving forward you will have to replace the version in the following commands with the version number you are attempting to validate). This process assumes that you have navigated to a folder where you have these four relevant files present:
 
 * seedsigner_pubkey.gpg (from the main folder of this repo)
-* seedsigner_0_4_5.img.zip (from the software release)
-* seedsigner_0_4_5.img.zip.sha256 (from the software release)
-* seedsigner_0_4_5.img.zip.sha256.sig (from the software release)
+* seedsigner_0_X_X.img.zip (from the software release)
+* seedsigner_0_X_X.img.zip.sha256 (from the software release)
+* seedsigner_0_X_X.img.zip.sha256.sig (from the software release)
 
 This process also assumes you are running the commands from a system where both GPG and shasum are installed and working.
 
@@ -101,7 +101,7 @@ key <...> not changed
 
 Now you can verify the authenticity of the small text file containing the release's SHA256 hash with the command:
 ```
-gpg --verify seedsigner_0_4_5.img.zip.sha256.sig
+gpg --verify seedsigner_0_*_*.img.zip.sha256.sig
 ```
 The reponse to this command should include the text:
 ```
@@ -111,11 +111,11 @@ The previous command validates that aforementioned small text file was signed us
 
 The last step is to make sure the .zip file that you've downloaded, and that contains the released software, is a perfect match to the software that was published by the holder of the private key in the last step. The command for this step is:
 ```
-shasum -a 256 -c seedsigner_0_4_5.img.zip.sha256
+shasum -a 256 -c seedsigner_0_*_*.img.zip.sha256
 ```
 The reponse to this command should include the text:
 ```
-seedsigner_0_4_5.img.zip: OK
+seedsigner_0_X_X.img.zip: OK
 ```
 
 There are other steps you can take to verify the software, including examining the hash value in the .sha256 text file, but this one has been documented here because it seems the simplest for most people to follow. Please recognize that this process can only validate the software to the extent that the entity that first published the key is an honest actor, and assumes the private key has remained uncompromised and is not being used by a malicious actor.

--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ The quickest and easiest way to install the software is to download the most rec
 After downloading the .zip file, extract the seedsigner .img file, and write it to a MicroSD card (at least 4GB in size or larger). Then install the MicroSD in the assembled hardware and off you go. If your goal is a more trustless installation, you can follow the [manual installation instructions](docs/manual_installation.md).
 
 ## Verifying Your Software
-You can verify the data integrity and authenticity of the latest release with as little as three commands (though moving forward you will have to replace the version in the following commands with the version number you are attempting to validate). This process assumes that you have navigated to a folder where you have these four relevant files present:
+You can verify the data integrity and authenticity of the latest release with as little as three commands. This process assumes that you know [how to navigate on a terminal](https://terminalcheatsheet.com/guides/navigate-terminal) and have navigated to the folder where you have these four relevant files present: (This will most likely be your Downloads folder.)
 
 * seedsigner_pubkey.gpg (from the main folder of this repo)
-* seedsigner_0_X_X.img.zip (from the software release)
-* seedsigner_0_X_X.img.zip.sha256 (from the software release)
-* seedsigner_0_X_X.img.zip.sha256.sig (from the software release)
+* seedsigner_0_4_6.img.zip (from the software release)
+* seedsigner_0_4_6.img.zip.sha256 (from the software release)
+* seedsigner_0_4_6.img.zip.sha256.sig (from the software release)
 
-This process also assumes you are running the commands from a system where both GPG and shasum are installed and working.
+**Note:** The specific version number of the files in your folder might not match the above exactly, but their overall format and amount should be the same.
+
+This process also assumes you are running the commands from a system where both [GPG](https://gnupg.org/download/index.html) and [shasum](https://command-not-found.com/shasum) are installed and working.
 
 First make sure that the public key is present in your keychain:
 ```
@@ -103,6 +105,8 @@ Now you can verify the authenticity of the small text file containing the releas
 ```
 gpg --verify seedsigner_0_*_*.img.zip.sha256.sig
 ```
+**Note:** The `*`s in the command above allow the terminal to auto-populate the command with the version number you have in the folder you are in. It should be copied and pasted as is.
+
 The reponse to this command should include the text:
 ```
 Good signature from "seedsigner <btc.hardware.solutions@gmail.com>" [unknown]
@@ -115,7 +119,7 @@ shasum -a 256 -c seedsigner_0_*_*.img.zip.sha256
 ```
 The reponse to this command should include the text:
 ```
-seedsigner_0_X_X.img.zip: OK
+seedsigner_0_4_6.img.zip: OK
 ```
 
 There are other steps you can take to verify the software, including examining the hash value in the .sha256 text file, but this one has been documented here because it seems the simplest for most people to follow. Please recognize that this process can only validate the software to the extent that the entity that first published the key is an honest actor, and assumes the private key has remained uncompromised and is not being used by a malicious actor.


### PR DESCRIPTION
This seeks to make it easier for any user to simply copy and paste without worrying about changing commands to the current version or the one they downloaded.

An alternative would be updating these guidelines with the most recent version on the releases page, but the tradeoff is that it is cumbersome and requires indefinite updates.