### PR TITLE
[Enhancement] Specific `ScanView` child classes to limit acceptable QR types

### DIFF
--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -44,7 +44,7 @@ class ScanScreen(BaseScreen):
     decoder: DecodeQR = None
     instructions_text: str = None
     resolution: tuple[int,int] = (480, 480)
-    framerate: int = 12
+    framerate: int = 6  # TODO: alternate optimization for Pi Zero 2W?
     render_rect: tuple[int,int,int,int] = None
 
 

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -42,9 +42,9 @@ class ScanScreen(BaseScreen):
     this should probably be refactored into the Controller.
     """
     decoder: DecodeQR = None
-    instructions_text: str = "< back  |  Scan a QR code"
+    instructions_text: str = None
     resolution: tuple[int,int] = (480, 480)
-    framerate: int = 6  # TODO: alternate optimization for Pi Zero 2W?
+    framerate: int = 12
     render_rect: tuple[int,int,int,int] = None
 
 
@@ -52,6 +52,8 @@ class ScanScreen(BaseScreen):
         from seedsigner.hardware.camera import Camera
         # Initialize the base class
         super().__post_init__()
+
+        self.instructions_text = "< back  |  " + self.instructions_text
 
         self.camera = Camera.get_instance()
         self.camera.start_video_stream_mode(resolution=self.resolution, framerate=self.framerate, format="rgb")

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -70,8 +70,8 @@ class PSBTSelectSeedView(View):
         self.controller.resume_main_flow = Controller.FLOW__PSBT
 
         if self.button_data[selected_menu_num] == self.SCAN_SEED:
-            from seedsigner.views.scan_views import ScanView
-            return Destination(ScanView)
+            from seedsigner.views.scan_views import ScanSeedQRView
+            return Destination(ScanSeedQRView)
 
         elif self.button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -135,7 +135,13 @@ class ScanView(View):
                 return Destination(NotYetImplementedView)
 
         elif self.decoder.is_invalid:
-            raise Exception("QRCode not recognized or format not yet supported.")
+            return Destination(ErrorView, view_args=dict(
+                title="Error",
+                status_headline="Unknown QR Type",
+                text="QRCode is invalid or is a data format not yet supported.",
+                button_text="Back",
+                next_destination=Destination(BackStackView, skip_current_view=True),
+            ))
 
         return Destination(MainMenuView)
 
@@ -168,6 +174,16 @@ class ScanWalletDescriptorView(ScanView):
     @property
     def is_valid_qr_type(self):
         return self.decoder.is_wallet_descriptor
+
+
+
+class ScanAddressView(ScanView):
+    instructions_text = "Scan address QR"
+    invalid_qr_type_message = "Expected an address QR"
+
+    @property
+    def is_valid_qr_type(self):
+        return self.decoder.is_address
 
 
 

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -50,6 +50,10 @@ class ScanView(View):
         # Handle the results
         if self.decoder.is_complete:
             if not self.is_valid_qr_type:
+                # We recognized the QR type but it was not the type expected for the
+                # current flow.
+                # Report QR types in more human-readable text (e.g. QRType
+                # `seed__compactseedqr` as "seed: compactseedqr").
                 return Destination(ErrorView, view_args=dict(
                     title="Error",
                     status_headline="Wrong QR Type",
@@ -184,24 +188,3 @@ class ScanAddressView(ScanView):
     @property
     def is_valid_qr_type(self):
         return self.decoder.is_address
-
-
-
-class SettingsUpdatedView(View):
-    def __init__(self, config_name: str):
-        super().__init__()
-
-        self.config_name = config_name
-    
-
-    def run(self):
-        from seedsigner.gui.screens.scan_screens import SettingsUpdatedScreen
-        screen = SettingsUpdatedScreen(config_name=self.config_name)
-        selected_menu_num = screen.display()
-
-        if selected_menu_num == RET_CODE__BACK_BUTTON:
-            return Destination(BackStackView)
-
-        # Only one exit point
-        return Destination(MainMenuView)
-

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -2,31 +2,62 @@ import re
 
 from embit.descriptor import Descriptor
 
-from seedsigner.gui.screens import scan_screens
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.settings_views import SettingsIngestSettingsQRView
-from seedsigner.views.view import MainMenuView, NotYetImplementedView, View, Destination
+from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
 
 
 
 class ScanView(View):
+    """
+        The catch-all generic scanning View that will accept any of our supported QR
+        formats and will route to the most sensible next step.
+
+        Can also be used as a base class for more specific scanning flows with
+        dedicated errors when an unexpected QR type is scanned (e.g. Scan PSBT was
+        selected but a SeedQR was scanned).
+    """
+    instructions_text = "Scan a QR code"
+    invalid_qr_type_message = "QRCode not recognized or not yet supported."
+
+
     def __init__(self):
         super().__init__()
-
-        # Set up the QR decoder here so we can inject data into it in the test suite's
-        # `before_run`.
+        # Define the decoder here to make it available to child classes' is_valid_qr_type
+        # checks and so we can inject data into it in the test suite's `before_run()`.
         self.wordlist_language_code = self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE)
-        self.decoder = DecodeQR(wordlist_language_code=self.wordlist_language_code)
+        self.decoder: DecodeQR = DecodeQR(wordlist_language_code=self.wordlist_language_code)
+
+
+    @property
+    def is_valid_qr_type(self):
+        return True
 
 
     def run(self):
+        from seedsigner.gui.screens.scan_screens import ScanScreen
+
         # Start the live preview and background QR reading
-        self.run_screen(scan_screens.ScanScreen, decoder=self.decoder)
+        self.run_screen(
+            ScanScreen,
+            instructions_text=self.instructions_text,
+            decoder=self.decoder
+        )
 
         # Handle the results
         if self.decoder.is_complete:
+            if not self.is_valid_qr_type:
+                return Destination(ErrorView, view_args=dict(
+                    title="Error",
+                    status_headline="Wrong QR Type",
+                    text=self.invalid_qr_type_message + f""", received "{self.decoder.qr_type.replace("__", ": ").replace("_", " ")}\" format""",
+                    button_text="Back",
+                    next_destination=Destination(BackStackView, skip_current_view=True),
+                ))
+
             if self.decoder.is_seed:
                 seed_mnemonic = self.decoder.get_seed_phrase()
 
