### PR TITLE
raise exception if psbt is for another network

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -28,6 +28,19 @@ class PSBTSelectSeedView(View):
         if not self.controller.psbt:
             # Shouldn't be able to get here
             raise Exception("No PSBT currently loaded")
+
+        # PSBT may optionally contain PSBT_GLOBAL_XPUBS which informs network
+        if self.controller.psbt.xpubs:
+            embit_network = SettingsConstants.map_network_to_embit(
+                self.controller.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            )
+            psbt_versions = [k.version for k in self.controller.psbt.xpubs]
+            our_version = NETWORKS[embit_network]['xpub']
+
+            # even if multiple xpubs, should all be for the same network
+            if set(psbt_versions) != set([our_version]):
+                raise Exception("This PSBT is for another network")
+            del embit_network, psbt_versions, our_version
         
         seeds = self.controller.storage.seeds
 


### PR DESCRIPTION
resolves #398

This pull request raises an ugly exception (far from ideal) w/ message "This PSBT is for another network" whenever PSBT_GLOBAL_XPUBS indicates that the wallet was exported for another network version than what seedsigner is currently set to use in Settings / Advanced / Bitcoin network (though test/regtest/signet are all the same).
![psbt_wrong_network](https://github.com/SeedSigner/seedsigner/assets/117163651/ee4cffa5-e4da-4fe9-a49d-432415c455aa)

Specter Desktop: does not include PSBT_GLOBAL_XPUBS, users would see wrong addresses but signatures would be valid.

Sparrow and Nunchuk: both include PSBT_GLOBAL_XPUBS, and this pr would help to inform users to switch networks.

It is unknown, at least to me, if BlueWallet or Keeper include PSBT_GLOBAL_XPUBS, but I would appreciate if anyone could share a PSBT from those wallets so that I may verify, or inform me if they already know.

