### PR TITLE
bip85 child seeds via embit.bip85.derive_mnemonic()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-embit==0.6.1
+embit==0.7.0
 numpy==1.21.1
 picamera==1.13
 Pillow==8.2.0

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -34,7 +34,7 @@ class Seed:
 
     @staticmethod
     def get_wordlist(wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> List[str]:
-        # TODO: Support other bip-39 wordlist languages!
+        # TODO: Support other BIP-39 wordlist languages!
         if wordlist_language_code == SettingsConstants.WORDLIST_LANGUAGE__ENGLISH:
             return bip39.WORDLIST
         else:
@@ -98,7 +98,7 @@ class Seed:
 
 
     def set_wordlist_language_code(self, language_code: str):
-        # TODO: Support other bip-39 wordlist languages!
+        # TODO: Support other BIP-39 wordlist languages!
         raise Exception("Not yet implemented!")
 
 
@@ -115,7 +115,7 @@ class Seed:
         """Derives the seed's nth BIP-85 child mnemonic"""
         root = bip32.HDKey.from_seed(self.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(network)]["xprv"])
 
-        # TODO: Support other bip-39 wordlist languages!
+        # TODO: Support other BIP-39 wordlist languages!
         return bip85.derive_mnemonic(root, bip85_num_words, bip85_index)
         
 

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -111,14 +111,11 @@ class Seed:
         return embit_utils.get_xpub(seed_bytes=self.seed_bytes, derivation_path=wallet_path, embit_network=SettingsConstants.map_network_to_embit(network))
 
 
-    # Derives a BIP85 mnemonic (seed word) from the master seed words using embit functions
     def get_bip85_child_mnemonic(self, bip85_index: int, bip85_num_words: int, network: str = SettingsConstants.MAINNET):
-
-        # Calculate the master bip32 root key from the parents bip39 seed_bytes (the mnemonic entropy)
+        """Derives the seed's nth BIP-85 child mnemonic"""
         root = bip32.HDKey.from_seed(self.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(network)]["xprv"])
 
         # TODO: Support other bip-39 wordlist languages!
-
         return bip85.derive_mnemonic(root, bip85_num_words, bip85_index)
         
 

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -1,7 +1,7 @@
 import unicodedata
 
 from binascii import hexlify
-from embit import bip39, bip32
+from embit import bip39, bip32, bip85
 from embit.networks import NETWORKS
 from typing import List
 
@@ -121,25 +121,8 @@ class Seed:
         root = bip32.HDKey.from_seed(self.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(network)]["xprv"])
 
         # TODO: Support other bip-39 wordlist languages!
-        # As per the BIP85 spec, 39 is the application number used for bip39 mnemonic,
-        # we use the selected word count and the index to form the full path.
-        path = "m/83696968'/39'/0'/{bip85_num_words}'/{bip85_index}'".format(
-                            bip85_num_words=bip85_num_words,
-                            bip85_index=bip85_index)
 
-        # Derive the child xprv (HDKey) using the path format defined above
-        xprv = root.derive(path)
-
-        # The xprv.secret plus the BIP85 key is hashed together using hmac sha512.
-        entropy = hmac.new(key=b'bip-entropy-from-k', msg=xprv.secret, digestmod=hashlib.sha512).digest()
-
-        # Calculate number of bytes to retain for the entropy
-        # 24 words the width is 32bytes (256bits)
-        # 12 words the width is 16bytes (128bits)
-        width = round(bip85_num_words / 12 * 16)
-
-        # Return the derived BIP85 child mnemonic using the truncated derived entropy
-        return bip39.mnemonic_from_bytes(entropy[:width])
+        return bip85.derive_mnemonic(root, bip85_num_words, bip85_index)
         
 
     ### override operators    

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -8,9 +8,6 @@ from typing import List
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.helpers import embit_utils
 
-import hashlib
-import hmac
-
 
 class InvalidSeedException(Exception):
     pass


### PR DESCRIPTION
**This change:**

* updates a dependency from embit 0.6.1 to embit 0.7.0,
* removes our own implementation of the 'mnemonic' app from bip85, replacing it with embit's implementation of the same.  Also, it removes the importing of hmac and hashlib as they are no longer necessary in models/seed.py.
* does NOT affect any of our own internal api's; changes are contained within a single method of Seed.

~~From me, this gets a temporary NACK while I'm waiting for feedback on "confidence regarding bip85 api stability" from the embit author.~~ I'd also prefer waiting for hints that others will add stability by depending on embit.bip85 within one or more of specter-diy, specter-desktop, krux, etc.  It's worthwhile to note that the author had enough confidence to have bumped the version and uploaded to pypi as of last week.  I had questions/comments at first glance, and left them in https://github.com/diybitcoinhardware/embit/commit/41f0a38f83f9df77bee7e0ddece4b32e3d935879, only to later answer my own questions at the bottom of my comment.

[Update]: As noted in the convo link just above, the embit author has responded and does not foresee api changes, except for asserts to become raised ValueErrors (I believe that assert exceptions do crash seedsigner so a ValueError would be nicer,) but this is a non issue for us.  We won't be calling embit.bip85.derive_mnemonic() with anything other than 12 or 24 words.
Bitcoin-Brainbow/Brainbow's nowallet.py recently adds stability to the same derive_mnemonic() embit function that this depends on... but ONLY for index=0 for now.

**Regarding the upgraded dependency**

The differences between embit versions 0.6.1 and 0.7.0 are mostly the addition of the bip85 module, which passes the standard tests for this bip, at least in regards to deriving entropy (used by all apps): in deriving a seed mnemonic, an xprv, a wif, and hex data -- but we rely only on derive_mnemonic() for now.

It ALSO appears to fix a bug that is internal to embit -- around PSBTs.
* a type hint was corrected from the wrong type to the correct one in embit.psbt (theirs not ours).
* an unnecessary iteration of a loop is short-circuited within embit.psbtview (theirs, not ours).
I suspect these changes will NOT break seedsigner code, but I ask for peer's eyes to take a look as well; I have NOT retested PSBTs yet.

**What I did NOT do**

I did not remove the test suite for bip85.  Actually, I'm a big fan of too many tests rather than too few tests, because it doesn't hurt to re-test our dependencies;  It protects us both... until maintaining them becomes an onerous chore.  These tests still pass.

**In testing this change**

* I have reproduced the same child mnemonic words from the same seed backups as I did originally -- before and after BIP-85 Child Seed support was merged into seedsigner/dev, this time using embit's implementation.

This was first discussed in https://github.com/SeedSigner/seedsigner/issues/296
Our original bip85 implementation appears in https://github.com/SeedSigner/seedsigner/commit/69905562b79e883d76164d1d7137a53bab6b5c78
The original enhancement request discussion appears in https://github.com/SeedSigner/seedsigner/issues/131