### PR TITLE
[Bugfix] Preserve multiselect sort order

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -156,8 +156,11 @@ class Settings(Singleton):
             raise Exception(f"Unsupported SettingsEntry.type: {settings_entry.type}")
 
         display_names = []
-        for value in self._data[attr_name]:
-            display_names.append(settings_entry.get_selection_option_display_name_by_value(value))
+        # Iterate through the selection_options list in order to preserve intended sort
+        # order when adding which options are selected.
+        for value, display_name in settings_entry.selection_options:
+            if value in self._data[attr_name]:
+                display_names.append(display_name)
         return display_names
 
 


### PR DESCRIPTION
## Bug
Multiselect `SettingsEntry` types (e.g. Xpub script types) do not preserve their sort order when displayed if the user has previously enabled/disabled various options.


## Steps to reproduce:
* In Settings -> Advanced, enable all Script types and exit (to establish a starting point)
* Re-enter Script types and de-select "Native Segwit" and exit
* Re-enter Script types and re-select "Native Segwit" and exit
* Load a seed and go to Export Xpub
* The available script types will be sorted based on the order that they were enabled in each subsequent Settings update (e.g. we enabled "Native Segwit" last/most recently, so it will render last in the list)


## Expected behavior:
In the above scenario, we still want "Native Segwit" to appear at the top of the list.
