### PR TITLE
add microSD add/remove support for seedsigner-os

### DIFF
--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -58,6 +58,8 @@ class GUIConstants:
     BUTTON_BACKGROUND_COLOR = "#2c2c2c"
     BUTTON_HEIGHT = 32
     BUTTON_SELECTED_FONT_COLOR = "black"
+    
+    NOTIFICATION_COLOR = "#00f100"
 
 
 
@@ -568,6 +570,52 @@ class IconTextLine(BaseComponent):
             self.icon.render()
 
 
+@dataclass
+class ToastOverlay(BaseComponent):
+    icon_name: str = None
+    color: str = None
+    label_text: str = None
+
+    def __post_init__(self):
+        super().__post_init__()
+            
+        self.icon = Icon(
+            image_draw=self.image_draw,
+            canvas=self.canvas,
+            screen_x=20,
+            screen_y=190,
+            icon_name=self.icon_name,
+            icon_size=30,
+            icon_color=self.color
+        )
+        
+        self.label = TextArea(
+            image_draw=self.image_draw,
+            canvas=self.canvas,
+            text=self.label_text,
+            font_size=19,
+            font_color=self.color,
+            edge_padding=0,
+            is_text_centered=False,
+            auto_line_break=False,
+            width=160,
+            height=20,
+            screen_x=55,
+            screen_y=195,
+            allow_text_overflow=False
+        )
+            
+    def render(self):
+        self.image_draw.rounded_rectangle(
+            ( 10, 180, 230, 230),
+            fill=GUIConstants.BACKGROUND_COLOR,
+            radius=8,
+            outline=self.color,
+            width=2,
+        )
+        
+        self.icon.render()
+        self.label.render()
 
 @dataclass
 class FormattedAddress(BaseComponent):

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -1,0 +1,58 @@
+import time
+
+from seedsigner.models.singleton import Singleton
+from seedsigner.models.threads import BaseThread
+
+class MicroSD(Singleton, BaseThread):
+	
+	ui_handler = None
+	settings_handler = None
+	
+	@classmethod
+	def get_instance(cls):
+		# This is the only way to access the one and only instance
+		if cls._instance is None:
+			# Instantiate the one and only instance
+			microsd = cls.__new__(cls)
+			cls._instance = microsd
+			
+			# explicitly call BaseThread __init__ since multiple class inheritance
+			BaseThread.__init__(microsd)
+	
+		return cls._instance
+	
+	def start_detection(self):
+		self.start()
+	
+	def run(self):
+		import socket, os, time
+		
+		from seedsigner.controller import Controller
+		
+		# explicitly only microsd add/remove detection in seedsigner-os
+		if Controller.HOSTNAME == Controller.SEEDSIGNER_OS:
+			
+			if os.path.exists("/tmp/mdev_socket"):
+				os.remove("/tmp/mdev_socket")
+			
+			server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+			server.bind("/tmp/mdev_socket")
+			while self.keep_running:
+				
+				server.listen(1)
+				conn, addr = server.accept()
+				data = conn.recv(1000) # 1000 bytes limit
+				action = ""
+				mount_dir = ""
+				if data:
+					msg = data.decode("utf-8").strip().split(" ")
+					action = msg[0]
+					mount_dir = msg[1]
+					print(f"socket message: {action} {mount_dir}")
+				conn.close()
+					
+				if self.settings_handler:
+					self.settings_handler(action, mount_dir)
+					
+				if self.ui_handler:
+					self.ui_handler(action, mount_dir)

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -13,6 +13,9 @@ class SettingsConstants:
         (OPTION__ENABLED, "Enabled"),
         (OPTION__DISABLED, "Disabled"),
     ]
+    OPTIONS__ONLY_DISABLED = [
+        (OPTION__DISABLED, "Disabled"),
+    ]
     OPTIONS__PROMPT_REQUIRED_DISABLED = [
         (OPTION__PROMPT, "Prompt"),
         (OPTION__REQUIRED, "Required"),

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -142,7 +142,7 @@ class ScreensaverScreen(LogoScreen):
         with self.renderer.lock:
             try:
                 while True:
-                    if self.buttons.has_any_input():
+                    if self.buttons.has_any_input() or self.buttons.override_ind:
                         return self.stop()
 
                     # Must crop the image to the exact display size

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -24,8 +24,7 @@ class ToolsMenuView(View):
         IMAGE = (" New seed", FontAwesomeIconConstants.CAMERA)
         DICE = ("New seed", FontAwesomeIconConstants.DICE)
         KEYBOARD = ("Calc 12th/24th word", FontAwesomeIconConstants.KEYBOARD)
-        MICROSD = ("MicroSD", FontAwesomeIconConstants.SDCARD)
-        button_data = [IMAGE, DICE, KEYBOARD, MICROSD]
+        button_data = [IMAGE, DICE, KEYBOARD]
         screen = ButtonListScreen(
             title="Tools",
             is_button_text_centered=False,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from seedsigner.gui.components import FontAwesomeIconConstants
+from seedsigner.gui.components import FontAwesomeIconConstants, ToastOverlay, GUIConstants
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, DireWarningScreen, LargeButtonScreen, PowerOffScreen, ResetScreen, WarningScreen
 from seedsigner.models.threads import BaseThread
@@ -243,3 +243,50 @@ class UnhandledExceptionView(View):
         ).display()
         
         return Destination(MainMenuView, clear_history=True)
+
+class MicroSDToastView(View):
+    def event_handler(self, action, mount_dir):
+        import time
+        
+        self.current_screen = self.renderer.canvas.copy()
+        
+        # Special case when screensaver is running
+        if self.controller.screensaver._is_running:
+            self.buttons.override_ind = True
+        
+        # MicroSDToastView blocks any attempts to use the Renderer in another thread so it
+        # never gives up the lock until it returns.
+        with self.renderer.lock:
+            if action == "remove":
+
+                toast = ToastOverlay(
+                    icon_name=FontAwesomeIconConstants.SDCARD,
+                    color=GUIConstants.NOTIFICATION_COLOR,
+                    label_text="MicroSD removed"
+                )
+                toast.render()
+                self.renderer.show_image()
+                
+                t_end = time.time() + 3
+                while time.time() < t_end:
+                    if self.buttons.has_any_input():
+                        break
+
+                self.renderer.show_image(self.current_screen)
+            
+            elif action == "add":
+                
+                toast = ToastOverlay(
+                    icon_name=FontAwesomeIconConstants.SDCARD,
+                    color=GUIConstants.NOTIFICATION_COLOR,
+                    label_text="MicroSD inserted"
+                )
+                toast.render()
+                self.renderer.show_image()
+                
+                t_end = time.time() + 3
+                while time.time() < t_end:
+                    if self.buttons.has_any_input():
+                        break
+                
+                self.renderer.show_image(self.current_screen)


### PR DESCRIPTION
Replaces PR #240

dependent on:
- https://github.com/SeedSigner/seedsigner-os/pull/18
- https://github.com/SeedSigner/seedsigner-os/pull/17 (for the dev image)

Features:

- Adds handling of microSD card being removed and inserted
- Displays overlay notification when microSD card is mounted/unmounted
- Changes persistent settings to disabled when microSD card is removed
- Saves persistent settings to disk when microSD card is re-inserted back into pi, but only if persistent settings was previously enabled (aka settings.json file exists).

Testing comments:

- Works on raspberry pi OS without issues. No microSD icon is displayed on raspberry pi OS on purpose because removing the microSD card is not supported.