### PR TITLE
handle exceptions which have no message

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -309,6 +309,8 @@ class Controller(Singleton):
         # So we extract the Exception type and trim off any "foo.bar." namespacing:
         last_line = traceback.format_exc().splitlines()[-1]
         exception_type = last_line.split(":")[0].split(".")[-1]
+
+        # Extract the error message, if there is one
         if ":" in last_line:
             exception_msg = last_line.split(":")[1]
         else:

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -309,7 +309,10 @@ class Controller(Singleton):
         # So we extract the Exception type and trim off any "foo.bar." namespacing:
         last_line = traceback.format_exc().splitlines()[-1]
         exception_type = last_line.split(":")[0].split(".")[-1]
-        exception_msg = last_line.split(":")[1]
+        if ":" in last_line:
+            exception_msg = last_line.split(":")[1]
+        else:
+            exception_msg = ""
 
         # Scan for the last debugging line that includes a line number reference
         line_info = None


### PR DESCRIPTION
Discovered while researching Nico's issue #369,

An exception that is raised and caught by the controller which has no exception message was causing another IndexError while handling the original exception.
```
File "/home/pi/seedsigner-dev/src/seedsigner/controller.py", line 312, in handle_exception
    exception_msg = last_line.split(":")[1]
IndexError: list index out of range
```

This pr intends to handle exceptions which have no exception message (as in `assert False`) so that the program does not crash and so that the user sees a dire warning with exception type and line number.  

PLEASE CORRECT ME IF IM WRONG ABOUT THIS ASSUMPTION
... because I could very-well understand the value in wanting the system to go no further in some cases... but I have no evidence that we already do this with expressed intent elsewhere.   It's rare that exceptions are raised w/o exception messages, but it is happening, at least, in embit.bip85's derive_entropy(), like `assert max(path) < H` as it's checking that the child index is not greater than 2**31-1, as Nico reported yesterday.

IF THERE ARE TIMES WHEN WE WANT SEEDSIGNER TO CRASH, whether in our local codebase or as dependencies want to crash, then this pr should NOT be merged.  I don't have enough history here to make this call (but thinking `exit()` would be more obvious than relying on unhandled asserts.)