### PR TITLE
add BCUR P2TR script expression tag used by Sparrow

### DIFF
--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -498,6 +498,8 @@ class UrXpubQrEncoder(XpubQrEncoder):
                         ur_outputs.append(Output([SCRIPT_EXPRESSION_TAG_MAP[401]],self.ur_hdkey))
                     elif origin.components[3].index == 1:  # Nested Multisig
                         ur_outputs.append(Output([SCRIPT_EXPRESSION_TAG_MAP[400], SCRIPT_EXPRESSION_TAG_MAP[401]],self.ur_hdkey))
+            elif origin.components[0].index == 86: # P2TR
+                ur_outputs.append(Output([SCRIPT_EXPRESSION_TAG_MAP[409]],self.ur_hdkey))
         
         # If empty, add all script types
         if len(ur_outputs) == 0:


### PR DESCRIPTION
Useful after PR #239 is merged

Adds support for BCUR taproot script type that is needed to import a p2tr into Sparrow wallet.