### PR TITLE
[Enhancement] Live preview speedup

### DIFF
--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -34,7 +34,12 @@ class Renderer(ConfigurableSingleton):
         renderer.draw = ImageDraw.Draw(renderer.canvas)
 
 
-    def show_image(self, image=None, alpha_overlay=None):
+    def show_image(self, image=None, alpha_overlay=None, show_direct=False):
+        if show_direct:
+            # Use the incoming image as the canvas and immediately render
+            self.disp.ShowImage(image, 0, 0)
+            return
+
         if alpha_overlay:
             if image == None:
                 image = self.canvas

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -65,6 +65,8 @@ class ScanScreen(BaseScreen):
             from timeit import default_timer as timer
 
             instructions_font = Fonts.get_font(GUIConstants.BODY_FONT_NAME, GUIConstants.BUTTON_FONT_SIZE)
+
+            framerate = 0
             while self.keep_running:
                 start = timer()
                 frame = self.camera.read_video_stream(as_image=True)
@@ -84,13 +86,14 @@ class ScanScreen(BaseScreen):
                             (self.render_rect[0], self.render_rect[1])
                         )
 
-                        if scan_text:
+                        if scan_text or True:
                             self.renderer.draw.text(
                                 xy=(
                                     int(self.renderer.canvas_width/2),
                                     self.renderer.canvas_height - GUIConstants.EDGE_PADDING
                                 ),
-                                text=scan_text,
+                                # text=scan_text,
+                                text=f"{framerate:0.2f} fps",
                                 fill=GUIConstants.BODY_FONT_COLOR,
                                 font=instructions_font,
                                 stroke_width=4,
@@ -101,7 +104,8 @@ class ScanScreen(BaseScreen):
                         self.renderer.show_image()
 
                         end = timer()
-                        print(f"{1.0/(end - start):0.2f} fps") # Time in seconds, e.g. 5.38091952400282
+                        framerate = 1.0/(end - start)
+                        # print(f"{framerate:0.2f} fps") # Time in seconds, e.g. 5.38091952400282
 
                 if self.camera._video_stream is None:
                     break

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -126,8 +126,8 @@ class ScanScreen(BaseScreen):
                                 text=scan_text,
                                 fill=GUIConstants.BODY_FONT_COLOR,
                                 font=instructions_font,
-                                stroke_width=4,
-                                stroke_fill=GUIConstants.BACKGROUND_COLOR,
+                                # stroke_width=4,
+                                # stroke_fill=GUIConstants.BACKGROUND_COLOR,
                                 anchor="ms"
                             )
 

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -42,7 +42,7 @@ class ScanScreen(BaseScreen):
     decoder: DecodeQR = None
     instructions_text: str = "< back  |  Scan a QR code"
     resolution: tuple[int,int] = (480, 480)
-    framerate: int = 5  # TODO: alternate optimization for Pi Zero 2W
+    framerate: int = 4  # TODO: alternate optimization for Pi Zero 2W
     render_rect: tuple[int,int,int,int] = None
 
 

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -117,6 +117,8 @@ class ScanScreen(BaseScreen):
 
                         if scan_text:
                             # Temp solution: render a slight 1px shadow behind the text
+                            # TODO: Replace the instructions_text with a disappearing
+                            # toast/popup (see: QR Brightness UI)?
                             draw.text(xy=(
                                         int(self.renderer.canvas_width/2 + 1),
                                         self.renderer.canvas_height - GUIConstants.EDGE_PADDING + 1
@@ -137,7 +139,7 @@ class ScanScreen(BaseScreen):
                                      anchor="ms")
 
                         self.renderer.disp.ShowImage(frame, 0, 0)
-                        print(f" {cur_fps:0.2f} | {self.decoder_fps}")
+                        # print(f" {cur_fps:0.2f} | {self.decoder_fps}")
 
                 if self.camera._video_stream is None:
                     break
@@ -149,11 +151,9 @@ class ScanScreen(BaseScreen):
             Screen. Once interaction starts, the display updates have to be managed in
             _run(). The live preview is an extra-complex case.
         """
-        from timeit import default_timer as timer
         num_frames = 0
         start_time = time.time()
         while True:
-            start = timer()
             frame = self.camera.read_video_stream()
             if frame is not None:
                 # print("Decoder checking next frame")

--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -1,5 +1,4 @@
 import io
-import numpy
 
 from picamera import PiCamera
 from PIL import Image


### PR DESCRIPTION
Due do slower rendering times in SeedSigner OS (full-screen updates are noticeably slower), we need to optimize the `ScanScreen` live preview as much as possible. Current `dev` branch is only rendering the live preview at about 1.6 fps for the live display and 3.1 fps for the QR decoder in SeedSigner OS (see my [benchmarking branch](https://github.com/kdmukai/seedsigner/tree/dev_livepreview_benchmarking) to get an onscreen fps display).

In my testing, this PR gets a Pi Zero running SeedSigner OS up to about 3.3 fps for the live preview and a coincidental 3.3 fps for the QR decoder.

On Raspi OS, I've seen this same code range from 4.6fps display / 3.8 fps decode to 3.5 fps display / 4.6 fps decode. 