### PR TITLE
ST7789 using array instead of numpy

### DIFF
--- a/src/seedsigner/hardware/ST7789.py
+++ b/src/seedsigner/hardware/ST7789.py
@@ -1,7 +1,7 @@
 import spidev
 import RPi.GPIO as GPIO
 import time
-import numpy as np
+import array
 
 
 
@@ -153,11 +153,10 @@ class ST7789(object):
         if imwidth != self.width or imheight != self.height:
             raise ValueError('Image must be same dimensions as display \
                 ({0}x{1}).' .format(self.width, self.height))
-        img = np.asarray(Image)
-        pix = np.zeros((self.width,self.height,2), dtype = np.uint8)
-        pix[...,[0]] = np.add(np.bitwise_and(img[...,[0]],0xF8),np.right_shift(img[...,[1]],5))
-        pix[...,[1]] = np.add(np.bitwise_and(np.left_shift(img[...,[1]],3),0xE0),np.right_shift(img[...,[2]],3))
-        pix = pix.flatten().tolist()
+        # 24-bit RGB-8:8:8 becomes 16-bit BGR-5:6:5 plus endianness toggle.
+        arr = array.array("H", Image.convert("BGR;16").tobytes())
+        arr.byteswap()
+        pix = arr.tobytes()
         self.SetWindows ( 0, 0, self.width, self.height)
         GPIO.output(self._dc,GPIO.HIGH)
         for i in range(0,len(pix),4096):


### PR DESCRIPTION
This change results in a ~10x speed-up for ShowImage() calls (from ~20ms to 2ms on pi2),
...as measured by wrapping deleted-lines/inserted-lines with something like:
`t0 = time.time()`
and 
`print("elapsed: ", time.time() - t0)`

The original goal was to do-away with our dependency on 'numpy', but picamera still requires it.
Still, this 'hack' gets us closer to not needing numpy and makes the interface feel a touch more 'snappy' on both pi2 and pi0.

Leaving this here because it's what I'm using from this point forward (and I'll forget about sharing it if not reminded), for others to consider.   (btw: I also found many ways to do the same thing which were 2 orders of magnitude slower than this hack).