### PR TITLE
conditional power-off: 'Powering Off' or 'Just Unplug It'

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -907,6 +907,21 @@ class PowerOffScreen(BaseTopNavScreen):
 
 
 @dataclass
+class PowerOffNotRequiredScreen(BaseTopNavScreen):
+    def __post_init__(self):
+        self.title = "Just Unplug It"
+        self.show_back_button = True
+        super().__post_init__()
+
+        self.components.append(TextArea(
+            text="In SeedSigner-OS, it is safe to disconnect power at any time.",
+            screen_y=self.top_nav.height,
+            height=self.canvas_height - self.top_nav.height,
+        ))
+
+
+
+@dataclass
 class KeyboardScreen(BaseTopNavScreen):
     """
         Generalized Screen for a single Keyboard layout writing user input to a

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -914,7 +914,7 @@ class PowerOffNotRequiredScreen(BaseTopNavScreen):
         super().__post_init__()
 
         self.components.append(TextArea(
-            text="In SeedSigner-OS, it is safe to disconnect power at any time.",
+            text="It is safe to disconnect power at any time.",
             screen_y=self.top_nav.height,
             height=self.canvas_height - self.top_nav.height,
         ))

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -3,7 +3,7 @@ from typing import List
 
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, DireWarningScreen, LargeButtonScreen, PowerOffScreen, ResetScreen, WarningScreen
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, DireWarningScreen, LargeButtonScreen, PowerOffScreen, PowerOffNotRequiredScreen, ResetScreen, WarningScreen
 from seedsigner.models.threads import BaseThread
 from seedsigner.models import Settings
 
@@ -199,9 +199,13 @@ class RestartView(View):
 
 class PowerOffView(View):
     def run(self):
-        thread = PowerOffView.PowerOffThread()
-        thread.start()
-        PowerOffScreen().display()
+        if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+            PowerOffNotRequiredScreen().display()
+            return Destination(BackStackView)
+        else:
+            thread = PowerOffView.PowerOffThread()
+            thread.start()
+            PowerOffScreen().display()
 
 
     class PowerOffThread(BaseThread):
@@ -210,13 +214,7 @@ class PowerOffView(View):
             from subprocess import call
             while self.keep_running:
                 time.sleep(5)
-                if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
-                    # disable microsd detection before shutdown to prevent display of toast notification during shutdown
-                    from seedsigner.controller import Controller
-                    Controller.get_instance().microsd.stop()
-                    call("poweroff", shell=True)
-                else:
-                    call("sudo shutdown --poweroff now", shell=True)
+                call("sudo shutdown --poweroff now", shell=True)
 
 
 


### PR DESCRIPTION
This branch is working for me when built on **SeedSigner-OS** as well as **raspios-buster-armhf-lite**.

Both look the same from the PowerOptionsView:
* for SeedSigner-OS, "Power Off" button will display PowerOffNotRequiredScreen "Just Unplug It" w/ back-button.
* for raspios-buster-armhf-lite, "Power Off" will display PowerOffScreen just as it has in the past, while gracefully shutting down.

Maybe we can discuss possible textual changes? @easyuxd ? since it takes 40m just to re-build the SeedSigner-OS version after each change?

Summary of changes:

* new title is: "**Just Unplug It**" instead of "Powering Off"

* textarea change is: ~~"In SeedSigner-OS, in..."~~ "**It is safe to disconnect power at any time.**" instead of "Please wait about 30 seconds before disconnecting power."

* behavioral change is: **The system will NOT gracefully shutdown at all** for SeedSigner-OS users.  They'll remain on this informational screen until they 1) pull the power cord or 2) use the back-button.  If they use the back-button, they'll land in the PowerOptionsView w/ choice to "Restart" or "Power Off", and if they use back-button again, they'll land back to the main menu.

Not implemented, but one thought I had:  Maybe in the PowerOptionsView, for SeedSigner-OS users: the power-off button might read "**Unplug It**" w/ same icon as "Power Off"?