### PR TITLE
Readme- Windows Verification steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ shasum -a 256 --ignore-missing --check seedsigner.0.6.*.sha256
 ```
 CertUtil -hashfile  seedsigner_os.0.6.0.Insert_Your_Pi_Models_binary_here_For_Example_pi02w.img SHA256 
 ```
-On Windows, you must then manually compare the resulting file hash value to the corresponding hash value shown inside the .SHA256 cleartext file.
+
  <BR>
 
 Wait up to 30 seconds for the command to complete, and it should display:


### PR DESCRIPTION
Improvements to Binary file verification on Windows Platform:
Add new Powershell script that simulates the Linux SHASUM command , but within the Windows platform. 
Remove reference to extra manual textfile checking