### PR TITLE
unused imports for faster initial navigation

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -15,6 +15,12 @@ from seedsigner.views.view import Destination, NotYetImplementedView, UnhandledE
 
 from .models import Seed, SeedStorage, Settings, Singleton, PSBTParser
 
+# unused imports for faster initial navigation
+from seedsigner.gui.screens import seed_screens as unused
+from seedsigner.gui.screens import scan_screens as unused
+from seedsigner.gui.screens import tools_screens as unused
+del unused
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -15,11 +15,13 @@ from seedsigner.views.view import Destination, NotYetImplementedView, UnhandledE
 
 from .models import Seed, SeedStorage, Settings, Singleton, PSBTParser
 
-# unused imports for faster initial navigation
-from seedsigner.gui.screens import seed_screens as unused
-from seedsigner.gui.screens import scan_screens as unused
-from seedsigner.gui.screens import tools_screens as unused
-del unused
+# unused heaviest-imports preloaded for faster initial navigation
+from importlib import import_module
+import_module('seedsigner.hardware.camera')
+import_module('seedsigner.gui.screens.seed_screens')
+import_module('seedsigner.gui.screens.scan_screens')
+import_module('seedsigner.gui.screens.tools_screens')
+del import_module
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
SUPERCEDED BY #416

Since commit 94abdd3 there is a noticeable delay after boot/restart moving from the MainMenu to Seeds or Tools.  That commit does not look suspicious, but I suspect it is the result of a history-rewriting --rebase on the flow_tests commit which followed it.

I have yet to identify exactly which changes created this delay.

In the meantime, I've tried importing slow-to-load modules from the controller so that navigation is much faster once the main menu has loaded.  If there is a cleaner way to do this, I'm game.  Otherwise, these unused modules are ~~bound to a name 'unused' that is then deleted~~ imported w/o local binding.  I've opted to target the camera as it's the slowest, then the heaviest of screens ordered by heaviest-first, to avoid circular imports like would happen with views; my choices based on a threshold of 0.1 seconds on a pi2.

This does result in a slightly slower boot and splash.
pi0 boots to splash in 19s, to main menu after 25s...