### PR TITLE
[Enhancement] Skip second seed selection & clear PSBT data on MainMenuView 

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -133,8 +133,7 @@ class Controller(Singleton):
         controller.microsd.start_detection()
 
         # Store one working psbt in memory
-        controller.psbt = None
-        controller.psbt_parser = None
+        controller.clear_psbt_data()
 
         # Configure the Renderer
         Renderer.configure_instance()
@@ -183,6 +182,12 @@ class Controller(Singleton):
 
     def clear_back_stack(self):
         self.back_stack = BackStack()
+
+
+    def clear_psbt_data(self):
+        self.psbt = None
+        self.psbt_parser = None
+        self.psbt_seed = None
 
 
     def start(self) -> None:

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -225,6 +225,9 @@ class Controller(Singleton):
                     next_destination = Destination(MainMenuView)
 
                 if next_destination.View_cls == MainMenuView:
+                    # Home always wipes the back_stack
+                     self.clear_back_stack()
+                    
                     # Home always wipes the back_stack/state of temp vars
                     self.resume_main_flow = None
                     self.multisig_wallet_descriptor = None

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -226,7 +226,7 @@ class Controller(Singleton):
 
                 if next_destination.View_cls == MainMenuView:
                     # Home always wipes the back_stack
-                     self.clear_back_stack()
+                    self.clear_back_stack()
                     
                     # Home always wipes the back_stack/state of temp vars
                     self.resume_main_flow = None

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -133,7 +133,8 @@ class Controller(Singleton):
         controller.microsd.start_detection()
 
         # Store one working psbt in memory
-        controller.clear_psbt_data()
+        controller.psbt = None
+        controller.psbt_parser = None
 
         # Configure the Renderer
         Renderer.configure_instance()
@@ -184,12 +185,6 @@ class Controller(Singleton):
         self.back_stack = BackStack()
 
 
-    def clear_psbt_data(self):
-        self.psbt = None
-        self.psbt_parser = None
-        self.psbt_seed = None
-
-
     def start(self) -> None:
         from .views import MainMenuView, BackStackView
         from .views.screensaver import OpeningSplashScreen
@@ -230,15 +225,14 @@ class Controller(Singleton):
                     next_destination = Destination(MainMenuView)
 
                 if next_destination.View_cls == MainMenuView:
-                    # Home always wipes the back_stack
-                    self.clear_back_stack()
-                    
-                    # Clear other temp vars
+                    # Home always wipes the back_stack/state of temp vars
                     self.resume_main_flow = None
                     self.multisig_wallet_descriptor = None
                     self.unverified_address = None
                     self.address_explorer_data = None
-
+                    self.psbt = None
+                    self.psbt_parser = None
+                    self.psbt_seed = None
                 
                 print(f"back_stack: {self.back_stack}")
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -49,6 +49,11 @@ class PSBTSelectSeedView(View):
         button_data.append(TYPE_12WORD)
         button_data.append(TYPE_24WORD)
 
+        if self.controller.psbt_seed:
+         if PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=self.controller.psbt_seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
+             # skip the seed prompt if a seed was previous selected and has matching input fingerprint
+             return Destination(PSBTOverviewView)
+
         selected_menu_num = ButtonListScreen(
             title="Select Signer",
             is_button_text_centered=False,
@@ -143,6 +148,7 @@ class PSBTOverviewView(View):
         selected_menu_num = screen.display()
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
+            self.controller.psbt_seed = None
             return Destination(BackStackView)
 
         # expecting p2sh (legacy multisig) and p2pkh to have no policy set
@@ -446,11 +452,6 @@ class PSBTAddressVerificationFailedView(View):
             show_back_button=False,
         ).display()
 
-        # Clear out the bad PSBT
-        self.controller.psbt = None
-        self.controller.psbt_parser = None
-        self.controller.psbt_seed = None
-        
         return Destination(MainMenuView, clear_history=True)
 
 
@@ -500,11 +501,6 @@ class PSBTSignedQRDisplayView(View):
             wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
         )
         QRDisplayScreen(qr_encoder=qr_encoder).display()
-
-        # We're done with this PSBT. Remove all related data
-        self.controller.psbt = None
-        self.controller.psbt_parser = None
-        self.controller.psbt_seed = None
 
         return Destination(MainMenuView, clear_history=True)
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -452,6 +452,8 @@ class PSBTAddressVerificationFailedView(View):
             show_back_button=False,
         ).display()
 
