### PR TITLE
Bump `embit` to v0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-embit @ git+https://github.com/seedsigner/embit.git@03cba13e0add64b241972c67e2aa970cb2e3a5d2
+embit==0.5.0
 numpy==1.21.1
 picamera==1.13
 Pillow==8.2.0

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -472,15 +472,9 @@ class PSBTFinalizeView(View):
 
         if selected_menu_num == 0:
             # Sign PSBT
-            loading_screen = LoadingScreenThread(text="Signing PSBT...")
-            loading_screen.start()
-
-            try:
-                sig_cnt = PSBTParser.sig_count(psbt)
-                psbt.sign_with(psbt_parser.root)
-                trimmed_psbt = PSBTParser.trim(psbt)
-            finally:
-                loading_screen.stop()
+            sig_cnt = PSBTParser.sig_count(psbt)
+            psbt.sign_with(psbt_parser.root)
+            trimmed_psbt = PSBTParser.trim(psbt)
 
             if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
                 # Signing failed / didn't do anything


### PR DESCRIPTION
`embit` v0.5.0 merged the compiled secp256k1 binary for Pi Zero architecture (armv6l) so we no longer need to point to our fork.

Removes the loading spinner on:
* PSBT sign tx
* Export xpub details

These operations complete fast enough that there is no value in keeping the spinner.