### PR TITLE
Fix mistake from pr #284

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -373,6 +373,14 @@ class SeedOptionsView(View):
             addr = self.controller.unverified_address["address"][:7]
             VERIFY_ADDRESS += f" {addr}"
             button_data.append(VERIFY_ADDRESS)
+            
+        if self.controller.psbt:
+         if PSBTParser.has_matching_input_fingerprint(self.controller.psbt, self.seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
+             if self.controller.resume_main_flow and self.controller.resume_main_flow == Controller.FLOW__PSBT:
+                 # Re-route us directly back to the start of the PSBT flow
+                 self.controller.resume_main_flow = None
+                 self.controller.psbt_seed = self.seed
+                 return Destination(PSBTOverviewView, skip_current_view=True)
 
         button_data.append(SCAN_PSBT)
         


### PR DESCRIPTION
Hopefully this fixes my mistake from PR #284. I should not have deleted the code for resume flow from PSBT.
This addition back allows Scan of PSBT first, then scan/entry of seed, then directly to PSBT Review.

Expected Behaviors/Flows:

Scan PSBT (from Home) -> "Scan a Seed" -> Finalize Seed (Done) -> Review PSBT

Scan Seed (from Home) -> Finalize Seed (Done) -> Scan PSBT -> Review PSBT

Tools (from Home) -> Address Explorer -> Scan a Seed -> Finalize Seed (Done) -> Addresses Explorer