### PR TITLE
Update manual_installation for Wi-Fi enabled Pi's

### DIFF
--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -10,7 +10,7 @@ The manual SeedSigner installation and configuration process requires an interne
 If your Pi does not have onboard wifi, you have two options:
 
 1. Run these steps on a separate Raspberry Pi 2/3/4 or Zero W which does have onboard Wi-Fi to connect to the internet, and then move the SD card over to the non Wi-Fi enabled Pi when complete.
-2. OR configure the non-wifi Pi directly by relaying through your computer's internet connection over USB. See instructions [here](usb_relay.md).
+2. OR configure the non Wi-Fi enabled Pi directly by relaying through your computer's internet connection over USB. See instructions [here](usb_relay.md).
 
 If your Pi does have onboard Wi-Fi, then using the Rasberry Pi Imager software will allow you to easily configure your Pi's Wi-Fi connection, as well as simultaneously write the image file. That will make your initial SSH into the Pi much easier.   
 Use the Pi's onboard Wi-Fi only if you are setting up a local development environment, never for real funds or binary image creation. 

--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -6,11 +6,15 @@ https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2
 
 Best practice is to verify the downloaded .zip file containing the Raspberry Pi Lite OS matches the published SHA256 hash of the file; for additional reference that hash is: c5dad159a2775c687e9281b1a0e586f7471690ae28f2f2282c90e7d59f64273c. After verifying the file's data integrity, you can decompress the .zip file to obtain the operating system image that it contains. You can then use Balena's Etcher tool (https://www.balena.io/etcher/) to write the Raspberry Pi Lite software image to a memory card (4 GB or larger). It's important to note that an image authoring tool must be used (the operating system image cannot be simply copied into a file storage partition on the memory card).
 
-The manual SeedSigner installation and configuration process requires an internet connection on the device to download the necessary libraries and code. But because the Pi Zero 1.3 does not have onboard wifi, you have two options:
+The manual SeedSigner installation and configuration process requires an internet connection on the Pi to download the necessary libraries and code.  
+If your Pi does not have onboard wifi, you have two options:
 
-1. Run these steps on a separate Raspberry Pi 2/3/4 or Zero W which can connect to the internet and then transfer the SD card to the Pi Zero 1.3 when complete.
-2. OR configure the Pi Zero 1.3 directly by relaying through your computer's internet connection over USB. See instructions [here](usb_relay.md).
+1. Run these steps on a separate Raspberry Pi 2/3/4 or Zero W which does have onboard Wi-Fi to connect to the internet, and then move the SD card over to the non-wifi Pi when complete.
+2. OR configure the non-wifi Pi directly by relaying through your computer's internet connection over USB. See instructions [here](usb_relay.md).
 
+If your Pi does have onboard Wi-Fi, then using the Rasberry Pi Imager software will allow you to easily configure your Pi's Wi-Fi connection, as well as simultaneously write the image file. That will make your initial ssh into the Pi much easier.   
+Use the Pi's onboard Wi-Fi only if you are setting up a local development environment, never for real funds or binary image creation. 
+  
 For the following steps you'll need to either connect a keyboard & monitor to the network-connected Raspberry Pi you are working with, or SSH into the Pi if you're familiar with that process.
 
 ### Configure the Pi

--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -9,10 +9,10 @@ Best practice is to verify the downloaded .zip file containing the Raspberry Pi 
 The manual SeedSigner installation and configuration process requires an internet connection on the Pi to download the necessary libraries and code.  
 If your Pi does not have onboard wifi, you have two options:
 
-1. Run these steps on a separate Raspberry Pi 2/3/4 or Zero W which does have onboard Wi-Fi to connect to the internet, and then move the SD card over to the non-wifi Pi when complete.
+1. Run these steps on a separate Raspberry Pi 2/3/4 or Zero W which does have onboard Wi-Fi to connect to the internet, and then move the SD card over to the non Wi-Fi enabled Pi when complete.
 2. OR configure the non-wifi Pi directly by relaying through your computer's internet connection over USB. See instructions [here](usb_relay.md).
 
-If your Pi does have onboard Wi-Fi, then using the Rasberry Pi Imager software will allow you to easily configure your Pi's Wi-Fi connection, as well as simultaneously write the image file. That will make your initial ssh into the Pi much easier.   
+If your Pi does have onboard Wi-Fi, then using the Rasberry Pi Imager software will allow you to easily configure your Pi's Wi-Fi connection, as well as simultaneously write the image file. That will make your initial SSH into the Pi much easier.   
 Use the Pi's onboard Wi-Fi only if you are setting up a local development environment, never for real funds or binary image creation. 
   
 For the following steps you'll need to either connect a keyboard & monitor to the network-connected Raspberry Pi you are working with, or SSH into the Pi if you're familiar with that process.


### PR DESCRIPTION
Since some people will be using this guide to only setup dev environments, the use of (any) on-board Wi-Fi allows them to get them setup sooner.  
Hence I suggest changes to improve the setup time of Pi's with WiFi and those without.  
Changed initial references from Pi 1.3's to 'Pi's with Wi-fi' and Pi's 'without Wi-Fi.'  
Added a suggestion to use Pi imager software to configure the onboard Wi-Fi connection while _also_ writing the image. That allows for the initial SSH login to happen a bit sooner.
