### PR TITLE
Update README.md

### DIFF
--- a/docs/seed_qr/README.md
+++ b/docs/seed_qr/README.md
@@ -70,7 +70,7 @@ It's important to note here that QR codes can encode data in a number of differe
 
 QR codes are typically used to encode a website url, in which case the "Alphanumeric" format has to be used (the encoded data can consist of upper- and lowercase letters, numbers, and certain allowed symbols).
 
-If you have a long url like `https://ohnoihavealongurl.com` (29 characters), the chart shows that it would not fit in a 21x21 QR code; its max capacity is 25 alphanumeric chars. But it's within the 47-char capacity of the 29x29 size.
+If you have a long url like `https://ohnoihavealongurl.com` (29 characters), the chart shows that it would not fit in a 21x21 QR code; its max capacity is 25 alphanumeric chars. But it's within the 47-char capacity of the 25x25 size.
 
 ### Bit efficiency matters
 Notice that the "Numeric" column has greater capacity. This is because when you have fewer possible characters to encode, it takes less data to specify each one.


### PR DESCRIPTION
Line 73 seems to have a typo associating the 47 character capacity with the 29x29 qr size, when the reference table displays 47 as the limit for 25x25. This proposed change corrects the typo to show 25x25 in the text of line 73.