### PR TITLE
Split symbols keyboard

### DIFF
--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -39,6 +39,12 @@ class Keyboard:
         "font": COMPACT_KEY_FONT,
         "size": 1,
     }
+    KEY_SPACE_2 = {
+        "code": "SPACE",
+        "letter": "space",
+        "font": COMPACT_KEY_FONT,
+        "size": 2,
+    }
     KEY_SPACE_3 = {
         "code": "SPACE",
         "letter": "space",
@@ -117,6 +123,7 @@ class Keyboard:
                 rect_color = self.keyboard.deactivated_background_color
                 font_color = "#333"  # Show the letter but render as gray
                 outline_color = self.keyboard.deactivated_background_color
+
                 if self.is_selected:
                     # Inactive, selected just gets highlighted outline
                     outline_color = self.keyboard.highlight_color
@@ -125,11 +132,12 @@ class Keyboard:
                 font_color = "black"
             else:
                 if self.is_additional_key:
-                    # rect_color = "#111"
-                    rect_color = self.keyboard.background_color
+                    rect_color = "#000"
+                    font_color = "#999"
+                    # rect_color = self.keyboard.background_color
                 else:
                     rect_color = self.keyboard.background_color
-                font_color = "#e8e8e8"
+                    font_color = "#e8e8e8"
 
             self.keyboard.draw.rounded_rectangle(
                 (
@@ -186,6 +194,7 @@ class Keyboard:
         self.auto_wrap = auto_wrap
         self.background_color = GUIConstants.BUTTON_BACKGROUND_COLOR
         self.deactivated_background_color = GUIConstants.BACKGROUND_COLOR
+        self.additional_key_deactivated_background_color = GUIConstants.BACKGROUND_COLOR
         self.highlight_color = highlight_color
 
         # Does the specified layout work?

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -134,7 +134,6 @@ class Keyboard:
                 if self.is_additional_key:
                     rect_color = "#000"
                     font_color = "#999"
-                    # rect_color = self.keyboard.background_color
                 else:
                     rect_color = self.keyboard.background_color
                     font_color = "#e8e8e8"

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -622,7 +622,8 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
     KEYBOARD__LOWERCASE_BUTTON_TEXT = "abc"
     KEYBOARD__UPPERCASE_BUTTON_TEXT = "ABC"
     KEYBOARD__DIGITS_BUTTON_TEXT = "123"
-    KEYBOARD__SYMBOLS_BUTTON_TEXT = "!@#"
+    KEYBOARD__SYMBOLS_1_BUTTON_TEXT = "!@#"
+    KEYBOARD__SYMBOLS_2_BUTTON_TEXT = "*[]"
 
 
     def __post_init__(self):
@@ -631,7 +632,9 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         keys_lower = "abcdefghijklmnopqrstuvwxyz"
         keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         keys_number = "0123456789"
-        keys_symbol = "!\"#$%&'()*+,=./;:<>?@[]|-_`~"
+        keys_symbol_1 = """!@#$%&();:,.-+='"?"""
+        keys_symbol_2 = """^*[]{}_\\|<>/`~"""
+
 
         # Set up the keyboard params
         self.right_panel_buttons_width = 56
@@ -702,11 +705,11 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             render_now=False
         )
 
-        self.keyboard_symbols = Keyboard(
+        self.keyboard_symbols_1 = Keyboard(
             draw=self.renderer.draw,
-            charset=keys_symbol,
+            charset=keys_symbol_1,
             rows=4,
-            cols=max_cols,
+            cols=6,
             rect=(
                 GUIConstants.COMPONENT_PADDING,
                 keyboard_start_y,
@@ -714,7 +717,28 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                 self.canvas_height - GUIConstants.EDGE_PADDING
             ),
             additional_keys=[
-                Keyboard.KEY_SPACE_4,
+                Keyboard.KEY_SPACE_2,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_symbols_2 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_symbol_2,
+            rows=4,
+            cols=6,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_2,
                 Keyboard.KEY_CURSOR_LEFT,
                 Keyboard.KEY_CURSOR_RIGHT,
                 Keyboard.KEY_BACKSPACE
@@ -824,8 +848,10 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                 # Return to the same button2 keyboard, if applicable
                 if cur_keyboard == self.keyboard_digits:
                     cur_button2_text = self.KEYBOARD__DIGITS_BUTTON_TEXT
-                elif cur_keyboard == self.keyboard_symbols:
-                    cur_button2_text = self.KEYBOARD__SYMBOLS_BUTTON_TEXT
+                elif cur_keyboard == self.keyboard_symbols_1:
+                    cur_button2_text = self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT
+                elif cur_keyboard == self.keyboard_symbols_2:
+                    cur_button2_text = self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT
 
                 if cur_button1_text == self.KEYBOARD__LOWERCASE_BUTTON_TEXT:
                     self.keyboard_abc.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
@@ -862,10 +888,15 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                     self.keyboard_digits.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                     cur_keyboard = self.keyboard_digits
                     cur_keyboard.render_keys()
-                    cur_button2_text = self.KEYBOARD__SYMBOLS_BUTTON_TEXT
-                else:
-                    self.keyboard_symbols.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                    cur_keyboard = self.keyboard_symbols
+                    cur_button2_text = self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT
+                elif cur_button2_text == self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT:
+                    self.keyboard_symbols_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                    cur_keyboard = self.keyboard_symbols_1
+                    cur_keyboard.render_keys()
+                    cur_button2_text = self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT
+                elif cur_button2_text == self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT:
+                    self.keyboard_symbols_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                    cur_keyboard = self.keyboard_symbols_2
                     cur_keyboard.render_keys()
                     cur_button2_text = self.KEYBOARD__DIGITS_BUTTON_TEXT
                 cur_keyboard.render_keys()

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -632,7 +632,12 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         keys_lower = "abcdefghijklmnopqrstuvwxyz"
         keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         keys_number = "0123456789"
+
+        # Present the most common/puncutation-related symbols & the most human-friendly
+        #   symbols first (limited to 18 chars).
         keys_symbol_1 = """!@#$%&();:,.-+='"?"""
+
+        # Isolate the more math-oriented or just uncommon symbols
         keys_symbol_2 = """^*[]{}_\\|<>/`~"""
 
 


### PR DESCRIPTION
Replaces #267.
Fixes #266.

Props to @initfortherekt for the original PR (#267) to address this issue which kicked off discussion which led to these more involved changes.

<img src="https://user-images.githubusercontent.com/934746/199079508-d7a4bd0f-74fd-4e5d-aeaa-0260bdc9836b.jpg" width="300"> <img src="https://user-images.githubusercontent.com/934746/199079513-86ca6ef3-4474-48af-a2fa-95d59bf21f9f.jpg" width="300">

* Adds the missing symbols, per #266.
* Splits the symbols across two swappable keyboards.
    * The new swap cycle is: `123` -> `!@#` -> `*[]` and then circles back to `123`.
* The most common symbols (punctuation, most human-friendly) are on the first keyboard, mostly following the layout across the top of a typical physical keyboard).
* Less common symbols (more math-related, less human-friendly) are on the second keyboard and will hopefully almost never need to be used in a typical passphrase.

Changes to ALL `Keyboard` instances across the code:
* Changes how the `additional_keys` are displayed to set them apart from the normal keys and to reduce confusion with the `<` and `>` cursor position keys.

---

Further TODO items for future contributors:
* Render the `additional_keys` with icons, especially the cursor position keys.

* Add a popup symbol name when hovering over a symbol. Could be temporarily added to the current position in the `TextEntryDisplay`:
```bash
# As you navigate across the symbols:
yourPassphrase[dollar sign]
yourPassphrase[percent]
yourPassphrase[ampersand]

# Now click to lock that symbol in:
yourPassphrase&
```
Rationale: Certain symbols are just hard to read clearly, especially `` ` `` vs `'` and `~` vs `-`. An explicit "backtick", "tilda", etc readout would hopefully completely eliminate any such errors.