### PR TITLE
Add os.sync fixing settings not written to disk

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -40,7 +40,9 @@ class Settings(Singleton):
         if self._data[SettingsConstants.SETTING__PERSISTENT_SETTINGS] == SettingsConstants.OPTION__ENABLED:
             with open(Settings.SETTINGS_FILENAME, 'w') as settings_file:
                 json.dump(self._data, settings_file, indent=4)
-            os.sync()
+                # SeedSignerOS makes removing the microsd possible, fsync forces persistent settings to disk
+                # without this, recent settings changes could be missing after the microsd card was removed
+                os.fsync(settings_file)
 
 
     def update(self, new_settings: dict, disable_missing_entries: bool = True):

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -40,6 +40,7 @@ class Settings(Singleton):
         if self._data[SettingsConstants.SETTING__PERSISTENT_SETTINGS] == SettingsConstants.OPTION__ENABLED:
             with open(Settings.SETTINGS_FILENAME, 'w') as settings_file:
                 json.dump(self._data, settings_file, indent=4)
+            os.sync()
 
 
     def update(self, new_settings: dict, disable_missing_entries: bool = True):

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -40,9 +40,10 @@ class Settings(Singleton):
         if self._data[SettingsConstants.SETTING__PERSISTENT_SETTINGS] == SettingsConstants.OPTION__ENABLED:
             with open(Settings.SETTINGS_FILENAME, 'w') as settings_file:
                 json.dump(self._data, settings_file, indent=4)
-                # SeedSignerOS makes removing the microsd possible, fsync forces persistent settings to disk
+                # SeedSignerOS makes removing the microsd possible, flush and then fsync forces persistent settings to disk
                 # without this, recent settings changes could be missing after the microsd card was removed
-                os.fsync(settings_file)
+                settings_file.flush()
+                os.fsync(settings_file.fileno())
 
 
     def update(self, new_settings: dict, disable_missing_entries: bool = True):


### PR DESCRIPTION
SeedSignerOS makes removing the microsd card is a common workflow. In testing I would occasionally run into an issue that caused persistent settings changes to not work. Some of the changes I would make would be written to the settings.json file, but the last few would not. Basically I could cause the issue by changed a bunch of settings and the last few would not write out to disk. Adding this python command after the save, forces the settings.json file change to disk (microsd). In my limited testing, this command fixed the issue.