### PR TITLE
[Bugfix] Remove errant import in psbt_screens.py

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from lzma import is_check_supported
 from PIL import Image, ImageDraw, ImageFilter
 from typing import List
 import time


### PR DESCRIPTION
Commit e9ad26bea9fe05f6c69b240de63bbbf174b3a7f3 introduced an unintended `lzma` import (blame VSCode automatic "quick fix" and a not careful enough visual inspection of diffs on what's being committed).

This errant import currently seems to be harmless because:
* Raspi OS built-in python3.7 seems to have `lzma` compiled in (otherwise those screens would crash on the import).
* SeedSigner OS python3.10.8 also seems to have `lzma` compiled in.

However, with #347 we're custom-compiling python3.10 on Raspi OS. And doing so without `lzma` support. So the import crashes the python file.