@@ -104,6 +135,57 @@ class ScanView(View):
                 return Destination(NotYetImplementedView)
 
         elif self.decoder.is_invalid:
-            raise Exception("QRCode not recognized or not yet supported.")
+            raise Exception("QRCode not recognized or format not yet supported.")
 
         return Destination(MainMenuView)
+
+
+
+class ScanPSBTView(ScanView):
+    instructions_text = "Scan PSBT"
+    invalid_qr_type_message = "Expected a PSBT"
+
+    @property
+    def is_valid_qr_type(self):
+        return self.decoder.is_psbt
+
+
+
+class ScanSeedQRView(ScanView):
+    instructions_text = "Scan SeedQR"
+    invalid_qr_type_message = f"Expected a SeedQR"
+
+    @property
+    def is_valid_qr_type(self):
+        return self.decoder.is_seed
+
+
+
+class ScanWalletDescriptorView(ScanView):
+    instructions_text = "Scan descriptor"
+    invalid_qr_type_message = "Expected a wallet descriptor QR"
+
+    @property
+    def is_valid_qr_type(self):
+        return self.decoder.is_wallet_descriptor
+
+
+
+class SettingsUpdatedView(View):
+    def __init__(self, config_name: str):
+        super().__init__()
+
+        self.config_name = config_name
+    
+
+    def run(self):
+        from seedsigner.gui.screens.scan_screens import SettingsUpdatedScreen
+        screen = SettingsUpdatedScreen(config_name=self.config_name)
+        selected_menu_num = screen.display()
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        # Only one exit point
+        return Destination(MainMenuView)
+

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -22,8 +22,6 @@ from seedsigner.models.seed import InvalidSeedException, Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
-from seedsigner.views.psbt_views import PSBTChangeDetailsView
-from seedsigner.views.scan_views import ScanView
 from seedsigner.views.view import NotYetImplementedView, View, Destination, BackStackView, MainMenuView
 
 
@@ -409,9 +407,9 @@ class SeedOptionsView(View):
             return Destination(MainMenuView)
 
         if button_data[selected_menu_num] == self.SCAN_PSBT:
-            from seedsigner.views.scan_views import ScanView
+            from seedsigner.views.scan_views import ScanPSBTView
             self.controller.psbt_seed = self.controller.get_seed(self.seed_num)
-            return Destination(ScanView)
+            return Destination(ScanPSBTView)
 
         elif button_data[selected_menu_num] == self.VERIFY_ADDRESS:
             return Destination(SeedAddressVerificationView, view_args=dict(seed_num=self.seed_num))
