### PR TITLE
[Bugfix] Allow PSBTOverviewScreen to truncate "self-transfer"

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -118,7 +118,7 @@ class PSBTOverviewScreen(ButtonListScreen):
         #     max_destination_col_width += curve_width
         
         # Now let's maximize the actual destination col by adjusting our addr truncation
-        def calculate_destination_col_width(truncate_at: int):
+        def calculate_destination_col_width(truncate_at: int = 0):
             def truncate_destination_addr(addr):
                 return f"{addr[:truncate_at]}..."
             
@@ -129,7 +129,7 @@ class PSBTOverviewScreen(ButtonListScreen):
                     destination_column.append(truncate_destination_addr(addr))
 
                 for i in range(0, self.num_self_transfer_outputs):
-                    destination_column.append(f"self-transfer")
+                    destination_column.append(truncate_destination_addr("self-transfer"))
             else:
                 # destination_column.append(f"{len(self.destination_addresses)} recipients")
                 destination_column.append(f"recipient 1")
@@ -151,7 +151,7 @@ class PSBTOverviewScreen(ButtonListScreen):
         
         if len(self.destination_addresses) + self.num_self_transfer_outputs > 3:
             # We're not going to display any destination addrs so truncation doesn't matter
-            (destination_text_width, destination_column) = calculate_destination_col_width(truncate_at=0)
+            (destination_text_width, destination_column) = calculate_destination_col_width()
         else:
             # Steadliy widen out the destination column until we run out of space
             for i in range(6, 13):

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -120,6 +120,9 @@ class PSBTOverviewScreen(ButtonListScreen):
         # Now let's maximize the actual destination col by adjusting our addr truncation
         def calculate_destination_col_width(truncate_at: int = 0):
             def truncate_destination_addr(addr):
+                if len(addr) <= truncate_at + len("..."):
+                    # No point in truncating
+                    return addr
                 return f"{addr[:truncate_at]}..."
             
             destination_column = []
@@ -154,7 +157,7 @@ class PSBTOverviewScreen(ButtonListScreen):
             (destination_text_width, destination_column) = calculate_destination_col_width()
         else:
             # Steadliy widen out the destination column until we run out of space
-            for i in range(6, 13):
+            for i in range(6, 14):
                 (new_width, new_col_text) = calculate_destination_col_width(truncate_at=i)
                 if new_width > max_destination_col_width:
                     break

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -120,6 +120,7 @@ class PSBTOverviewScreen(ButtonListScreen):
         # Now let's maximize the actual destination col by adjusting our addr truncation
         def calculate_destination_col_width(truncate_at: int = 0):
             def truncate_destination_addr(addr):
+                # TODO: Properly handle the ellipsis truncation in different languages
                 if len(addr) <= truncate_at + len("..."):
                     # No point in truncating
                     return addr


### PR DESCRIPTION
Fixes #215

Truncating "self-transfer" gives the UI the horizontal room it needs to properly render.

![20220526_093900](https://user-images.githubusercontent.com/934746/170511970-9c246b2d-1312-4149-91bb-fea443fafd2f.jpg)
