### PR TITLE
Update ST7789 to support writing to larger SPIDEV buffer

### DIFF
--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -215,6 +215,13 @@ workon seedsigner-env
 pwd
 ```
 
+### Optional: increase spidev buffer size
+This allows `ST7789.py` to update the LCD without performing multiple write operations because the default buffer size is 4096 bytes. The default can be changed via the  `/boot/cmdline.txt` file. You will need to add `spidev.bufsiz=131072` to the end of this single lined file command.
+
+Example `cmdline.txt` contents:
+```
+console=serial0,115200 console=tty1 root=PARTUUID=2fa4ba7e-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait modules-load=dwc2,g_ether spidev.bufsiz=131072
+```
 
 ### Configure `systemd` to run SeedSigner at boot:
 

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -44,7 +44,7 @@ class ScanScreen(BaseScreen):
     decoder: DecodeQR = None
     instructions_text: str = "< back  |  Scan a QR code"
     resolution: tuple[int,int] = (480, 480)
-    framerate: int = 5  # TODO: alternate optimization for Pi Zero 2W?
+    framerate: int = 6  # TODO: alternate optimization for Pi Zero 2W?
     render_rect: tuple[int,int,int,int] = None
 
 

--- a/src/seedsigner/hardware/ST7789.py
+++ b/src/seedsigner/hardware/ST7789.py
@@ -159,13 +159,11 @@ class ST7789(object):
         pix = arr.tobytes()
         self.SetWindows ( 0, 0, self.width, self.height)
         GPIO.output(self._dc,GPIO.HIGH)
-        for i in range(0,len(pix),4096):
-            self._spi.writebytes(pix[i:i+4096])		
+        self._spi.writebytes2(pix)	
         
     def clear(self):
         """Clear contents of image buffer"""
         _buffer = [0xff]*(self.width * self.height * 2)
         self.SetWindows ( 0, 0, self.width, self.height)
         GPIO.output(self._dc,GPIO.HIGH)
-        for i in range(0,len(_buffer),4096):
-            self._spi.writebytes(_buffer[i:i+4096])		
+        self._spi.writebytes2(_buffer)	


### PR DESCRIPTION
This PR provides a modest performance increase when an operation requires rendering an updated image to the waveshare LCD. Data is transferred to the LCD using spidev (user space interface) using python. This PR does not make any significant changes to this process. 

The performance gain on this PR is done by writing out the data via a larger buffer and removing the previously required loop of write operations. Prior to this PR, the `ShowImage` method draws the entire LCD display via 29 4096 byte operations. By increasing the buffer size the entire display can be refreshed in a single operation instead of 29. The spidev kernel module supports increasing the buffer size default from 4096 via cmdline.txt. This increase is required to write out the bytes in a single operation. SeedSigner currently uses 115200 bytes (240 * 240 * 2, 240x240@16bit color). So this PR only shows performance gains after the spidev buffer has been increased. `writebytes2` accepts arbitrary large lists. If list size exceeds the buffer size (which is read from /sys/module/spidev/parameters/bufsiz), data will be split into smaller chunks and sent in multiple operations. I will also be submitting at PR to increase the buffer size to 128k in SeedSignerOS. SeedSignerOS [PR 55](https://github.com/SeedSigner/seedsigner-os/pull/55) makes this change.

To Do:

- [x] Add documentation in manual install instructions on how to update the cmdline.txt file to increase spider buffer size
- [x] Create SeedSignerOS PR to increase SPIDEV buffer to 128k