@@ -1566,8 +1564,8 @@ class SeedSingleSigAddressVerificationSelectSeedView(View):
         self.controller.resume_main_flow = Controller.FLOW__VERIFY_SINGLESIG_ADDR
 
         if button_data[selected_menu_num] == SCAN_SEED:
-            from seedsigner.views.scan_views import ScanView
-            return Destination(ScanView)
+            from seedsigner.views.scan_views import ScanSeedQRView
+            return Destination(ScanSeedQRView)
 
         elif button_data[selected_menu_num] in [TYPE_12WORD, TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
@@ -1792,7 +1790,8 @@ class LoadMultisigWalletDescriptorView(View):
         ).display()
 
         if button_data[selected_menu_num] == SCAN:
-            return Destination(ScanView)
+            from seedsigner.views.scan_views import ScanWalletDescriptorView
+            return Destination(ScanWalletDescriptorView)
 
         elif button_data[selected_menu_num] == CANCEL:
             if self.controller.resume_main_flow == Controller.FLOW__PSBT:
@@ -1840,6 +1839,7 @@ class MultisigWalletDescriptorView(View):
         
         elif button_data[selected_menu_num] == RETURN:
             # Jump straight back to PSBT change verification
+            from seedsigner.views.psbt_views import PSBTChangeDetailsView
             self.controller.resume_main_flow = None
             return Destination(PSBTChangeDetailsView, view_args=dict(change_address_num=0))
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -94,8 +94,8 @@ class LoadSeedView(View):
             return Destination(BackStackView)
         
         if button_data[selected_menu_num] == self.SEED_QR:
-            from .scan_views import ScanView
-            return Destination(ScanView)
+            from .scan_views import ScanSeedQRView
+            return Destination(ScanSeedQRView)
         
         elif button_data[selected_menu_num] == self.TYPE_12WORD:
             self.controller.storage.init_pending_mnemonic(num_words=12)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -27,9 +27,10 @@ class ToolsMenuView(View):
     DICE = ("New seed", FontAwesomeIconConstants.DICE)
     KEYBOARD = ("Calc 12th/24th word", FontAwesomeIconConstants.KEYBOARD)
     EXPLORER = "Address Explorer"
+    ADDRESS = "Verify address"
 
     def run(self):
-        button_data = [self.IMAGE, self.DICE, self.KEYBOARD, self.EXPLORER]
+        button_data = [self.IMAGE, self.DICE, self.KEYBOARD, self.EXPLORER, self.ADDRESS]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -52,6 +53,11 @@ class ToolsMenuView(View):
 
         elif button_data[selected_menu_num] == self.EXPLORER:
             return Destination(ToolsAddressExplorerSelectSourceView)
