### PR TITLE
code cleanup to abandon "lock-icon for seeds w/ passphrase"

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -40,19 +40,17 @@ class PSBTSelectSeedView(View):
             if not PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
                 # Doesn't look like this seed can sign the current PSBT
                 button_str += " (?)"
-            
-            if seed.passphrase is not None:
-                # TODO: Include lock icon on right side of button
-                pass
+
             button_data.append((button_str, SeedSignerCustomIconConstants.FINGERPRINT, "blue"))
+
         button_data.append(SCAN_SEED)
         button_data.append(TYPE_12WORD)
         button_data.append(TYPE_24WORD)
 
         if self.controller.psbt_seed:
-         if PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=self.controller.psbt_seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
-             # skip the seed prompt if a seed was previous selected and has matching input fingerprint
-             return Destination(PSBTOverviewView)
+             if PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=self.controller.psbt_seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
+                 # skip the seed prompt if a seed was previous selected and has matching input fingerprint
+                 return Destination(PSBTOverviewView)
 
         selected_menu_num = ButtonListScreen(
             title="Select Signer",

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -36,8 +36,7 @@ class SeedsMenuView(View):
         self.seeds = []
         for seed in self.controller.storage.seeds:
             self.seeds.append({
-                "fingerprint": seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
-                "has_passphrase": seed.passphrase is not None
+                "fingerprint": seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
             })
 
 
@@ -1472,12 +1471,7 @@ class SeedSingleSigAddressVerificationSelectSeedView(View):
 
         for seed in seeds:
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            
-            if seed.passphrase is not None:
-                # TODO: Include lock icon on right side of button
-                pass
             button_data.append((button_str, SeedSignerCustomIconConstants.FINGERPRINT, "blue"))
-
             text = "Select seed to verify"
 
         button_data.append(SCAN_SEED)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -433,10 +433,6 @@ class ToolsAddressExplorerSelectSourceView(View):
         seeds = self.controller.storage.seeds
         for seed in seeds:
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            
-            if seed.passphrase is not None:
-                # TODO: Include lock icon on right side of button
-                pass
             button_data.append((button_str, SeedSignerCustomIconConstants.FINGERPRINT, "blue"))
 
         button_data.append(SCAN_SEED)


### PR DESCRIPTION
Originally submitted by @EverydayBitcoiner in pr #286, these are purely aesthetic code-cleanup changes related to abandoning the outdated idea of a visible lock-icon for seeds with passphrases.

* removal of if-statements that always pass, as well as surrounding stylish whitespace
* removal of a dictionary key

as well as
* a single case of whitespace/indentation correction (the boyscout rule to check-in cleaner what was checked-out while other devs are looking at it) which was within eye-sight of one of the above code changes.

Because none of these changes are expected to have any visible effect on application behavior, I found this harder than normal to test.  I logged into my dev rpi to make sure that what I had installed was actually the branch I was working on... to avoid testing no changes at all.  Then I attempted to step into each View that had been modified.
* PSBTSelectSeedView doesn't crash when I scan a PSBT with or without a seed, and then select a seed.
* SeedMenuView doesn't crash when selecting a seed.
* Tools then AddressExplorer doesn't crash while selecting a seed.
* Verifying an Address for a single-sig wallet doesn't crash while selecting a seed.
