### PR TITLE
fix restart/poweroff functions

### DIFF
--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -212,7 +212,8 @@ class PowerOffView(View):
                 time.sleep(5)
                 if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
                     # disable microsd detection before shutdown to prevent display of toast notification during shutdown
-                    self.controller.microsd.stop()
+                    from seedsigner.controller import Controller
+                    Controller.get_instance().microsd.stop()
                     call("poweroff", shell=True)
                 else:
                     call("sudo shutdown --poweroff now", shell=True)

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -5,7 +5,7 @@ from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, DireWarningScreen, LargeButtonScreen, PowerOffScreen, ResetScreen, WarningScreen
 from seedsigner.models.threads import BaseThread
-
+from seedsigner.models import Settings
 
 
 class BackStackView:
@@ -190,7 +190,10 @@ class RestartView(View):
 
             # Kill the SeedSigner process; Running the process again.
             # `.*` is a wildcard to detect either `python`` or `python3`.
-            call("kill $(pidof python*) & python /opt/src/main.py", shell=True)
+            if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+                call("kill $(pidof python*) & python /opt/src/main.py", shell=True)
+            else:
+                call("kill $(ps aux | grep '[p]ython.*main.py' | awk '{print $2}')", shell=True)
 
 
 
@@ -207,7 +210,10 @@ class PowerOffView(View):
             from subprocess import call
             while self.keep_running:
                 time.sleep(5)
-                call("poweroff", shell=True)
+                if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+                    call("poweroff", shell=True)
+                else:
+                    call("sudo shutdown --poweroff now", shell=True)
 
 
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -211,6 +211,8 @@ class PowerOffView(View):
             while self.keep_running:
                 time.sleep(5)
                 if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+                    # disable microsd detection before shutdown to prevent display of toast notification during shutdown
+                    self.controller.microsd.stop()
                     call("poweroff", shell=True)
                 else:
                     call("sudo shutdown --poweroff now", shell=True)


### PR DESCRIPTION
Accidentally broke power off and restart functions for the Raspberry Pi OS based builds. This corrects that issue. Still need to test in SeedSigner-OS. Leaving in draft until that testing is complete.