### PR TITLE
typo 'visibiilty' becomes 'visibility' in .get_settings_entries()

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -483,10 +483,10 @@ class SettingsDefinition:
 
 
     @classmethod
-    def get_settings_entries(cls, visibiilty: str = SettingsConstants.VISIBILITY__GENERAL) -> List[SettingsEntry]:
+    def get_settings_entries(cls, visibility: str = SettingsConstants.VISIBILITY__GENERAL) -> List[SettingsEntry]:
         entries = []
         for entry in cls.settings_entries:
-            if entry.visibility == visibiilty:
+            if entry.visibility == visibility:
                 entries.append(entry)
         return entries
     

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -20,7 +20,7 @@ class SettingsMenuView(View):
         DONATE = "Donate"
 
         settings_entries = SettingsDefinition.get_settings_entries(
-            visibiilty=self.visibility
+            visibility=self.visibility
         )
         button_data=[e.display_name for e in settings_entries]
 


### PR DESCRIPTION
In the method definition of SettingsDefinitions.get_settings_entries() and in the only place it is called, SettingsMenuView(), a typo of "visibiilty" has existed in an argument name since 0.5.0.  This was NOT causing any errors, because this typo was consistent in:
* the prototype line of the method definition,
* as well as its usage in the body of that method,
* as well as its only caller from the view class.

IT WAS HARMLESS.

However, because it:
* has caught my eye and compelled me to deep-grep and verify that this typo does NOT break anything,
* and because not fixing it might compel future developers to repeat the same distraction/unnecessary verification,
* and/or worse, to correct only half of it, turning a harmless typo into a real bug in the Settings Menu,
...I have resolved the typo to "visibility"

In testing this change, I have:
* fixed just half of it, to make sure that doing so would indeed create an exception bug upon entering the Settings Menu,
* and fixed all of it, then retested to verify that I am NOT getting an exception upon entering the Settings Menu.

This was first mentioned in https://github.com/SeedSigner/seedsigner/issues/296