### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="seedsigner",
-    version="0.5.2",
+    version="0.6.0",
     author="SeedSigner",
     author_email="author@example.com",
     description="Build an offline, airgapped Bitcoin signing device for less than $50!",

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -50,7 +50,7 @@ class Controller(Singleton):
         rather than at the top in order avoid circular imports.
     """
 
-    VERSION = "0.5.2"
+    VERSION = "0.6.0"
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.


### PR DESCRIPTION
A decision was made to skip 0.5.2 and go to 0.6.0 instead. The move from Raspberry Pi OS to SeedSigner OS is a big part of this justification. The change to SeedSigner OS justifies not a minor release version bump as originally planned.