### PR TITLE
back-button flow avoids landing in "scan"

### DIFF
--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -46,7 +46,7 @@ class ScanView(View):
                 psbt = self.decoder.get_psbt()
                 self.controller.psbt = psbt
                 self.controller.psbt_parser = None
-                return Destination(PSBTSelectSeedView)
+                return Destination(PSBTSelectSeedView, skip_current_view=True)
 
             elif self.decoder.is_settings:
                 from seedsigner.models.settings import Settings
@@ -83,7 +83,7 @@ class ScanView(View):
                     return Destination(NotYetImplementedView)
 
                 self.controller.multisig_wallet_descriptor = descriptor
-                return Destination(MultisigWalletDescriptorView)
+                return Destination(MultisigWalletDescriptorView, skip_current_view=True)
             
             elif self.decoder.is_address:
                 from seedsigner.views.seed_views import AddressVerificationStartView
@@ -92,6 +92,7 @@ class ScanView(View):
 
                 return Destination(
                     AddressVerificationStartView,
+                    skip_current_view=True,
                     view_args={
                         "address": address,
                         "script_type": script_type,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1387,14 +1387,14 @@ class AddressVerificationStartView(View):
                 sig_type = SettingsConstants.MULTISIG
                 if self.controller.multisig_wallet_descriptor:
                     # Can jump straight to the brute-force verification View
-                    destination = Destination(SeedAddressVerificationView)
+                    destination = Destination(SeedAddressVerificationView, skip_current_view=True)
                 else:
                     self.controller.resume_main_flow = Controller.FLOW__VERIFY_MULTISIG_ADDR
-                    destination = Destination(LoadMultisigWalletDescriptorView)
+                    destination = Destination(LoadMultisigWalletDescriptorView, skip_current_view=True)
 
             else:
                 sig_type = SettingsConstants.SINGLE_SIG
-                destination = Destination(SeedSingleSigAddressVerificationSelectSeedView)
+                destination = Destination(SeedSingleSigAddressVerificationSelectSeedView, skip_current_view=True)
 
         elif self.controller.unverified_address["script_type"] == SettingsConstants.TAPROOT:
             # TODO: add Taproot support


### PR DESCRIPTION
Originally submitted by @EverydayBitcoiner in pr #286

These changes concern back-button flow to avoid landing in the scan screen or landing at the same screen with no way to exit the flow via the back button.

In the original pr, all changes were implemented by adding "skip_current_view=True" to Destination calls, exclusively while in Address Verification.   However, during testing, I found that similar changes were also required while scanning a QR code.

* No change was made while scanning a valid SeedQR because the next screen is Finalize which has no "back" button.

* No change was made while scanning a SettingsQR because I couldn't figure out how to test it.  This might be necessary because this screen appears to have a back-button, but without being able to test this, I didn't want to introduce the expense of an IndexError for the benefit of a more fluid exit via back-button because it appears that any other key-press will bring the user back to the MainMenu anyways.

* While scanning multisig address for verification, the next step is to also scan the wallet descriptor.  Currently, if instead of the wallet descriptor you use the back-button, you'd end up in the scan screen, and this change avoids that so that user ends up at the Main Menu.  If instead of going back, they do scan a wallet descriptor, only to realize that the seed fingerprints don't look correct, they can use back without landing in scan and instead can actively choose to re-scan the musig wallet descriptor, or cancel, or back out to the main menu.

* While scanning a musig wallet descriptor by itself... just to verify the seed fingerprints, there is not much to do as a next step, but this change will NOT land the user in the scan screen if they use the back-button to escape, they'll just go back to the Main Menu as if they'd chosen "Ok"

* While scanning a single-sig address, this change allows the user to escape through the back-back button whether they bail-out while scanning a new seed, or after they've selected a loaded seed, instead of being stuck in an endless-loop where the back-button leaves them in the seed selection screen.

* While scanning a PSBT, this change avoids backing out via back-button without stepping through the scan screen.  I have also merged Nick's pr#321 into my local branch and these changes do not collide with Nick's latest pr.

* The original pr included similar ", skip_current_view=True" changes when using Destination("NotYetImplementedView"), which is more consistent from a code-style perspective, however even though this View has a back-button, there is no logic to make use of the backstack and the user is always brought back to the MainMenu; so I chose "no code changes" rather than "more code" which effectively doesn't do anything.

