### PR TITLE
dire-warning detour if invalid BIP-85 child index

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -942,6 +942,16 @@ class SeedBIP85SelectChildIndexView(View):
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
+        if not 0 <= int(ret) < 2**31:
+            return Destination(
+                SeedBIP85InvalidChildIndexView,
+                view_args=dict(
+                    seed_num=self.seed_num, 
+                    num_words=self.num_words
+                ),
+                skip_current_view=True
+            )
+
         return Destination(
             SeedWordsWarningView,
             view_args=dict(
@@ -949,6 +959,32 @@ class SeedBIP85SelectChildIndexView(View):
                 bip85_data=dict(child_index=int(ret), num_words=self.num_words),
             )
         )
+
+
+class SeedBIP85InvalidChildIndexView(View):
+    def __init__(self, seed_num: int, num_words: int):
+        super().__init__()
+        self.seed_num = seed_num
+        self.num_words = num_words
+
+
+    def run(self):
+        DireWarningScreen(
+            title="BIP-85 Index Error",
+            show_back_button=False,
+            status_headline=f"Invalid Child Index",
+            text=f"BIP-85 Child Index must be between 0 and {2**31-1}.",
+            button_data=["Try Again"]
+        ).display()
+
+        return Destination(
+                SeedBIP85SelectChildIndexView,
+                view_args=dict(
+                    seed_num=self.seed_num, 
+                    num_words=self.num_words
+                ),
+                skip_current_view=True
+            )
 
 
 


### PR DESCRIPTION
resolves issue #369

This pr adds a detour to Dire Warning whenever a BIP-85 Child Index is outside the valid range of (0, 2**31-1), informing the user and forcing them to "Try Again", instead of the application crashing.

Related to this pr is #370 (handling exceptions which have no exception message), but they are independent of each other.
* if this one is merged but not the other one: the bug reported in #369 will be resolved, and the exception handler bug will be disguised until another message-less exception is found.
* if the other one is merged but not this one:  users would see a vague "Assertion Error" with embit references, and can start over... guessing what they did wrong... but at least the application won't crash.
* if both are merged, users are informed and can try again AND we might learn of exception-type/filename/line-number the next time seedsigner "hangs" for message-less exceptions.