### PR TITLE
pi zero 2W hangs in psbt overview screen with animation

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from lzma import is_check_supported
 from PIL import Image, ImageDraw, ImageFilter
 from typing import List
+import time
 
 from seedsigner.gui.renderer import Renderer
 from seedsigner.models.threads import BaseThread
@@ -439,7 +440,7 @@ class PSBTOverviewScreen(ButtonListScreen):
                     self.renderer.show_image()
 
                 # No need to CPU limit when running in its own thread?
-                # time.sleep(0.02)
+                time.sleep(0.02)
 
 
 


### PR DESCRIPTION
Not entirely sure why, but on a pi zero 2, the animation consumes all of the CPU and does not respond to button clicks unless you hold down the button for a few seconds. Adding (or uncommenting) this small 20 ms sleep seems to allow enough cpu time for the button actions to register.