### PR TITLE
scan improvements from pr-286

### DIFF
--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -18,7 +18,7 @@ from ..components import BaseComponent, Button, GUIConstants, Fonts, IconButton,
 @dataclass
 class ScanScreen(BaseScreen):
     decoder: DecodeQR = None
-    instructions_text: str = "Scan a QR code"
+    instructions_text: str = "< back  |  Scan a QR code"
     resolution: Tuple[int,int] = (480, 480)
     framerate: int = 12
     render_rect: Tuple[int,int,int,int] = None

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -102,6 +102,9 @@ class ScanView(View):
             else:
                 return Destination(NotYetImplementedView)
 
+        elif self.decoder.is_invalid:
+            raise Exception("QRCode not recognized or not yet supported.")
+
         return Destination(MainMenuView)
 
 


### PR DESCRIPTION
Originally submitted by @EverydayBitcoiner in pr #286:

resolves #185
* hint while scanning changed from "Scan a QR code" to "< back  |  Scan a QR code".

* an exception is raised when an invalid QR code is scanned, instead of being redirected to Main menu.

For this last one, there are 2 similar failure conditions when scanning a QR code.
* when the qrcode is understood (decoder.is_complete) but we dont need/support using it, then the user is redirected to NotYetImplemented.
* when the qrcode is not understood (decoder.is_invalid), they will see a DireWarning screen with an error message "QRCode not recognized or not yet supported." instead of being redirected back to the main menu (where they might think a bug occurred instead of realizing they scanned the wrong qrcode.

To test the first type of error qrcode, scan a single-sig wallet descriptor from specter or sparrow.  To test the second, which is the only thing added, scan any random qrcode, or the xpub-qrcode from sparrow (instead of the wallet descriptor).