### PR TITLE
Reusable `KeyboardScreen`

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -935,12 +935,14 @@ class KeyboardScreen(BaseTopNavScreen):
 
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
         button_height = int((self.canvas_height - GUIConstants.EDGE_PADDING - text_entry_display_y - text_entry_display_height - GUIConstants.COMPONENT_PADDING - (self.rows - 1) * 2) / self.rows)
+
         if self.keyboard_font_size:
             font_size = self.keyboard_font_size
         else:
             # Scale with button height
             font_size = button_height - GUIConstants.COMPONENT_PADDING
-        self.keyboard_digits = Keyboard(
+
+        self.keyboard = Keyboard(
             draw=self.renderer.draw,
             charset=self.keys_charset,
             font_name=self.keyboard_font_name,
@@ -956,7 +958,7 @@ class KeyboardScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
-        self.keyboard_digits.set_selected_key(selected_letter=self.keys_charset[0])
+        self.keyboard.set_selected_key(selected_letter=self.keys_charset[0])
 
         self.text_entry_display = TextEntryDisplay(
             canvas=self.renderer.canvas,
@@ -975,7 +977,7 @@ class KeyboardScreen(BaseTopNavScreen):
     def _render(self):
         super()._render()
 
-        self.keyboard_digits.render_keys()
+        self.keyboard.render_keys()
         self.text_entry_display.render()
 
         self.renderer.show_image()
@@ -1022,7 +1024,7 @@ class KeyboardScreen(BaseTopNavScreen):
                 # ignore
                 continue
     
-            ret_val = self.keyboard_digits.update_from_input(input)
+            ret_val = self.keyboard.update_from_input(input)
     
             # Now process the result from the keyboard
             if ret_val in Keyboard.EXIT_DIRECTIONS:

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -886,6 +886,7 @@ class KeyboardScreen(BaseTopNavScreen):
         * cols
         * keyboard_font_name
         * keyboard_font_size: Specify `None` to auto-size to Key height.
+        * key_height: Specify `None` to maximize key height to available space.
         * keys_charset: Specify the chars displayed on the keys of the keyboard.
         * keys_to_values: Optional mapping from key_charset to input value (e.g. dice icon to digit).
         * return_after_n_chars: exits and returns the user's input after n characters.
@@ -896,6 +897,7 @@ class KeyboardScreen(BaseTopNavScreen):
     cols: int = None
     keyboard_font_name: str = GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME
     keyboard_font_size: int = GUIConstants.TOP_NAV_TITLE_FONT_SIZE + 2
+    key_height: int = None
     keys_charset: str = None
     keys_to_values: dict = None
     return_after_n_chars: int = None
@@ -934,13 +936,14 @@ class KeyboardScreen(BaseTopNavScreen):
         text_entry_display_height = 30
 
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
-        button_height = int((self.canvas_height - GUIConstants.EDGE_PADDING - text_entry_display_y - text_entry_display_height - GUIConstants.COMPONENT_PADDING - (self.rows - 1) * 2) / self.rows)
+        if self.key_height is None:
+            self.key_height = int((self.canvas_height - GUIConstants.EDGE_PADDING - text_entry_display_y - text_entry_display_height - GUIConstants.COMPONENT_PADDING - (self.rows - 1) * 2) / self.rows)
 
         if self.keyboard_font_size:
             font_size = self.keyboard_font_size
         else:
             # Scale with button height
-            font_size = button_height - GUIConstants.COMPONENT_PADDING
+            font_size = self.key_height - GUIConstants.COMPONENT_PADDING
 
         self.keyboard = Keyboard(
             draw=self.renderer.draw,
@@ -953,7 +956,7 @@ class KeyboardScreen(BaseTopNavScreen):
                 GUIConstants.EDGE_PADDING,
                 keyboard_start_y,
                 GUIConstants.EDGE_PADDING + self.keyboard_width,
-                keyboard_start_y + self.rows * button_height + (self.rows - 1) * 2
+                keyboard_start_y + self.rows * self.key_height + (self.rows - 1) * 2
             ),
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -3,13 +3,14 @@ import time
 from dataclasses import dataclass
 from PIL import Image, ImageDraw, ImageColor
 from typing import Any, List, Tuple
+from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.renderer import Renderer
 
 from seedsigner.models.threads import BaseThread
 from seedsigner.models.encode_qr import EncodeQR
 from seedsigner.models.settings import Settings, SettingsConstants
 
-from ..components import (GUIConstants, BaseComponent, Button, Icon, LargeIconButton, SeedSignerCustomIconConstants, TopNav,
+from ..components import (FontAwesomeIconConstants, GUIConstants, BaseComponent, Button, Icon, IconButton, LargeIconButton, SeedSignerCustomIconConstants, TopNav,
     TextArea, load_image)
 
 from seedsigner.hardware.buttons import HardwareButtonsConstants, HardwareButtons
@@ -871,3 +872,207 @@ class PowerOffScreen(BaseTopNavScreen):
             screen_y=self.top_nav.height,
             height=self.canvas_height - self.top_nav.height,
         ))
+
+
+
+@dataclass
+class KeyboardScreen(BaseTopNavScreen):
+    """
+        Generalized Screen for a single Keyboard layout writing user input to a
+        TextEntryDisplay.
+        
+        Args:
+        * rows
+        * cols
+        * keyboard_font_name
+        * keyboard_font_size: Specify `None` to auto-size to Key height.
+        * keys_charset: Specify the chars displayed on the keys of the keyboard.
+        * keys_to_values: Optional mapping from key_charset to input value (e.g. dice icon to digit).
+        * return_after_n_chars: exits and returns the user's input after n characters.
+        * show_save_button: Render a KEY3 soft button for save & exit
+        * initial_value: initialize the TextEntryDisplay with an existing string
+    """
+    rows: int = None
+    cols: int = None
+    keyboard_font_name: str = GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME
+    keyboard_font_size: int = GUIConstants.TOP_NAV_TITLE_FONT_SIZE + 2
+    keys_charset: str = None
+    keys_to_values: dict = None
+    return_after_n_chars: int = None
+    show_save_button: bool = False
+    initial_value: str = ""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.initial_value:
+            self.user_input = self.initial_value
+        else:
+            self.user_input = ""
+
+        # Set up the keyboard params        
+        if self.show_save_button:
+            right_panel_buttons_width = 60
+            hw_button_x = self.canvas_width - right_panel_buttons_width + GUIConstants.COMPONENT_PADDING
+            hw_button_y = int(self.canvas_height - GUIConstants.BUTTON_HEIGHT) / 2 + 60
+            
+            self.keyboard_width = self.canvas_width - (GUIConstants.EDGE_PADDING + GUIConstants.COMPONENT_PADDING + right_panel_buttons_width - GUIConstants.COMPONENT_PADDING)
+
+            # Render the right button panel (only has a Key3 "Save" button)
+            self.save_button = IconButton(
+                icon_name=FontAwesomeIconConstants.SOLID_CIRCLE_CHECK,
+                icon_color=GUIConstants.SUCCESS_COLOR,
+                width=right_panel_buttons_width,
+                screen_x=hw_button_x,
+                screen_y=hw_button_y,
+            )
+            self.components.append(self.save_button)
+        else:
+            self.keyboard_width = self.canvas_width - 2*GUIConstants.EDGE_PADDING
+
+        text_entry_display_y = self.top_nav.height
+        text_entry_display_height = 30
+
+        keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
+        button_height = int((self.canvas_height - GUIConstants.EDGE_PADDING - text_entry_display_y - text_entry_display_height - GUIConstants.COMPONENT_PADDING - (self.rows - 1) * 2) / self.rows)
+        if self.keyboard_font_size:
+            font_size = self.keyboard_font_size
+        else:
+            # Scale with button height
+            font_size = button_height - GUIConstants.COMPONENT_PADDING
+        self.keyboard_digits = Keyboard(
+            draw=self.renderer.draw,
+            charset=self.keys_charset,
+            font_name=self.keyboard_font_name,
+            font_size=font_size,
+            rows=self.rows,
+            cols=self.cols,
+            rect=(
+                GUIConstants.EDGE_PADDING,
+                keyboard_start_y,
+                GUIConstants.EDGE_PADDING + self.keyboard_width,
+                keyboard_start_y + self.rows * button_height + (self.rows - 1) * 2
+            ),
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+        self.keyboard_digits.set_selected_key(selected_letter=self.keys_charset[0])
+
+        self.text_entry_display = TextEntryDisplay(
+            canvas=self.renderer.canvas,
+            rect=(
+                GUIConstants.EDGE_PADDING,
+                text_entry_display_y,
+                self.canvas_width - GUIConstants.EDGE_PADDING,
+                text_entry_display_y + text_entry_display_height
+            ),
+            cursor_mode=TextEntryDisplay.CURSOR_MODE__BAR,
+            is_centered=False,
+            cur_text=self.initial_value,
+        )
+
+
+    def _render(self):
+        super()._render()
+
+        self.keyboard_digits.render_keys()
+        self.text_entry_display.render()
+
+        self.renderer.show_image()
+    
+
+    def _run(self):
+        self.cursor_position = len(self.user_input)
+
+        # Start the interactive update loop
+        while True:
+            input = self.hw_inputs.wait_for(
+                HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN + [HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3],
+                check_release=True,
+                release_keys=[HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3]
+            )
+    
+            # Check possible exit conditions   
+            if self.top_nav.is_selected and input == HardwareButtonsConstants.KEY_PRESS:
+                return RET_CODE__BACK_BUTTON
+            
+            elif self.show_save_button and input == HardwareButtonsConstants.KEY3:
+                # Save!
+                # First show the save button reacting to the click
+                self.save_button.is_selected = True
+                self.save_button.render()
+                self.renderer.show_image()
+
+                # Then return the input to the View
+                if len(self.user_input) > 0:
+                    return self.user_input.strip()
+    
+            # Process normal input
+            if input in [HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN] and self.top_nav.is_selected:
+                # We're navigating off the previous button
+                self.top_nav.is_selected = False
+                self.top_nav.render_buttons()
+    
+                # Override the actual input w/an ENTER signal for the Keyboard
+                if input == HardwareButtonsConstants.KEY_DOWN:
+                    input = Keyboard.ENTER_TOP
+                else:
+                    input = Keyboard.ENTER_BOTTOM
+            elif input in [HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT] and self.top_nav.is_selected:
+                # ignore
+                continue
+    
+            ret_val = self.keyboard_digits.update_from_input(input)
+    
+            # Now process the result from the keyboard
+            if ret_val in Keyboard.EXIT_DIRECTIONS:
+                self.top_nav.is_selected = True
+                self.top_nav.render_buttons()
+    
+            elif ret_val in Keyboard.ADDITIONAL_KEYS and input == HardwareButtonsConstants.KEY_PRESS:
+                if ret_val == Keyboard.KEY_BACKSPACE["code"]:
+                    if len(self.user_input) > 0:
+                        self.user_input = self.user_input[:-1]
+                        self.cursor_position -= 1
+    
+            elif input == HardwareButtonsConstants.KEY_PRESS and ret_val not in Keyboard.ADDITIONAL_KEYS:
+                # User has locked in the current letter
+                if self.keys_to_values:
+                    # Map the Key display char to its output value (e.g. dice icon to digit)
+                    ret_val = self.keys_to_values[ret_val]
+                self.user_input += ret_val
+                self.cursor_position += 1
+
+                if self.cursor_position == self.return_after_n_chars:
+                    return self.user_input
+
+                # Render a new TextArea over the TopNav title bar
+                if self.update_title():
+                    TextArea(
+                        text=self.title,
+                        font_name=GUIConstants.TOP_NAV_TITLE_FONT_NAME,
+                        font_size=GUIConstants.TOP_NAV_TITLE_FONT_SIZE,
+                        height=self.top_nav.height,
+                    ).render()
+                    self.top_nav.render_buttons()
+    
+            elif input in HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN:
+                # Live joystick movement; haven't locked this new letter in yet.
+                # Leave current spot blank for now. Only update the active keyboard keys
+                # when a selection has been locked in (KEY_PRESS) or removed ("del").
+                pass
+    
+            # Render the text entry display and cursor block
+            self.text_entry_display.render(self.user_input)
+    
+            self.renderer.show_image()
+
+
+    def update_title(self) -> bool:
+        """
+            Optionally update the self.title after each completed key input.
+            
+            e.g. to increment the dice roll count:
+                self.title = f"Roll {self.cursor_position + 1}"
+        """
+        return False

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -4,7 +4,7 @@ from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.hardware.camera import Camera
 from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerCustomIconConstants, TextArea
 
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, KeyboardScreen
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 
 
@@ -111,153 +111,42 @@ class ToolsImageEntropyFinalImageScreen(BaseScreen):
 
 
 @dataclass
-class ToolsDiceEntropyEntryScreen(BaseTopNavScreen):
-    total_rolls: int = None
-
-
+class ToolsDiceEntropyEntryScreen(KeyboardScreen):
     def __post_init__(self):
-        self.title = f"Dice Roll 1/{self.total_rolls}"
+        # Override values set by the parent class
+        self.title = f"Dice Roll 1/{self.return_after_n_chars}"
+
+        # Specify the keys in the keyboard
+        self.rows = 3
+        self.cols = 3
+        self.keyboard_font_name = GUIConstants.ICON_FONT_NAME__FONT_AWESOME
+        self.keyboard_font_size = None  # Force auto-scaling to Key height
+        self.keys_charset = "".join([
+            FontAwesomeIconConstants.DICE_ONE,
+            FontAwesomeIconConstants.DICE_TWO,
+            FontAwesomeIconConstants.DICE_THREE,
+            FontAwesomeIconConstants.DICE_FOUR,
+            FontAwesomeIconConstants.DICE_FIVE,
+            FontAwesomeIconConstants.DICE_SIX,
+        ])
+
+        # Map Key display chars to actual output values
+        self.keys_to_values = {
+            FontAwesomeIconConstants.DICE_ONE: "1",
+            FontAwesomeIconConstants.DICE_TWO: "2",
+            FontAwesomeIconConstants.DICE_THREE: "3",
+            FontAwesomeIconConstants.DICE_FOUR: "4",
+            FontAwesomeIconConstants.DICE_FIVE: "5",
+            FontAwesomeIconConstants.DICE_SIX: "6",
+        }
+
+        # Now initialize the parent class
         super().__post_init__()
-
-        self.dice_rolls = ""
-
-        # Set up the keyboard params
-        keyboard_width = self.canvas_width - 2*GUIConstants.EDGE_PADDING
-        text_entry_display_y = self.top_nav.height
-        text_entry_display_height = 30
-
-        keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
-        rows = 3
-        button_height = int((self.canvas_height - GUIConstants.EDGE_PADDING - text_entry_display_y - text_entry_display_height - GUIConstants.COMPONENT_PADDING - (rows - 1) * 2) / rows)
-        self.keyboard_digits = Keyboard(
-            draw=self.renderer.draw,
-            charset="".join([
-                FontAwesomeIconConstants.DICE_ONE,
-                FontAwesomeIconConstants.DICE_TWO,
-                FontAwesomeIconConstants.DICE_THREE,
-                FontAwesomeIconConstants.DICE_FOUR,
-                FontAwesomeIconConstants.DICE_FIVE,
-                FontAwesomeIconConstants.DICE_SIX,
-            ]),
-            font_name=GUIConstants.ICON_FONT_NAME__FONT_AWESOME,
-            font_size=button_height - GUIConstants.COMPONENT_PADDING,
-            rows=rows,
-            cols=3,
-            rect=(
-                GUIConstants.EDGE_PADDING,
-                keyboard_start_y,
-                GUIConstants.EDGE_PADDING + keyboard_width,
-                keyboard_start_y + rows * button_height + (rows - 1) * 2
-            ),
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-        self.keyboard_digits.set_selected_key(selected_letter=FontAwesomeIconConstants.DICE_ONE)
-
-        self.text_entry_display = TextEntryDisplay(
-            canvas=self.renderer.canvas,
-            rect=(
-                GUIConstants.EDGE_PADDING,
-                text_entry_display_y,
-                self.canvas_width - GUIConstants.EDGE_PADDING,
-                text_entry_display_y + text_entry_display_height
-            ),
-            cursor_mode=TextEntryDisplay.CURSOR_MODE__BAR,
-            is_centered=False,
-        )
-
-
-    def _render(self):
-        super()._render()
-
-        self.keyboard_digits.render_keys()
-        self.text_entry_display.render()
-
-        self.renderer.show_image()
     
 
-    def _run(self):
-        cursor_position = len(self.dice_rolls)
-
-        # Start the interactive update loop
-        while True:
-            input = self.hw_inputs.wait_for(
-                HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN + [HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3],
-                check_release=True,
-                release_keys=[HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3]
-            )
-    
-            # Check possible exit condition    
-            if self.top_nav.is_selected and input == HardwareButtonsConstants.KEY_PRESS:
-                return RET_CODE__BACK_BUTTON
-    
-            # Process normal input
-            if input in [HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN] and self.top_nav.is_selected:
-                # We're navigating off the previous button
-                self.top_nav.is_selected = False
-                self.top_nav.render_buttons()
-    
-                # Override the actual input w/an ENTER signal for the Keyboard
-                if input == HardwareButtonsConstants.KEY_DOWN:
-                    input = Keyboard.ENTER_TOP
-                else:
-                    input = Keyboard.ENTER_BOTTOM
-            elif input in [HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT] and self.top_nav.is_selected:
-                # ignore
-                continue
-    
-            ret_val = self.keyboard_digits.update_from_input(input)
-    
-            # Now process the result from the keyboard
-            if ret_val in Keyboard.EXIT_DIRECTIONS:
-                self.top_nav.is_selected = True
-                self.top_nav.render_buttons()
-    
-            elif ret_val in Keyboard.ADDITIONAL_KEYS and input == HardwareButtonsConstants.KEY_PRESS:
-                if ret_val == Keyboard.KEY_BACKSPACE["code"]:
-                    if len(self.dice_rolls) > 0:
-                        self.dice_rolls = self.dice_rolls[:-1]
-                        cursor_position -= 1
-    
-            elif input == HardwareButtonsConstants.KEY_PRESS and ret_val not in Keyboard.ADDITIONAL_KEYS:
-                # User has locked in the current letter
-                if ret_val == FontAwesomeIconConstants.DICE_ONE:
-                    ret_val = "1"
-                elif ret_val == FontAwesomeIconConstants.DICE_TWO:
-                    ret_val = "2"
-                elif ret_val == FontAwesomeIconConstants.DICE_THREE:
-                    ret_val = "3"
-                elif ret_val == FontAwesomeIconConstants.DICE_FOUR:
-                    ret_val = "4"
-                elif ret_val == FontAwesomeIconConstants.DICE_FIVE:
-                    ret_val = "5"
-                elif ret_val == FontAwesomeIconConstants.DICE_SIX:
-                    ret_val = "6"
-                self.dice_rolls += ret_val
-                cursor_position += 1
-
-                if cursor_position == self.total_rolls:
-                    return self.dice_rolls
-
-                # Render a new TextArea over the TopNav title bar
-                TextArea(
-                    text=f"Dice Roll {cursor_position + 1}/{self.total_rolls}",
-                    font_name=GUIConstants.TOP_NAV_TITLE_FONT_NAME,
-                    font_size=GUIConstants.TOP_NAV_TITLE_FONT_SIZE,
-                    height=self.top_nav.height,
-                ).render()
-                self.top_nav.render_buttons()
-    
-            elif input in HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN:
-                # Live joystick movement; haven't locked this new letter in yet.
-                # Leave current spot blank for now. Only update the active keyboard keys
-                # when a selection has been locked in (KEY_PRESS) or removed ("del").
-                pass
-    
-            # Render the text entry display and cursor block
-            self.text_entry_display.render(self.dice_rolls)
-    
-            self.renderer.show_image()
+    def update_title(self) -> bool:
+        self.title = f"Dice Roll {self.cursor_position + 1}/{self.return_after_n_chars}"
+        return True
 
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -529,7 +529,7 @@ class SeedExportXpubCustomDerivationView(View):
 
     def run(self):
         ret = seed_screens.SeedExportXpubCustomDerivationScreen(
-            derivation_path=self.custom_derivation_path
+            initial_value=self.custom_derivation_path,
         ).display()
 
         if ret == RET_CODE__BACK_BUTTON:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -200,7 +200,7 @@ class ToolsDiceEntropyEntryView(View):
 
     def run(self):
         ret = ToolsDiceEntropyEntryScreen(
-            total_rolls=self.total_rolls,
+            return_after_n_chars=self.total_rolls,
         ).display()
 
         if ret == RET_CODE__BACK_BUTTON:


### PR DESCRIPTION
* Eliminates the need for copy-paste on various screens with a basic Keyboard UI.
* Refactored and simplified `SeedExportXpubCustomDerivationScreen`
* Refactored and simplified `ToolsDiceEntropyEntryScreen`

Can now refactor #194 child index input screen with a `KeyboardScreen`.

Should be targeted for v0.5.1 or greater.