### PR TITLE
urtype update to v0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ qrcode==7.3.1
 RPi.GPIO==0.7.0
 six==1.16.0
 spidev==3.5
-urtypes @ git+https://github.com/jreesun/urtypes.git@e0d0db277ec2339650343eaf7b220fffb9233241
+urtypes @ git+https://github.com/selfcustody/urtypes.git@7fb280eab3b3563dfc57d2733b0bf5cbc0a96a6a


### PR DESCRIPTION
updates requirements.txt to pull latest release of urtype

Release Notes: https://github.com/selfcustody/urtypes/releases/tag/v0.1.0

What changed: https://github.com/selfcustody/urtypes/compare/e0d0db2..7fb280e