+
+        elif button_data[selected_menu_num] == self.ADDRESS:
+            from seedsigner.views.scan_views import ScanAddressView
+            return Destination(ScanAddressView)
+
 
 
 """****************************************************************************
@@ -465,9 +471,13 @@ class ToolsAddressExplorerSelectSourceView(View):
                 )
             )
 
-        elif button_data[selected_menu_num] in [self.SCAN_SEED, self.SCAN_DESCRIPTOR]:
-            from seedsigner.views.scan_views import ScanView
-            return Destination(ScanView)
+        elif button_data[selected_menu_num] == self.SCAN_SEED:
+            from seedsigner.views.scan_views import ScanSeedQRView
+            return Destination(ScanSeedQRView)
+
+        elif button_data[selected_menu_num] == self.SCAN_DESCRIPTOR:
+            from seedsigner.views.scan_views import ScanWalletDescriptorView
+            return Destination(ScanWalletDescriptorView)
 
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -479,14 +479,6 @@ class ToolsAddressExplorerSelectSourceView(View):
             from seedsigner.views.scan_views import ScanWalletDescriptorView
             return Destination(ScanWalletDescriptorView)
 
-        elif button_data[selected_menu_num] == self.SCAN_DESCRIPTOR:
-            from seedsigner.views.scan_views import ScanWalletDescriptorView
-            return Destination(ScanWalletDescriptorView)
-
-        elif button_data[selected_menu_num] == self.SCAN_DESCRIPTOR:
-            from seedsigner.views.scan_views import ScanWalletDescriptorView
-            return Destination(ScanWalletDescriptorView)
-
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
             if button_data[selected_menu_num] == self.TYPE_12WORD:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -479,6 +479,10 @@ class ToolsAddressExplorerSelectSourceView(View):
             from seedsigner.views.scan_views import ScanWalletDescriptorView
             return Destination(ScanWalletDescriptorView)
 
+        elif button_data[selected_menu_num] == self.SCAN_DESCRIPTOR:
+            from seedsigner.views.scan_views import ScanWalletDescriptorView
+            return Destination(ScanWalletDescriptorView)
+
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
             if button_data[selected_menu_num] == self.TYPE_12WORD:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -483,6 +483,10 @@ class ToolsAddressExplorerSelectSourceView(View):
             from seedsigner.views.scan_views import ScanWalletDescriptorView
             return Destination(ScanWalletDescriptorView)
 
+        elif button_data[selected_menu_num] == self.SCAN_DESCRIPTOR:
+            from seedsigner.views.scan_views import ScanWalletDescriptorView
+            return Destination(ScanWalletDescriptorView)
+
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
             if button_data[selected_menu_num] == self.TYPE_12WORD:

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -271,12 +271,13 @@ class ErrorView(View):
     next_destination: Destination = Destination(MainMenuView, clear_history=True)
 
     def run(self):
-        WarningScreen(
+        self.run_screen(
+            WarningScreen,
             title=self.title,
             status_headline=self.status_headline,
             text=self.text,
             button_data=[self.button_text],
-        ).display()
+        )
 
         return self.next_destination
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -260,6 +260,28 @@ class NotYetImplementedView(View):
 
 
 
+@dataclass
+class ErrorView(View):
+    """
+    """
+    title: str = "Error"
+    status_headline: str = None
+    text: str = None
+    button_text: str = None
+    next_destination: Destination = Destination(MainMenuView, clear_history=True)
+
+    def run(self):
+        WarningScreen(
+            title=self.title,
+            status_headline=self.status_headline,
+            text=self.text,
+            button_data=[self.button_text],
+        ).display()
+
+        return self.next_destination
+
+
+
 class UnhandledExceptionView(View):
     def __init__(self, error: list[str]):
         self.error = error

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -41,7 +41,7 @@ class TestPSBTFlows(FlowTest):
 			FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
 			FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),  # simulate read PSBT; ret val is ignored
 			FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_SEED),
-			FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+			FlowStep(scan_views.ScanSeedQRView, before_run=load_seed_into_decoder),
 			FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
 			FlowStep(seed_views.SeedOptionsView, is_redirect=True),
 			FlowStep(psbt_views.PSBTOverviewView),

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -48,7 +48,7 @@ class TestToolsFlows(FlowTest):
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
             FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.EXPLORER),
             FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_SEED),
-            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR
+            FlowStep(scan_views.ScanSeedQRView, before_run=load_seed_into_decoder),  # simulate read SeedQR
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
             FlowStep(seed_views.SeedOptionsView, is_redirect=True),
             FlowStep(seed_views.SeedExportXpubScriptTypeView),

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -4,7 +4,7 @@ from base import FlowTest, FlowStep
 from seedsigner.controller import Controller
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
-from seedsigner.views.view import MainMenuView
+from seedsigner.views.view import ErrorView, MainMenuView
 from seedsigner.views import scan_views, seed_views, tools_views
 
 
@@ -70,3 +70,20 @@ class TestToolsFlows(FlowTest):
                 FlowStep(seed_views.SeedExportXpubScriptTypeView),
             ]
         )
+
+
+    def test_addressexplorer_scan_wrong_qrtype(self):
+        """
+        Scanning the wrong type of QR code when a SeedQR is expected should route to ErrorView
+        """
+        def load_wrong_data_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq")
+
+        # Finalize the new seed w/out passphrase
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_SEED),
+            FlowStep(scan_views.ScanSeedQRView, before_run=load_wrong_data_into_decoder),  # simulate scanning the wrong QR type
+            FlowStep(ErrorView),
+        ])


### PR DESCRIPTION
Aside from the `MainMenuView`'s "Scan" option, all other `ScanView` calls are expecting a specific type of QR code (e.g. "Scan a PSBT") but nothing is stopping `ScanView` from accepting an unexpected but supported QR type.


## This PR:
* adds specific `ScanView` child classes that display an error screen if the user scans an unexpected QR type.

* displays a friendlier error screen when an invalid or unrecognized QR format is scanned (the current approach just raises an `Exception` and makes it look like a bug in SeedSigner).

* promotes "Verify address" to the Tools menu. Previously it was a kind of hidden feature that would be activated if a bitcoin address was scanned by `ScanView`.


## Testing notes
If a user scans the wrong kind of QR, verify that they get another chance to resume their task and scan again.