### PR TITLE
[Enhancement] Add test coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,41 @@
+[run]
+branch = True
+
+[report]
+show_missing = True
+skip_empty = True
+skip_covered = True
+
+# Omit; need a different approach to test modules with hardware dependencies 
+omit =
+    */__init__.py
+    */tests/*
+    */pyzbar/*
+    */gui/*
+
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    def __str__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # Don't complain about abstract methods, they aren't run:
+    @(abc\.)?abstractmethod
+
+
+[html]
+directory = coverage_html_report
+skip_empty = True
+skip_covered = False

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 branch = True
 
 [report]
-show_missing = True
 skip_empty = True
 skip_covered = True
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/seedsigner.egg-info/
 src/seedsigner/models/settings_definition.json
 .idea
 *.mo
+.coverage

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,7 +33,7 @@ coverage run -m pytest
 
 Show the resulting test coverage details:
 ```
-coverage report --show-missing
+coverage report
 ```
 
 Generate the html overview:

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,3 +24,19 @@ Run a specific test:
 ```
 pytest tests/test_this_file.py::test_this_specific_test
 ```
+
+### Test Coverage
+Run tests and generate test coverage
+```
+coverage run -m pytest
+```
+
+Show the resulting test coverage details:
+```
+coverage report --show-missing
+```
+
+Generate the html overview:
+```
+coverage html
+```

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
-pytest==6.2.4
+coverage==7.2.1
 mock==4.0.3
+pytest==6.2.4

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -51,21 +51,25 @@ def test_calculate_checksum_invalid_mnemonics():
         # Mnemonic is too short: 10 words instead of 11
         partial_mnemonic = "abandon " * 9 + "about"
         mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    assert "12- or 24-word" in str(e)
 
     with pytest.raises(Exception) as e:
         # Valid mnemonic but unsupported length
         mnemonic = "devote myth base logic dust horse nut collect buddy element eyebrow visit empty dress jungle"
         mnemonic_generation.calculate_checksum(mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    assert "12- or 24-word" in str(e)
 
     with pytest.raises(Exception) as e:
         # Mnemonic is too short: 22 words instead of 23
         partial_mnemonic = "abandon " * 21 + "about"
         mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    assert "12- or 24-word" in str(e)
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(ValueError) as e:
         # Invalid BIP-39 word
-        partial_mnemonic = "foobar " * 9 + "about"
+        partial_mnemonic = "foobar " * 11 + "about"
         mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    assert "not in the dictionary" in str(e)
 
 
 

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -1,3 +1,4 @@
+import pytest
 import random
 
 from embit import bip39
@@ -42,6 +43,31 @@ def test_calculate_checksum():
     assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
 
+def test_calculate_checksum_invalid_mnemonics():
+    """
+        Should raise an Exception on a mnemonic that is invalid due to length or using invalid words.
+    """
+    with pytest.raises(Exception) as e:
+        # Mnemonic is too short: 10 words instead of 11
+        partial_mnemonic = "abandon " * 9 + "about"
+        mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+    with pytest.raises(Exception) as e:
+        # Valid mnemonic but unsupported length
+        mnemonic = "devote myth base logic dust horse nut collect buddy element eyebrow visit empty dress jungle"
+        mnemonic_generation.calculate_checksum(mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+    with pytest.raises(Exception) as e:
+        # Mnemonic is too short: 22 words instead of 23
+        partial_mnemonic = "abandon " * 21 + "about"
+        mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+    with pytest.raises(Exception) as e:
+        # Invalid BIP-39 word
+        partial_mnemonic = "foobar " * 9 + "about"
+        mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+
 
 def test_calculate_checksum_with_default_final_word():
     """ 11-word and 23-word mnemonics use word `0000` as a temp final word to complete
@@ -60,6 +86,22 @@ def test_calculate_checksum_with_default_final_word():
     partial_mnemonic += " abandon"
     mnemonic2 = mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "), wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
     assert mnemonic1 == mnemonic2
+
+
+def test_generate_mnemonic_from_bytes():
+    """
+        Should generate a valid BIP-39 mnemonic from entropy bytes
+    """
+    # From iancoleman.io
+    entropy = "3350f6ac9eeb07d2c6209932808aa7f6"
+    expected_mnemonic = "crew marble private differ race truly blush basket crater affair prepare unique".split()
+    mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
+    assert mnemonic == expected_mnemonic
+
+    entropy = "5bf41629fce815c3570955e8f45422abd7e2234141bd4d7ec63b741043b98cad"
+    expected_mnemonic = "fossil pass media what life ticket found click trophy pencil anger fish lawsuit balance agree dash estate wage mom trial aerobic system crawl review".split()
+    mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
+    assert mnemonic == expected_mnemonic
 
 
 


### PR DESCRIPTION
## Add test suite `coverage` reports

_Note: The current test suite only runs on Raspi hardware (#339 will move testing to non-Raspi local dev)._


## Changes
* Adds new test-only dependency in tests/requirements.txt for `coverage`.
* `.coveragerc` configuration.
* See the usage notes for `coverage` in the tests/README.md.
* Additional tests in test_mnemonic_generation.py to prototype improving test coverage.


# tldr
```
pip install coverage
coverage run -m pytest
coverage report
coverage html
```

Open the resulting coverage html. Click into any listed file and explore which lines of code the tests did or did not execute.