### PR TITLE
Trim PSBT for P2TR

### DIFF
--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -197,9 +197,10 @@ class PSBTParser():
         trimmed_psbt = psbt.PSBT(tx.tx)
         for i, inp in enumerate(tx.inputs):
             if inp.final_scriptwitness:
-                # Taproot sign; leave the input as-is
-                # TODO: See BIP-371 about fields that can be trimmed
-                trimmed_psbt.inputs[i] = inp
+                # Taproot sign; trim to only final_scriptwitness
+                # From BIP-371 and BIP-174, once final script witness is populated
+                # it contains all necessary signatures
+                trimmed_psbt.inputs[i].final_scriptwitness = inp.final_scriptwitness
             else:
                 trimmed_psbt.inputs[i].partial_sigs = inp.partial_sigs
 


### PR DESCRIPTION
After reviewing BIP-371 and BIP-174 it's my understanding that a single signature p2tr coming out of seedsigner will only need the final script witness to be included. All the additional taproot fields added in BIP-371 should be removed once the final script witness signature is constructed.

This reduces the size of the payload/psbt returned via animated QR and makes the user experience better.