### PR TITLE
PSBT signing flow change: Remove unnecessary prompt to select coordinator

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -696,19 +696,3 @@ class PSBTFinalizeScreen(ButtonListScreen):
             text="Click to authorize this transaction",
             screen_y=icon.screen_y + icon.height + GUIConstants.COMPONENT_PADDING
         ))
-
-
-
-@dataclass
-class PSBTSelectCoordinatorScreen(ButtonListScreen):
-    def __post_init__(self):
-        # Customize defaults
-        self.title = "Signed PSBT"
-        self.is_bottom_list = True
-        super().__post_init__()
-
-        self.components.append(TextArea(
-            text="Export as a QR code for:",
-            is_text_centered=True,
-            screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
-        ))

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -484,44 +484,18 @@ class PSBTFinalizeView(View):
             
             else:
                 self.controller.psbt = trimmed_psbt
-
-                if len(self.settings.get_value(SettingsConstants.SETTING__COORDINATORS)) == 1:
-                    return Destination(PSBTSignedQRDisplayView, view_args={"coordinator": self.settings.get_value(SettingsConstants.SETTING__COORDINATORS)[0]})
-                else:
-                    return Destination(PSBTSelectCoordinatorView)
+                return Destination(PSBTSignedQRDisplayView)
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-
-
-
-class PSBTSelectCoordinatorView(View):
-    def run(self):
-        button_data = self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__COORDINATORS)
-        selected_menu_num = psbt_screens.PSBTSelectCoordinatorScreen(
-            button_data=button_data
-        ).display()
-
-        if selected_menu_num == RET_CODE__BACK_BUTTON:
-            return Destination(BackStackView)
-
-        return Destination(PSBTSignedQRDisplayView, view_args={"coordinator": button_data[selected_menu_num]})
 
 
 
 class PSBTSignedQRDisplayView(View):
-    def __init__(self, coordinator: str):
-        super().__init__()
-        self.coordinator = coordinator
-    
     def run(self):
-        qr_psbt_type = QRType.PSBT__UR2
-        if self.coordinator == SettingsConstants.COORDINATOR__SPECTER_DESKTOP:
-            qr_psbt_type = QRType.PSBT__SPECTER
-
         qr_encoder = EncodeQR(
             psbt=self.controller.psbt,
-            qr_type=qr_psbt_type,
+            qr_type=QRType.PSBT__UR2,
             qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
             wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
         )

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -495,7 +495,7 @@ class PSBTSignedQRDisplayView(View):
     def run(self):
         qr_encoder = EncodeQR(
             psbt=self.controller.psbt,
-            qr_type=QRType.PSBT__UR2,
+            qr_type=QRType.PSBT__UR2,  # All coordinators (as of 2022-08) use this format
             qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
             wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
         )


### PR DESCRIPTION
The coordinator selection only mattered if the user selected "Specter"; the other three were always using `UR2` QR format.

Now that Specter Desktop support `UR2`, this coordinator selection step is unnecessary.