### PR TITLE
Light changes to make `SeedWordsScreen` more generalized

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -451,7 +451,7 @@ class SeedOptionsScreen(ButtonListScreen):
 
 @dataclass
 class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
-    seed: Seed = None
+    words: List[str] = None
     page_index: int = 0
     num_pages: int = 3
     is_bottom_list: bool = True
@@ -459,15 +459,9 @@ class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
 
 
     def __post_init__(self):
-        self.title = f"Seed Words: {self.page_index+1}/{self.num_pages}"
         super().__post_init__()
 
-        # Can only render 4 words per screen
-        words_per_page = 4
-        mnemonic = self.seed.mnemonic_display_list
-
-        # Slice the mnemonic to our current 4-word section
-        self.mnemonic = mnemonic[self.page_index*words_per_page:(self.page_index + 1)*words_per_page]
+        words_per_page = len(self.words)
 
         self.body_x = 0
         self.body_y = self.top_nav.height - int(GUIConstants.COMPONENT_PADDING / 2)
@@ -479,7 +473,7 @@ class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
 
         # Calc horizontal center based on longest word
         max_word_width = 0
-        for word in self.mnemonic:
+        for word in self.words:
             (left, top, right, bottom) = font.getbbox(word, anchor="ls")
             if right > max_word_width:
                 max_word_width = right
@@ -503,7 +497,7 @@ class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
         )
         draw = ImageDraw.Draw(self.body_img)
 
-        for index, word in enumerate(self.mnemonic):
+        for index, word in enumerate(self.words):
             draw.rounded_rectangle(
                 (number_box_x, number_box_y, number_box_x + number_box_width, number_box_y + number_box_height),
                 fill="#202020",

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -793,6 +793,12 @@ class SeedWordsView(View):
         NEXT = "Next"
         DONE = "Done"
 
+        # Slice the mnemonic to our current 4-word section
+        words_per_page = 4  # TODO: eventually make this configurable for bigger screens?
+
+        mnemonic = self.seed.mnemonic_display_list
+        words = mnemonic[self.page_index*words_per_page:(self.page_index + 1)*words_per_page]
+
         button_data = []
         if self.page_index < self.num_pages - 1 or self.seed_num is None:
             button_data.append(NEXT)
@@ -800,7 +806,8 @@ class SeedWordsView(View):
             button_data.append(DONE)
 
         selected_menu_num = seed_screens.SeedWordsScreen(
-            seed=self.seed,
+            title=f"Seed Words: {self.page_index+1}/{self.num_pages}",
+            words=words,
             page_index=self.page_index,
             num_pages=self.num_pages,
             button_data=button_data,


### PR DESCRIPTION
* Removes any knowledge of the `Seed` class.
* `title` is now passed in so the calling `View` can alter it (e.g. #194 can now avoid unnecessary copy-paste).

Should be targeted for a v0.5.1 or greater.