+        # We're done with this PSBT. Route back to MainMenuView which always
+        #   clears all ephemeral data (except in-memory seeds).
         return Destination(MainMenuView, clear_history=True)
 
 
@@ -502,6 +504,8 @@ class PSBTSignedQRDisplayView(View):
         )
         QRDisplayScreen(qr_encoder=qr_encoder).display()
 
+        # We're done with this PSBT. Route back to MainMenuView which always
+        #   clears all ephemeral data (except in-memory seeds).
         return Destination(MainMenuView, clear_history=True)
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -346,7 +346,6 @@ class SeedOptionsView(View):
         from seedsigner.views.psbt_views import PSBTOverviewView
 
         SCAN_PSBT = ("Scan PSBT", FontAwesomeIconConstants.QRCODE)
-        REVIEW_PSBT = "Review PSBT"
         VERIFY_ADDRESS = "Verify Addr"
         EXPORT_XPUB = "Export Xpub"
         EXPLORER = "Address Explorer"
@@ -372,20 +371,7 @@ class SeedOptionsView(View):
             VERIFY_ADDRESS += f" {addr}"
             button_data.append(VERIFY_ADDRESS)
 
-        if self.controller.psbt:
-            if PSBTParser.has_matching_input_fingerprint(self.controller.psbt, self.seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
-                if self.controller.resume_main_flow and self.controller.resume_main_flow == Controller.FLOW__PSBT:
-                    # Re-route us directly back to the start of the PSBT flow
-                    self.controller.resume_main_flow = None
-                    self.controller.psbt_seed = self.seed
-                    return Destination(PSBTOverviewView, skip_current_view=True)
-            else:
-                # This seed does not seem to be a signer for this PSBT
-                # TODO: How sure are we? Should disable this entirely if we're 100% sure?
-                REVIEW_PSBT += " (?)"
-            button_data.append(REVIEW_PSBT)
-        else:
-            button_data.append(SCAN_PSBT)
+        button_data.append(SCAN_PSBT)
         
         if self.settings.get_value(SettingsConstants.SETTING__XPUB_EXPORT) == SettingsConstants.OPTION__ENABLED:
             button_data.append(EXPORT_XPUB)
@@ -408,12 +394,9 @@ class SeedOptionsView(View):
             # Force BACK to always return to the Main Menu
             return Destination(MainMenuView)
 
-        if button_data[selected_menu_num] == REVIEW_PSBT:
-            self.controller.psbt_seed = self.controller.get_seed(self.seed_num)
-            return Destination(PSBTOverviewView)
-
         if button_data[selected_menu_num] == SCAN_PSBT:
             from seedsigner.views.scan_views import ScanView
+            self.controller.psbt_seed = self.controller.get_seed(self.seed_num)
             return Destination(ScanView)
 
         elif button_data[selected_menu_num] == VERIFY_ADDRESS:

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -121,12 +121,6 @@ class Destination:
 #
 #########################################################################################
 class MainMenuView(View):
-    def __init__(self):
-        super().__init__()
-        # always clear psbt state when on Main Menu
-        self.controller.clear_psbt_data()
-
-
     def run(self):
         from .seed_views import SeedsMenuView
         from .settings_views import SettingsMenuView

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -121,6 +121,12 @@ class Destination:
 #
 #########################################################################################
 class MainMenuView(View):
+    def __init__(self):
+        super().__init__()
+        # always clear psbt state when on Main Menu
+        self.controller.clear_psbt_data()
+
+
     def run(self):
         from .seed_views import SeedsMenuView
         from .settings_views import SettingsMenuView


### PR DESCRIPTION
Either this PR or PR #282 should be merged, not both.

Correction/Enhancing workflow related to selecting a seed after scanning a PSBT (when you've already selected the seed previously).

The skipping of the "second" seed selection requires these conditions:

- PSBT was scanned from a previous selected seed menu
- The fingerprint of the seed must match a input fingerprint in the PSBT (this means network settings also need to be correct).

Also navigation to MainMenuView causes all PSBT state to be cleared and a rescan will be required.

See https://github.com/SeedSigner/seedsigner/pull/282#issuecomment-1345651979 for more information.