### PR TITLE
added setup() for singletons in test_controller

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -9,7 +9,7 @@ from seedsigner.models.settings_definition import SettingsConstants
 
 
 @pytest.fixture(scope="module")
-def setup():
+def reset_controller():
     Settings._instance = None
     MicroSD._instance = None
     Controller._instance = None
@@ -17,13 +17,13 @@ def setup():
     yield Controller
 
     
-def test_singleton_init_fails(setup):
+def test_singleton_init_fails(reset_controller):
     """ The Controller should not allow any code to instantiate it via Controller() """
     with pytest.raises(Exception):
         c = Controller()
 
 
-def test_singleton_get_instance_preserves_state(setup):
+def test_singleton_get_instance_preserves_state(reset_controller):
     """ Changes to the Controller singleton should be preserved across calls to get_instance() """
 
     # Initialize the instance and verify that it read the config settings
@@ -38,7 +38,7 @@ def test_singleton_get_instance_preserves_state(setup):
     assert controller.unverified_address == "123abc"
 
 
-def test_missing_settings_get_defaults(setup):
+def test_missing_settings_get_defaults(reset_controller):
     """ Should gracefully handle any missing fields from `settings.ini` """
     # TODO: This is not complete; currently only handles missing compact_seedqr_enabled.
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2,16 +2,12 @@ import configparser
 import pytest
 from mock import MagicMock
 from seedsigner.controller import Controller
-from seedsigner.models.settings import Settings
-from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.settings_definition import SettingsConstants
 
 
 
 @pytest.fixture(scope="module")
 def reset_controller():
-    Settings._instance = None
-    MicroSD._instance = None
     Controller._instance = None
     Controller.configure_instance(disable_hardware=True)
     yield Controller

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,16 +1,22 @@
 import configparser
 import pytest
 from mock import MagicMock
+from seedsigner.hardware.microsd import MicroSD
 from seedsigner.controller import Controller
 from seedsigner.models.settings_definition import SettingsConstants
 
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def reset_controller():
-    Controller._instance = None
+    print("\nEntering reset_controller fixture; setting up...")
     Controller.configure_instance(disable_hardware=True)
-    yield Controller
+    print("...done setting up; yielding to run a test...")
+    yield
+    print("\n...back from the test; tearing down...")
+    MicroSD._instance = None
+    Controller._instance = None
+    print("...done tearing down; leaving reset_controller fixture.")
 
     
 def test_singleton_init_fails(reset_controller):
@@ -35,9 +41,32 @@ def test_singleton_get_instance_preserves_state(reset_controller):
 
 
 def test_missing_settings_get_defaults(reset_controller):
-    """ Should gracefully handle any missing fields from `settings.ini` """
-    # TODO: This is not complete; currently only handles missing compact_seedqr_enabled.
+    """ Should gracefully handle all missing fields from `settings.json` """
 
-    # Controller should still have a default value
     controller = Controller.get_instance()
-    assert controller.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) == SettingsConstants.OPTION__DISABLED
+
+    # Settings defaults
+    assert controller.settings.get_value(SettingsConstants.SETTING__LANGUAGE) == SettingsConstants.LANGUAGE__ENGLISH
+    assert controller.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE) == SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
+    assert controller.settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) == SettingsConstants.OPTION__DISABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__COORDINATORS) == [i for i,j in SettingsConstants.ALL_COORDINATORS]
+    assert controller.settings.get_value(SettingsConstants.SETTING__BTC_DENOMINATION) == SettingsConstants.BTC_DENOMINATION__THRESHOLD
+
+    # Advanced Settings defaults
+    assert controller.settings.get_value(SettingsConstants.SETTING__NETWORK) == SettingsConstants.MAINNET
+    assert controller.settings.get_value(SettingsConstants.SETTING__QR_DENSITY) == SettingsConstants.DENSITY__MEDIUM
+    assert controller.settings.get_value(SettingsConstants.SETTING__XPUB_EXPORT) == SettingsConstants.OPTION__ENABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__SIG_TYPES) == [i for i,j in SettingsConstants.ALL_SIG_TYPES]
+    assert controller.settings.get_value(SettingsConstants.SETTING__SCRIPT_TYPES) == [SettingsConstants.NATIVE_SEGWIT, SettingsConstants.NESTED_SEGWIT]
+    assert controller.settings.get_value(SettingsConstants.SETTING__XPUB_DETAILS) == SettingsConstants.OPTION__ENABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) == SettingsConstants.OPTION__ENABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__CAMERA_ROTATION) == SettingsConstants.CAMERA_ROTATION__0
+    assert controller.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) == SettingsConstants.OPTION__ENABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS) == SettingsConstants.OPTION__DISABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__PRIVACY_WARNINGS) == SettingsConstants.OPTION__ENABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__DIRE_WARNINGS) == SettingsConstants.OPTION__ENABLED
+    assert controller.settings.get_value(SettingsConstants.SETTING__PARTNER_LOGOS) == SettingsConstants.OPTION__ENABLED
+
+    # Hidden Settings defaults
+    assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS) == 189
+


### PR DESCRIPTION
fixes #299
since https://github.com/SeedSigner/seedsigner/commit/c6c8ff25eee414840b2769fde7a0f9360d244bec merged Dec 2, 2022, NOT all "Controller" tests passing.

**In order to test:**
```
pip3 install -r tests/requirements.txt
pip3 install -e .
pytest -v tests/test_controller.py
pytest -v
```