### PR TITLE
Avoid OS specific function uname()

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 
 from typing import Any, List
 
@@ -10,7 +11,7 @@ from .singleton import Singleton
 
 
 class Settings(Singleton):
-    HOSTNAME = os.uname()[1]
+    HOSTNAME = platform.uname()[1]
     SEEDSIGNER_OS = "seedsigner-os"
     SETTINGS_FILENAME = "/mnt/microsd/settings.json" if HOSTNAME == SEEDSIGNER_OS else "settings.json"
         


### PR DESCRIPTION
It is necessary to avoid `AttributeError: module 'os' has no attribute 'uname'` when using the `seedsigner-emulator` project on Windows: https://github.com/tadeubas/seedsigner-emulator