### PR TITLE
[Enhancement] Skip second seed selection & Discard PSBT option

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -48,6 +48,11 @@ class PSBTSelectSeedView(View):
         button_data.append(SCAN_SEED)
         button_data.append(TYPE_12WORD)
         button_data.append(TYPE_24WORD)
+        
+        if self.controller.psbt_seed:
+            if PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=self.controller.psbt_seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
+                # skip the seed prompt if a seed was previous selected and has matching input fingerprint
+                return Destination(PSBTOverviewView)
 
         selected_menu_num = ButtonListScreen(
             title="Select Signer",
@@ -143,6 +148,7 @@ class PSBTOverviewView(View):
         selected_menu_num = screen.display()
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
+            self.controller.psbt_seed = None
             return Destination(BackStackView)
 
         # expecting p2sh (legacy multisig) and p2pkh to have no policy set

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -353,6 +353,7 @@ class SeedOptionsView(View):
         BACKUP = ("Backup Seed", None, None, None, SeedSignerCustomIconConstants.SMALL_CHEVRON_RIGHT)
         BIP85_CHILD_SEED = "BIP-85 Child Seed"
         DISCARD = ("Discard Seed", None, None, "red")
+        DISCARD_PSBT = ("Discard PSBT", None, None, "red")
 
         button_data = []
 
@@ -397,6 +398,9 @@ class SeedOptionsView(View):
             button_data.append(BIP85_CHILD_SEED)
 
         button_data.append(DISCARD)
+        
+        if self.controller.psbt:
+            button_data.append(DISCARD_PSBT)
 
         selected_menu_num = seed_screens.SeedOptionsScreen(
             button_data=button_data,
@@ -414,6 +418,7 @@ class SeedOptionsView(View):
 
         if button_data[selected_menu_num] == SCAN_PSBT:
             from seedsigner.views.scan_views import ScanView
+            self.controller.psbt_seed = self.controller.get_seed(self.seed_num)
             return Destination(ScanView)
 
         elif button_data[selected_menu_num] == VERIFY_ADDRESS:
@@ -435,6 +440,11 @@ class SeedOptionsView(View):
         elif button_data[selected_menu_num] == DISCARD:
             return Destination(SeedDiscardView, view_args=dict(seed_num=self.seed_num))
 
+        elif button_data[selected_menu_num] == DISCARD_PSBT:
+            self.controller.psbt = None
+            self.controller.psbt_parser = None
+            self.controller.psbt_seed = None
+            return Destination(SeedOptionsView, view_args=dict(seed_num=self.seed_num))
 
 
 class SeedBackupView(View):


### PR DESCRIPTION
Correction/Enhancing workflow related to selecting a seed after scanning a PSBT (when you've already selected the seed previously).

The skipping of the "second" seed selection requires these conditions:
- PSBT was scanned from a previous selected seed menu
- The fingerprint of the seed must match a input fingerprint in the PSBT (this means network settings also need to be correct).

Also add "Discard PSBT" at the bottom of the seed selection menu (after Discard Seed). This only appears if a PSBT was previously loaded (scanned) into memory and then the user backed out. This provides the user a way to discard the PSBT without having to complete the signing workflow or scan from the home menu.