### PR TITLE
fixes required "dupe-back-button" from explorer to seeds menu

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -522,6 +522,9 @@ class SeedExportXpubScriptTypeView(View):
         ).display()
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
+            # If previous view is SeedOptionsView then that should be where resume_main_flow started (otherwise it would have been skipped).
+            if len(self.controller.back_stack) >= 2 and self.controller.back_stack[-2].View_cls == SeedOptionsView:
+                self.controller.resume_main_flow = None
             return Destination(BackStackView)
 
         else:


### PR DESCRIPTION
Currently, when leaving the Address Explorer flow via "back" button to Seeds menu, user passes twice through the script-type selection screen.

This pr solves the above redundant "back-button" clicks which are necessary, without disturbing backwards flow for Exporting Xpubs nor for Address Explorer when coming from the Tools menu.

This was first discussed [here](https://github.com/SeedSigner/seedsigner/pull/286#issuecomment-1364552409) and solved [here](https://github.com/SeedSigner/seedsigner/pull/286/files#r1063923426) in a large pr by @EverydayBitcoiner that has not since moved forward.