### PR TITLE
Update version for next release to v0.7.0

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -67,7 +67,7 @@ class Controller(Singleton):
         rather than at the top in order avoid circular imports.
     """
 
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.


### PR DESCRIPTION
Because it's a big f'n deal!

Calling the first reproducible build a mere v0.6.1 doesn't do it justice.