### PR TITLE
Use SeedSigner fork of `embit` w/`secp256k1` binary for Pi Zero

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-embit==0.4.10
+embit @ git+https://github.com/seedsigner/embit.git@03cba13e0add64b241972c67e2aa970cb2e3a5d2
 numpy==1.21.1
 picamera==1.13
 Pillow==8.2.0


### PR DESCRIPTION
Points to the specific PR merge that included the `libsecp256k1` binary compiled for the Pi Zero (`armv6l`).

Compiled binary speeds up basic ECDSA math by roughly 8.5k, depending on the task. 

Updates SeedSigner to embit v0.4.14.

SeedSigner image must be updated with a fresh `pip install -r requirements.txt` call. Either updating directly on the device (if internet access is enabled on-device) or by rebuilding the SD card through the usual steps.

Further considerations:
* In initial tests with simple PSBTs, signing a PSBT is now nearly instantaneous. If signing more complex PSBTs are reasonably fast, it may make sense to remove the loading/waiting spinner on that page.
* Similarly, brute-force address verification is so fast that "Skip 10" now seems pointlessly small. Perhaps a "Skip 50" or "Skip 100"?