### PR TITLE
Reminder to remove SD card via Toast notification

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -181,7 +181,8 @@ class Controller(Singleton):
         controller.back_stack = BackStack()
 
         # Other behavior constants
-        controller.screensaver_activation_ms = 120 * 1000
+        # controller.screensaver_activation_ms = 2 * 60 * 1000
+        controller.screensaver_activation_ms = 20 * 1000  # DEBUGGING
     
         background_import_thread = BackgroundImportThread()
         background_import_thread.start()

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -182,8 +182,7 @@ class Controller(Singleton):
         controller.back_stack = BackStack()
 
         # Other behavior constants
-        # controller.screensaver_activation_ms = 2 * 60 * 1000
-        controller.screensaver_activation_ms = 15 * 1000  # DEBUGGING
+        controller.screensaver_activation_ms = 2 * 60 * 1000  # two minutes
     
         background_import_thread = BackgroundImportThread()
         background_import_thread.start()

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -402,6 +402,7 @@ class Controller(Singleton):
         """
         if self.is_screensaver_running:
             # New toast notifications break out of the Screensaver
+            print("Controller: stopping screensaver")
             self.screensaver.stop()
 
         if self.toast_notification_thread and self.toast_notification_thread.is_alive():

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -130,6 +130,7 @@ class Controller(Singleton):
 
     back_stack: BackStack = None
     screensaver: 'ScreensaverScreen' = None
+    toast_notification_thread: 'BaseToastOverlayManagerThread' = None
 
 
     @classmethod
@@ -182,7 +183,7 @@ class Controller(Singleton):
 
         # Other behavior constants
         # controller.screensaver_activation_ms = 2 * 60 * 1000
-        controller.screensaver_activation_ms = 20 * 1000  # DEBUGGING
+        controller.screensaver_activation_ms = 15 * 1000  # DEBUGGING
     
         background_import_thread = BackgroundImportThread()
         background_import_thread.start()
@@ -241,8 +242,9 @@ class Controller(Singleton):
             * initial_destination: The first View to run. If None, the MainMenuView is
             used. Only used by the test suite.
         """
-        from .views import MainMenuView, BackStackView
-        from .views.screensaver import OpeningSplashScreen
+        from seedsigner.views import MainMenuView, BackStackView
+        from seedsigner.views.screensaver import OpeningSplashScreen
+        from seedsigner.gui.toast import RemoveSDCardToastManagerThread
 
         OpeningSplashScreen().start()
 
@@ -276,6 +278,9 @@ class Controller(Singleton):
                 next_destination = initial_destination
             else:
                 next_destination = Destination(MainMenuView)
+            
+            # Set up our one-time toast notification tip to remove the SD card
+            self.activate_toast(RemoveSDCardToastManagerThread())
 
             while True:
                 # Destination(None) is a special case; render the Home screen
@@ -356,6 +361,9 @@ class Controller(Singleton):
             from seedsigner.gui.renderer import Renderer
             if self.is_screensaver_running:
                 self.screensaver.stop()
+            
+            if self.toast_notification_thread and self.toast_notification_thread.is_alive():
+                self.toast_notification_thread.stop()
 
             # Clear the screen when exiting
             print("Clearing screen, exiting")
@@ -368,12 +376,42 @@ class Controller(Singleton):
 
 
     def start_screensaver(self):
+        # If a toast is running, tell it to give up the Renderer.lock; it will then
+        # block until the screensaver is done, at which point the toast can re-acquire
+        # the Renderer.lock and resume where it left off.
+        if self.toast_notification_thread and self.toast_notification_thread.is_alive():
+            print(f"Controller: settings toggle_render_lock for {self.toast_notification_thread.__class__.__name__}")
+            self.toast_notification_thread.toggle_renderer_lock()
+
+        print("Controller: Starting screensaver")
         if not self.screensaver:
             # Do a lazy/late import and instantiation to reduce Controller initial startup time
             from seedsigner.views.screensaver import ScreensaverScreen
             from seedsigner.hardware.buttons import HardwareButtons
             self.screensaver = ScreensaverScreen(HardwareButtons.get_instance())
+        
+        # Start the screensaver, but it will block until it can acquire the Renderer.lock.
         self.screensaver.start()
+        print("Controller: Screensaver started")
+
+
+    def activate_toast(self, toast_manager_thread: 'BaseToastOverlayManagerThread'):
+        """
+        Ensures that the Controller has explicit control over which processes get to
+        claim the Renderer.lock and which need to (potentially) release it.
+        """
+        if self.is_screensaver_running:
+            # New toast notifications break out of the Screensaver
+            self.screensaver.stop()
+
+        if self.toast_notification_thread and self.toast_notification_thread.is_alive():
+            # Can only run one toast at a time
+            print(f"Controller: stopping {self.toast_notification_thread.__class__.__name__}")
+            self.toast_notification_thread.stop()
+        
+        self.toast_notification_thread = toast_manager_thread
+        print(f"Controller: starting {self.toast_notification_thread.__class__.__name__}")
+        self.toast_notification_thread.start()
 
 
     def handle_exception(self, e) -> Destination:

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -274,7 +274,12 @@ class Controller(Singleton):
             if initial_destination:
                 next_destination = initial_destination
             else:
-                next_destination = Destination(MainMenuView)
+                # remind the user to remove the microsd card
+                if self.settings.HOSTNAME == Settings.SEEDSIGNER_OS and self.microsd.is_inserted():
+                    next_destination = Destination(RemoveMicroSDWarningView)
+                else:
+                    next_destination = Destination(MainMenuView)
+
             while True:
                 # Destination(None) is a special case; render the Home screen
                 if next_destination.View_cls is None:

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -274,11 +274,7 @@ class Controller(Singleton):
             if initial_destination:
                 next_destination = initial_destination
             else:
-                # remind the user to remove the microsd card
-                if self.settings.HOSTNAME == Settings.SEEDSIGNER_OS and self.microsd.is_inserted():
-                    next_destination = Destination(RemoveMicroSDWarningView)
-                else:
-                    next_destination = Destination(MainMenuView)
+                next_destination = Destination(MainMenuView)
 
             while True:
                 # Destination(None) is a special case; render the Home screen

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -569,61 +569,6 @@ class IconTextLine(BaseComponent):
 
 
 @dataclass
-class ToastOverlay(BaseComponent):
-    icon_name: str = None
-    color: str = GUIConstants.NOTIFICATION_COLOR
-    label_text: str = None
-    height: int = GUIConstants.ICON_TOAST_FONT_SIZE + 2*GUIConstants.EDGE_PADDING
-    font_size: int = 19
-    outline_thickness: int = 2  # pixels
-
-    def __post_init__(self):
-        super().__post_init__()
-
-        self.icon = Icon(
-            image_draw=self.image_draw,
-            canvas=self.canvas,
-            screen_x=self.outline_thickness + 2*GUIConstants.EDGE_PADDING,  # Push the icon further from the left edge than strictly necessary
-            icon_name=self.icon_name,
-            icon_size=GUIConstants.ICON_TOAST_FONT_SIZE,
-            icon_color=self.color
-        )
-        self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2) - 1  # -1 fudge factor
-        
-        self.label = TextArea(
-            image_draw=self.image_draw,
-            canvas=self.canvas,
-            text=self.label_text,
-            font_size=self.font_size,
-            font_color=self.color,
-            edge_padding=0,
-            is_text_centered=False,
-            auto_line_break=True,
-            width=self.canvas_width - self.icon.screen_x - self.icon.width - GUIConstants.COMPONENT_PADDING - self.outline_thickness,
-            screen_x=self.icon.screen_x + self.icon.width + GUIConstants.COMPONENT_PADDING,
-            allow_text_overflow=False
-        )
-        self.label.screen_y = self.canvas_height - self.height + int((self.height - self.label.height)/2)
-
-
-    def render(self):
-        self.image_draw.rounded_rectangle(
-            (0, self.canvas_height - self.height, self.canvas_width, self.canvas_height),
-            fill=GUIConstants.BACKGROUND_COLOR,
-            radius=8,
-            outline=self.color,
-            width=self.outline_thickness,
-        )
-
-        self.icon.render()
-        self.label.render()
-
-        self.renderer.show_image()
-
-
-
-
-@dataclass
 class FormattedAddress(BaseComponent):
     """
         Display a Bitcoin address in a "{first 7} {middle} {last 7}" formatted view with

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -139,7 +139,6 @@ class SeedSignerIconConstants:
     BRIGHTNESS = "\ue91d"
     MICROSD = "\ue91e"
     QRCODE = "\ue91f"
-    SDCARD = "\ue920"
 
     MIN_VALUE = SCAN
     MAX_VALUE = QRCODE

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -571,7 +571,7 @@ class IconTextLine(BaseComponent):
 @dataclass
 class ToastOverlay(BaseComponent):
     icon_name: str = None
-    color: str = None
+    color: str = GUIConstants.NOTIFICATION_COLOR
     label_text: str = None
     height: int = GUIConstants.ICON_TOAST_FONT_SIZE + 2*GUIConstants.EDGE_PADDING
     font_size: int = 19

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -584,12 +584,12 @@ class ToastOverlay(BaseComponent):
         self.icon = Icon(
             image_draw=self.image_draw,
             canvas=self.canvas,
-            screen_x=GUIConstants.EDGE_PADDING + self.outline_thickness + GUIConstants.EDGE_PADDING,
+            screen_x=self.outline_thickness + 2*GUIConstants.EDGE_PADDING,  # Push the icon further from the left edge than strictly necessary
             icon_name=self.icon_name,
             icon_size=30,
             icon_color=self.color
         )
-        self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2)
+        self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2) - 1  # -1 fudge factor
         
         self.label = TextArea(
             image_draw=self.image_draw,
@@ -600,7 +600,7 @@ class ToastOverlay(BaseComponent):
             edge_padding=0,
             is_text_centered=False,
             auto_line_break=True,
-            width=self.canvas_width - self.icon.screen_x - self.icon.width - GUIConstants.COMPONENT_PADDING - self.outline_thickness - GUIConstants.EDGE_PADDING,
+            width=self.canvas_width - self.icon.screen_x - self.icon.width - GUIConstants.COMPONENT_PADDING - self.outline_thickness,
             screen_x=self.icon.screen_x + self.icon.width + GUIConstants.COMPONENT_PADDING,
             screen_y=self.canvas_height - self.height + GUIConstants.EDGE_PADDING,
             allow_text_overflow=False
@@ -621,7 +621,7 @@ class ToastOverlay(BaseComponent):
 
         with self.renderer.lock:
             self.image_draw.rounded_rectangle(
-                ( GUIConstants.EDGE_PADDING, self.canvas_height - self.height, self.canvas_width - GUIConstants.EDGE_PADDING, self.canvas_height),
+                (0, self.canvas_height - self.height, self.canvas_width, self.canvas_height),
                 fill=GUIConstants.BACKGROUND_COLOR,
                 radius=8,
                 outline=self.color,

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -370,6 +370,9 @@ class TextArea(BaseComponent):
     def render(self):
         # Render to a temp img scaled up by self.supersampling_factor, then resize down
         #   with bicubic resampling.
+        # Add a `resample_padding` above and below when supersampling to avoid edge
+        # effects (resized text that's right up against the top/bottom gets slightly
+        # dimmer at the edge otherwise).
         # TODO: Store resulting super-sampled image as a member var in __post_init__ and 
         # just re-paste it here.
         if self.font_size < 20 and (not self.supersampling_factor or self.supersampling_factor == 1):
@@ -415,7 +418,9 @@ class TextArea(BaseComponent):
         if self.supersampling_factor > 1.0:
             resized = img.resize((self.width, self.height + 2*resample_padding), Image.LANCZOS)
             sharpened = resized.filter(ImageFilter.SHARPEN)
-            img = sharpened.crop((0, resample_padding, self.width, self.height + 2*resample_padding))
+
+            # Crop args are actually (left, top, WIDTH, HEIGHT)
+            img = sharpened.crop((0, resample_padding, self.width, self.height + resample_padding))
         self.canvas.paste(img, (self.screen_x, self.screen_y))
 
 

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1222,6 +1222,8 @@ class KeyboardScreen(BaseTopNavScreen):
         """
         return False
 
+
+
 class MicroSDToastScreen(BaseScreen):
     """
         This screen is an overlay with special behavior with the ToastOverlay component. The ToastOverlay component overides all button
@@ -1256,3 +1258,40 @@ class MicroSDToastScreen(BaseScreen):
             )
         
         self.toast.render()
+
+
+
+@dataclass
+class MainMenuScreen(LargeButtonScreen):
+    # Override LargeButtonScreen defaults
+    title_font_size: int = 26
+    show_back_button: bool = False
+    show_power_button: bool = True
+
+
+    class SDCardNotificationToastThread(BaseThread):
+        def run(self):
+            print("Started SDCardNotificationToastThread")
+            activation_delay = 3  # seconds
+            toast = ToastOverlay(
+                icon_name=FontAwesomeIconConstants.SDCARD,
+                color=GUIConstants.NOTIFICATION_COLOR,
+                label_text="Security tip:\nRemove SD card",
+                duration=999,  # seconds
+                font_size=GUIConstants.BODY_FONT_SIZE,
+                height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
+            )
+
+            start = time.time()
+            has_rendered = False
+            while self.keep_running:
+                if time.time() - start > activation_delay and not has_rendered:
+                    toast.render()
+                    has_rendered = True
+                time.sleep(0.1)
+    
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.threads.append(self.SDCardNotificationToastThread())
+

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1276,7 +1276,7 @@ class MainMenuScreen(LargeButtonScreen):
                 icon_name=FontAwesomeIconConstants.SDCARD,
                 color=GUIConstants.NOTIFICATION_COLOR,
                 label_text="Security tip:\nRemove SD card",
-                duration=999999,  # persist "forever"
+                duration=1e6,  # persist "forever"
                 font_size=GUIConstants.BODY_FONT_SIZE,
                 height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
             )

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1256,7 +1256,7 @@ class MicroSDToastScreen(BaseScreen):
             # Hold onto the Renderer lock so we're guaranteed to restore the original
             # screen before any other listener can get a screen write in.
             self.renderer.lock.acquire()
-    
+
             # Persist until timeout...
             while time.time() < t_end:
                 # or hide it on button press
@@ -1287,6 +1287,7 @@ class MainMenuScreen(LargeButtonScreen):
             from seedsigner.controller import Controller
             from seedsigner.gui.renderer import Renderer
             from seedsigner.hardware.buttons import HardwareButtons
+            from seedsigner.hardware.microsd import MicroSD
             renderer = Renderer.get_instance()
             controller = Controller.get_instance()
             hw_inputs = HardwareButtons.get_instance()
@@ -1310,7 +1311,7 @@ class MainMenuScreen(LargeButtonScreen):
                 # screen before any other listener can get a screen write in.
                 renderer.lock.acquire()
                 while self.keep_running:
-                    if not controller.microsd.is_inserted:
+                    if not MicroSD.is_inserted():
                         # Card is removed! No need to keep running
                         break
                     if hw_inputs.has_any_input():
@@ -1339,9 +1340,9 @@ class MainMenuScreen(LargeButtonScreen):
     
 
     def __post_init__(self):
-        from seedsigner.controller import Controller
+        from seedsigner.hardware.microsd import MicroSD
         super().__post_init__()
-        if Controller.get_instance().microsd.is_inserted:
+        if MicroSD.is_inserted():
             # Remind user they can/should remove the SD card
             self.threads.append(self.SDCardNotificationToastThread())
     

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -2,19 +2,16 @@ import time
 
 from dataclasses import dataclass
 from PIL import Image, ImageDraw, ImageColor
-from typing import Any, Callable, List, Tuple
-from seedsigner.gui.components import ToastOverlay
+from typing import Any, List, Tuple
+
+from seedsigner.gui.components import (GUIConstants,
+    BaseComponent, Button, Icon, IconButton, LargeIconButton,
+    SeedSignerIconConstants, TopNav, TextArea, load_image)
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.renderer import Renderer
-
-from seedsigner.models.threads import BaseThread, ThreadsafeCounter
-from seedsigner.models.settings import SettingsConstants
-
-from ..components import (FontAwesomeIconConstants, GUIConstants, BaseComponent, Button, Icon, IconButton,
-                          LargeIconButton, SeedSignerIconConstants, TopNav, TextArea, load_image, ToastOverlay,
-                          Fonts)
-
 from seedsigner.hardware.buttons import HardwareButtonsConstants, HardwareButtons
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 
 
 # Must be huge numbers to avoid conflicting with the selected_button returned by the

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1271,13 +1271,12 @@ class MainMenuScreen(LargeButtonScreen):
 
     class SDCardNotificationToastThread(BaseThread):
         def run(self):
-            print("Started SDCardNotificationToastThread")
             activation_delay = 3  # seconds
             toast = ToastOverlay(
                 icon_name=FontAwesomeIconConstants.SDCARD,
                 color=GUIConstants.NOTIFICATION_COLOR,
                 label_text="Security tip:\nRemove SD card",
-                duration=999,  # seconds
+                duration=999999,  # persist "forever"
                 font_size=GUIConstants.BODY_FONT_SIZE,
                 height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
             )
@@ -1292,6 +1291,8 @@ class MainMenuScreen(LargeButtonScreen):
     
 
     def __post_init__(self):
+        from seedsigner.controller import Controller
         super().__post_init__()
-        self.threads.append(self.SDCardNotificationToastThread())
-
+        if Controller.get_instance().microsd.is_inserted:
+            # Remind user they can/should remove the SD card
+            self.threads.append(self.SDCardNotificationToastThread())

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -26,7 +26,7 @@ class ToastOverlay(BaseComponent):
             icon_color=self.color
         )
         self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2) - 1  # -1 fudge factor
-        
+
         self.label = TextArea(
             image_draw=self.image_draw,
             canvas=self.canvas,
@@ -99,7 +99,7 @@ class BaseToastOverlayManagerThread(BaseThread):
         self.hw_inputs.override_ind = True
 
         self.toast = self.instantiate_toast()
-    
+
 
     def instantiate_toast(self) -> ToastOverlay:
         raise Exception("Must be implemented by subclass")
@@ -155,7 +155,7 @@ class BaseToastOverlayManagerThread(BaseThread):
                     print(f"{self.__class__.__name__}: Showing toast")
                     self.toast.render()
                     has_rendered = True
-                
+
                 if time.time() - start > self.activation_delay + self.duration and has_rendered:
                     print(f"{self.__class__.__name__}: Hiding toast")
                     break
@@ -169,28 +169,30 @@ class BaseToastOverlayManagerThread(BaseThread):
                 # As far as we know, we currently hold the Renderer.lock
                 self.renderer.show_image(previous_screen_state)
                 print(f"{self.__class__.__name__}: restored previous screen state")
-            
+
             # We're done, release the lock
             self.renderer.lock.release()
 
 
 
 class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
-    def __init__(self):
+    def __init__(self, activation_delay=3):
+        # Note: activation_delay is configurable so the screenshot generator can get the
+        # toast to immediately render.
         super().__init__(
-            activation_delay=3,  # seconds
-            duration=1e6,        # seconds ("forever")
+            activation_delay=activation_delay,  # seconds
+            duration=1e6,                       # seconds ("forever")
         )
 
 
     def instantiate_toast(self) -> ToastOverlay:
         return ToastOverlay(
-            icon_name=SeedSignerIconConstants.SDCARD,
+            icon_name=SeedSignerIconConstants.MICROSD,
             label_text="Security tip:\nRemove SD card",
             font_size=GUIConstants.BODY_FONT_SIZE,
             height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
         )
-        
+
 
     def should_keep_running(self) -> bool:
         """ Custom exit condition: keep running until the SD card is removed """
@@ -210,9 +212,8 @@ class SDCardStateChangeToastManagerThread(BaseToastOverlayManagerThread):
 
 
     def instantiate_toast(self) -> ToastOverlay:
+        print("instantiating toast!")
         return ToastOverlay(
-            icon_name=SeedSignerIconConstants.SDCARD,
+            icon_name=SeedSignerIconConstants.MICROSD,
             label_text=self.message,
         )
-
-

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -1,0 +1,218 @@
+from dataclasses import dataclass
+from seedsigner.gui.components import BaseComponent, GUIConstants, Icon, TextArea
+from seedsigner.models.threads import BaseThread
+
+
+
+@dataclass
+class ToastOverlay(BaseComponent):
+    icon_name: str = None
+    color: str = GUIConstants.NOTIFICATION_COLOR
+    label_text: str = None
+    height: int = GUIConstants.ICON_TOAST_FONT_SIZE + 2*GUIConstants.EDGE_PADDING
+    font_size: int = 19
+    outline_thickness: int = 2  # pixels
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.icon = Icon(
+            image_draw=self.image_draw,
+            canvas=self.canvas,
+            screen_x=self.outline_thickness + 2*GUIConstants.EDGE_PADDING,  # Push the icon further from the left edge than strictly necessary
+            icon_name=self.icon_name,
+            icon_size=GUIConstants.ICON_TOAST_FONT_SIZE,
+            icon_color=self.color
+        )
+        self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2) - 1  # -1 fudge factor
+        
+        self.label = TextArea(
+            image_draw=self.image_draw,
+            canvas=self.canvas,
+            text=self.label_text,
+            font_size=self.font_size,
+            font_color=self.color,
+            edge_padding=0,
+            is_text_centered=False,
+            auto_line_break=True,
+            width=self.canvas_width - self.icon.screen_x - self.icon.width - GUIConstants.COMPONENT_PADDING - self.outline_thickness,
+            screen_x=self.icon.screen_x + self.icon.width + GUIConstants.COMPONENT_PADDING,
+            allow_text_overflow=False
+        )
+        self.label.screen_y = self.canvas_height - self.height + int((self.height - self.label.height)/2)
+
+
+    def render(self):
+        self.image_draw.rounded_rectangle(
+            (0, self.canvas_height - self.height, self.canvas_width, self.canvas_height),
+            fill=GUIConstants.BACKGROUND_COLOR,
+            radius=8,
+            outline=self.color,
+            width=self.outline_thickness,
+        )
+
+        self.icon.render()
+        self.label.render()
+
+        self.renderer.show_image()
+
+
+
+
+class BaseToastOverlayManagerThread(BaseThread):
+    """
+    The toast notification popup consists of a gui component (`ToastOverlay`) and this
+    manager thread that the Controller will use to coordinate handing off resources
+    between competing toasts, the screensaver, and the current underlying Screen.
+
+    Controller should set BaseThread.keep_running = False to terminate the toast when it
+    needs to be removed or replaced.
+
+    Controller should set toggle_renderer_lock = True to make the toast temporarily
+    release the Renderer.lock so another process (e.g. screensaver) can use it. The toast
+    thread will immediately try to reacquire the lock, but will have to block and wait
+    until it's available again. Note that this thread will be unresponsive while it
+    waits to reacquire the lock!
+
+    Note: any process can call lock.release() but it simplifies the logic to try to keep
+    each process aware of whether it is currently holding the lock or not (i.e. it's 
+    better for the "owner" thread to release the lock itself).
+    """
+    def __init__(self,
+                 activation_delay: int = 0,  # seconds before toast is displayed
+                 duration: int = 3,          # seconds toast is displayed
+                 ):
+        from seedsigner.controller import Controller
+        from seedsigner.gui.renderer import Renderer
+        from seedsigner.hardware.buttons import HardwareButtons
+        super().__init__()
+        self.activation_delay: int = activation_delay
+        self.duration: int = duration
+        self._toggle_renderer_lock: bool = False
+
+        self.renderer = Renderer.get_instance()
+        self.controller = Controller.get_instance()
+        self.hw_inputs = HardwareButtons.get_instance()
+
+        # Special case when screensaver is running
+        self.hw_inputs.override_ind = True
+
+        self.toast = self.instantiate_toast()
+    
+
+    def instantiate_toast(self) -> ToastOverlay:
+        raise Exception("Must be implemented by subclass")
+
+
+    def should_keep_running(self) -> bool:
+        """ Placeholder for custom exit conditions """
+        return True
+
+
+    def toggle_renderer_lock(self):
+        self._toggle_renderer_lock = True
+
+
+    def run(self):
+        try:
+            print(f"{self.__class__.__name__}: started")
+            start = time.time()
+            has_rendered = False
+            self.previous_screen_state = None
+            if self.activation_delay > 0:
+                time.sleep(self.activation_delay)
+
+            # Hold onto the Renderer lock so we're guaranteed to restore the original
+            # screen before any other listener can get a screen write in.
+            print(f"{self.__class__.__name__}: Acquiring lock")
+            self.renderer.lock.acquire()
+            print(f"{self.__class__.__name__}: Lock acquired")
+            while self.keep_running and self.should_keep_running():
+                if self.hw_inputs.has_any_input():
+                    # User has pressed a button, hide the toast
+                    print(f"{self.__class__.__name__}: Exiting due to user input")
+                    break
+
+                print(time.time(), self._toggle_renderer_lock)
+
+                if self._toggle_renderer_lock:
+                    # Controller has notified us that another process needs the lock
+                    print(f"{self.__class__.__name__}: Releasing lock")
+                    self._toggle_renderer_lock = False
+                    self.renderer.lock.release()
+
+                    # pause to avoid race conditions reacquiring the lock
+                    while not self.renderer.lock.locked():
+                        # Wait for a different process to grab the lock
+                        time.sleep(0.1)
+
+                    # Block while waiting to reaquire the lock
+                    print(f"{self.__class__.__name__}: Blocking to re-acquire lock")
+                    self.renderer.lock.acquire()
+                    print(f"{self.__class__.__name__}: Lock re-acquired")
+
+                if not has_rendered:
+                    self.previous_screen_state = self.renderer.canvas.copy()
+                    print(f"{self.__class__.__name__}: Showing toast")
+                    self.toast.render()
+                    has_rendered = True
+                
+                if time.time() - start > self.activation_delay + self.duration and has_rendered:
+                    print(f"{self.__class__.__name__}: Hiding toast")
+                    break
+
+                # Free up cpu resources for main thread
+                time.sleep(0.1)
+
+        finally:
+            print(f"{self.__class__.__name__}: exiting")
+            if has_rendered and self.renderer.lock.locked():
+                # As far as we know, we currently hold the Renderer.lock
+                self.renderer.show_image(self.previous_screen_state)
+            
+            # We're done, release the lock
+            self.renderer.lock.release()
+
+
+
+class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
+    def __init__(self):
+        super().__init__(
+            activation_delay=3,  # seconds
+            duration=1e6,        # seconds ("forever")
+        )
+
+
+    def instantiate_toast(self) -> ToastOverlay:
+        return ToastOverlay(
+            icon_name=FontAwesomeIconConstants.SDCARD,
+            label_text="Security tip:\nRemove SD card",
+            font_size=GUIConstants.BODY_FONT_SIZE,
+            height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
+        )
+        
+
+    def should_keep_running(self) -> bool:
+        """ Custom exit condition: keep running until the SD card is removed """
+        from seedsigner.hardware.microsd import MicroSD
+        return MicroSD.is_inserted()
+
+
+
+class SDCardStateChangeToastManagerThread(BaseToastOverlayManagerThread):
+    def __init__(self, action: str, *args, **kwargs):
+        from seedsigner.hardware.microsd import MicroSD
+        if action not in [MicroSD.ACTION__INSERTED, MicroSD.ACTION__REMOVED]:
+            raise Exception(f"Invalid MicroSD action: {action}")
+        self.message = "SD card removed" if action == MicroSD.ACTION__REMOVED else "SD card inserted"
+
+        super().__init__(*args, **kwargs)
+
+
+    def instantiate_toast(self) -> ToastOverlay:
+        return ToastOverlay(
+            icon_name=FontAwesomeIconConstants.SDCARD,
+            label_text=self.message,
+        )
+
+

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -1,5 +1,6 @@
+import time
 from dataclasses import dataclass
-from seedsigner.gui.components import BaseComponent, GUIConstants, Icon, TextArea
+from seedsigner.gui.components import BaseComponent, FontAwesomeIconConstants, GUIConstants, Icon, TextArea
 from seedsigner.models.threads import BaseThread
 
 
@@ -132,8 +133,6 @@ class BaseToastOverlayManagerThread(BaseThread):
                     # User has pressed a button, hide the toast
                     print(f"{self.__class__.__name__}: Exiting due to user input")
                     break
-
-                print(time.time(), self._toggle_renderer_lock)
 
                 if self._toggle_renderer_lock:
                     # Controller has notified us that another process needs the lock

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import dataclass
-from seedsigner.gui.components import BaseComponent, FontAwesomeIconConstants, GUIConstants, Icon, TextArea
+from seedsigner.gui.components import BaseComponent, FontAwesomeIconConstants, GUIConstants, Icon, SeedSignerIconConstants, TextArea
 from seedsigner.models.threads import BaseThread
 
 
@@ -185,7 +185,7 @@ class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
 
     def instantiate_toast(self) -> ToastOverlay:
         return ToastOverlay(
-            icon_name=FontAwesomeIconConstants.SDCARD,
+            icon_name=SeedSignerIconConstants.SDCARD,
             label_text="Security tip:\nRemove SD card",
             font_size=GUIConstants.BODY_FONT_SIZE,
             height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
@@ -211,7 +211,7 @@ class SDCardStateChangeToastManagerThread(BaseToastOverlayManagerThread):
 
     def instantiate_toast(self) -> ToastOverlay:
         return ToastOverlay(
-            icon_name=FontAwesomeIconConstants.SDCARD,
+            icon_name=SeedSignerIconConstants.SDCARD,
             label_text=self.message,
         )
 

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import dataclass
-from seedsigner.gui.components import BaseComponent, FontAwesomeIconConstants, GUIConstants, Icon, SeedSignerIconConstants, TextArea
+from seedsigner.gui.components import BaseComponent, GUIConstants, Icon, SeedSignerIconConstants, TextArea
 from seedsigner.models.threads import BaseThread
 
 
@@ -203,6 +203,8 @@ class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
 
 class SDCardStateChangeToastManagerThread(BaseToastOverlayManagerThread):
     def __init__(self, action: str, *args, **kwargs):
+        # Note: we could just directly detect the MicroSD status here, but passing it in
+        # via `action` lets us simulate the state we want in the screenshot generator.
         from seedsigner.hardware.microsd import MicroSD
         if action not in [MicroSD.ACTION__INSERTED, MicroSD.ACTION__REMOVED]:
             raise Exception(f"Invalid MicroSD action: {action}")

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -25,7 +25,7 @@ class ToastOverlay(BaseComponent):
             icon_size=GUIConstants.ICON_TOAST_FONT_SIZE,
             icon_color=self.color
         )
-        self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2) - 1  # -1 fudge factor
+        self.icon.screen_y = self.canvas_height - self.height + self.outline_thickness + int((self.height - self.icon.height)/2)
 
         self.label = TextArea(
             image_draw=self.image_draw,
@@ -40,7 +40,7 @@ class ToastOverlay(BaseComponent):
             screen_x=self.icon.screen_x + self.icon.width + GUIConstants.COMPONENT_PADDING,
             allow_text_overflow=False
         )
-        self.label.screen_y = self.canvas_height - self.height + int((self.height - self.label.height)/2)
+        self.label.screen_y = self.canvas_height - self.height + self.outline_thickness + int((self.height - self.label.height)/2)
 
 
     def render(self):

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -119,7 +119,7 @@ class BaseToastOverlayManagerThread(BaseThread):
             print(f"{self.__class__.__name__}: started")
             start = time.time()
             has_rendered = False
-            self.previous_screen_state = None
+            previous_screen_state = None
             if self.activation_delay > 0:
                 time.sleep(self.activation_delay)
 
@@ -151,7 +151,7 @@ class BaseToastOverlayManagerThread(BaseThread):
                     print(f"{self.__class__.__name__}: Lock re-acquired")
 
                 if not has_rendered:
-                    self.previous_screen_state = self.renderer.canvas.copy()
+                    previous_screen_state = self.renderer.canvas.copy()
                     print(f"{self.__class__.__name__}: Showing toast")
                     self.toast.render()
                     has_rendered = True
@@ -167,7 +167,8 @@ class BaseToastOverlayManagerThread(BaseThread):
             print(f"{self.__class__.__name__}: exiting")
             if has_rendered and self.renderer.lock.locked():
                 # As far as we know, we currently hold the Renderer.lock
-                self.renderer.show_image(self.previous_screen_state)
+                self.renderer.show_image(previous_screen_state)
+                print(f"{self.__class__.__name__}: restored previous screen state")
             
             # We're done, release the lock
             self.renderer.lock.release()

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -25,7 +25,7 @@ class ToastOverlay(BaseComponent):
             icon_size=GUIConstants.ICON_TOAST_FONT_SIZE,
             icon_color=self.color
         )
-        self.icon.screen_y = self.canvas_height - self.height + self.outline_thickness + int((self.height - self.icon.height)/2)
+        self.icon.screen_y = self.canvas_height - self.height + int((self.height - self.icon.height)/2)
 
         self.label = TextArea(
             image_draw=self.image_draw,
@@ -40,7 +40,7 @@ class ToastOverlay(BaseComponent):
             screen_x=self.icon.screen_x + self.icon.width + GUIConstants.COMPONENT_PADDING,
             allow_text_overflow=False
         )
-        self.label.screen_y = self.canvas_height - self.height + self.outline_thickness + int((self.height - self.label.height)/2)
+        self.label.screen_y = self.canvas_height - self.height + int((self.height - self.label.height)/2)
 
 
     def render(self):
@@ -188,7 +188,7 @@ class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
     def instantiate_toast(self) -> ToastOverlay:
         return ToastOverlay(
             icon_name=SeedSignerIconConstants.MICROSD,
-            label_text="Security tip:\nRemove SD card",
+            label_text="You can remove\nthe SD card now",
             font_size=GUIConstants.BODY_FONT_SIZE,
             height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
         )

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -1,11 +1,11 @@
-import time
 import os
 
 from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
 from seedsigner.models.settings import Settings
-#from seedsigner.views.view import MicroSDToastView
 from seedsigner.gui.screens.screen import MicroSDToastScreen
+
+
 
 class MicroSD(Singleton, BaseThread):
     
@@ -29,15 +29,18 @@ class MicroSD(Singleton, BaseThread):
     
         return cls._instance
     
-    def start_detection(self):
-        self.start()
 
-    def is_inserted(self):
+    @classmethod
+    def is_inserted(cls):
         # could only be False in seedsigner-os, else True
         if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
-            return os.path.exists(self.MOUNT_POINT)
+            return os.path.exists(MicroSD.MOUNT_POINT)
         else:
             return True
+
+
+    def start_detection(self):
+        self.start()
 
 
     def run(self):
@@ -47,7 +50,7 @@ class MicroSD(Singleton, BaseThread):
         if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
 
             # at start-up, get current status and inform Settings
-            if self.is_inserted():
+            if MicroSD.is_inserted():
                 Settings.microsd_handler(self.ACTION__INSERTED)
             else:
                 Settings.microsd_handler(self.ACTION__REMOVED)

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -14,6 +14,7 @@ class MicroSD(Singleton, BaseThread):
     FIFO_MODE = 0o600
     ACTION__INSERTED = "add"
     ACTION__REMOVED = "remove"
+    warn_to_remove = True
 
     @classmethod
     def get_instance(cls):
@@ -62,6 +63,9 @@ class MicroSD(Singleton, BaseThread):
                     print(f"fifo message: {action}")
             
                     Settings.microsd_handler(action=action)
+
+                    if action == self.ACTION__INSERTED:
+                        self.warn_to_remove = True
                             
                     toastscreen = MicroSDToastScreen(action=action)
                     toastscreen.display()

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -7,49 +7,49 @@ from seedsigner.models.settings import Settings
 from seedsigner.gui.screens.screen import MicroSDToastScreen
 
 class MicroSD(Singleton, BaseThread):
-	
-	ACTION__INSERTED = "add"
-	ACTION__REMOVED = "remove"
+    
+    ACTION__INSERTED = "add"
+    ACTION__REMOVED = "remove"
 
-	settings_handler = None
-	
-	@classmethod
-	def get_instance(cls):
-		# This is the only way to access the one and only instance
-		if cls._instance is None:
-			# Instantiate the one and only instance
-			microsd = cls.__new__(cls)
-			cls._instance = microsd
-			
-			# explicitly call BaseThread __init__ since multiple class inheritance
-			BaseThread.__init__(microsd)
-	
-		return cls._instance
-	
-	def start_detection(self):
-		self.start()
-	
-	def run(self):
-		import os
-		
-		FIFO_PATH = "/tmp/mdev_fifo"
-		FIFO_MODE = 0o600
-		action = ""
-		
-		# explicitly only microsd add/remove detection in seedsigner-os
-		if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
-			
-			if os.path.exists(FIFO_PATH):
-				os.remove(FIFO_PATH)
-			
-			os.mkfifo(FIFO_PATH, FIFO_MODE)
-			
-			while self.keep_running:
-				with open(FIFO_PATH) as fifo:
-					action = fifo.read()
-					print(f"fifo message: {action}")
-			
-					Settings.microsd_handler(action=action)
-							
-					toastscreen = MicroSDToastScreen(action=action)
-					toastscreen.display()
+    settings_handler = None
+    
+    @classmethod
+    def get_instance(cls):
+        # This is the only way to access the one and only instance
+        if cls._instance is None:
+            # Instantiate the one and only instance
+            microsd = cls.__new__(cls)
+            cls._instance = microsd
+            
+            # explicitly call BaseThread __init__ since multiple class inheritance
+            BaseThread.__init__(microsd)
+    
+        return cls._instance
+    
+    def start_detection(self):
+        self.start()
+    
+    def run(self):
+        import os
+        
+        FIFO_PATH = "/tmp/mdev_fifo"
+        FIFO_MODE = 0o600
+        action = ""
+        
+        # explicitly only microsd add/remove detection in seedsigner-os
+        if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+            
+            if os.path.exists(FIFO_PATH):
+                os.remove(FIFO_PATH)
+            
+            os.mkfifo(FIFO_PATH, FIFO_MODE)
+            
+            while self.keep_running:
+                with open(FIFO_PATH) as fifo:
+                    action = fifo.read()
+                    print(f"fifo message: {action}")
+            
+                    Settings.microsd_handler(action=action)
+                            
+                    toastscreen = MicroSDToastScreen(action=action)
+                    toastscreen.display()

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -101,6 +101,8 @@ class SettingsConstants:
         if network == SettingsConstants.REGTEST:
             return "regtest"
     
+    PERSISTENT_SETTINGS__SD_INSERTED__HELP_TEXT = "Store Settings on SD card"
+    PERSISTENT_SETTINGS__SD_REMOVED__HELP_TEXT = "Insert SD card to enable"
 
     SINGLE_SIG = "ss"
     MULTISIG = "ms"
@@ -354,7 +356,7 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__PERSISTENT_SETTINGS,
                       abbreviated_name="persistent",
                       display_name="Persistent settings",
-                      help_text="Store Settings on SD card.",
+                      help_text=SettingsConstants.PERSISTENT_SETTINGS__SD_INSERTED__HELP_TEXT,
                       default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__WALLET,

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -89,7 +89,6 @@ class OpeningSplashScreen(LogoScreen):
 
 
 
-
 class ScreensaverScreen(LogoScreen):
     def __init__(self, buttons):
         super().__init__()

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -140,9 +140,9 @@ class ScreensaverScreen(LogoScreen):
         # never gives up the lock until it returns.
         with self.renderer.lock:
             try:
-                while True:
+                while self._is_running:
                     if self.buttons.has_any_input() or self.buttons.override_ind:
-                        return self.stop()
+                        break
 
                     # Must crop the image to the exact display size
                     crop = self.image.crop((
@@ -175,20 +175,23 @@ class ScreensaverScreen(LogoScreen):
                         self.increment_y = self.rand_increment()
                         if self.increment_y > 0.0:
                             self.increment_y *= -1.0
+
             except KeyboardInterrupt as e:
                 # Exit triggered; close gracefully
                 print("Shutting down Screensaver")
-                self.stop()
 
                 # Have to let the interrupt bubble up to exit the main app
                 raise e
 
+            finally:
+                self._is_running = False
+
+                # Restore the original screen
+                self.renderer.show_image(self.last_screen)
+
 
 
     def stop(self):
-        # Restore the original screen
-        self.renderer.show_image(self.last_screen)
-
         self._is_running = False
 
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -185,45 +185,33 @@ class MainMenuView(View):
     TOOLS = ("Tools", SeedSignerIconConstants.TOOLS)
     SETTINGS = ("Settings", SeedSignerIconConstants.SETTINGS)
 
-    # returns a Destination for: RemoveMicroSDWarningView or next_view
-    def microsd_warning_or_next_view(self, next_view):
-        if (self.settings.HOSTNAME == Settings.SEEDSIGNER_OS
-        and self.controller.microsd.warn_to_remove
-        and len(self.controller.storage.seeds) == 0
-        and self.controller.microsd.is_inserted()):
-            self.controller.microsd.warn_to_remove = False
-            return Destination(RemoveMicroSDWarningView, view_args={'next_view': next_view})
-        else:
-            return Destination(next_view)
 
     def run(self):
+        from seedsigner.gui.screens.screen import MainMenuScreen
         button_data = [self.SCAN, self.SEEDS, self.TOOLS, self.SETTINGS]
         selected_menu_num = self.run_screen(
-            LargeButtonScreen,
+            MainMenuScreen,
             title="Home",
-            title_font_size=26,
             button_data=button_data,
-            show_back_button=False,
-            show_power_button=True,
         )
 
         if selected_menu_num == RET_CODE__POWER_BUTTON:
             return Destination(PowerOptionsView)
 
         if button_data[selected_menu_num] == self.SCAN:
-            from .scan_views import ScanView
-            return self.microsd_warning_or_next_view(ScanView)
+            from seedsigner.views.scan_views import ScanView
+            return Destination(ScanView)
         
         elif button_data[selected_menu_num] == self.SEEDS:
-            from .seed_views import SeedsMenuView
-            return self.microsd_warning_or_next_view(SeedsMenuView)
+            from seedsigner.views.seed_views import SeedsMenuView
+            return Destination(SeedsMenuView)
 
         elif button_data[selected_menu_num] == self.TOOLS:
-            from .tools_views import ToolsMenuView
-            return self.microsd_warning_or_next_view(ToolsMenuView)
+            from seedsigner.views.tools_views import ToolsMenuView
+            return Destination(ToolsMenuView)
 
         elif button_data[selected_menu_num] == self.SETTINGS:
-            from .settings_views import SettingsMenuView
+            from seedsigner.views.settings_views import SettingsMenuView
             return Destination(SettingsMenuView)
 
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -185,12 +185,12 @@ class MainMenuView(View):
     TOOLS = ("Tools", SeedSignerIconConstants.TOOLS)
     SETTINGS = ("Settings", SeedSignerIconConstants.SETTINGS)
 
-    # returns a Destination for: RemoveMicroSDWarning or next_view
+    # returns a Destination for: RemoveMicroSDWarningView or next_view
     def microsd_warning_or_next_view(self, next_view):
         if (self.settings.HOSTNAME == Settings.SEEDSIGNER_OS
-        and self.controller.microsd.is_inserted()
         and self.controller.microsd.warn_to_remove
-        and len(self.controller.storage.seeds) == 0):
+        and len(self.controller.storage.seeds) == 0
+        and self.controller.microsd.is_inserted()):
             self.controller.microsd.warn_to_remove = False
             return Destination(RemoveMicroSDWarningView, view_args={'next_view': next_view})
         else:
@@ -406,11 +406,10 @@ class RemoveMicroSDWarningView(View):
     def run(self):
         self.run_screen(
             WarningScreen,
-            title="Best-Practice Tip",
+            title="Security Tip",
             status_icon_name=FontAwesomeIconConstants.SDCARD,
-            status_headline="Microsd is inserted!",
-            status_color="red",
-            text="For maximum security\nremove the MicroSD card\nbefore continuing.",
+            status_headline="",
+            text="For maximum security,\nremove the MicroSD card\nbefore continuing.",
             show_back_button=False,
             button_data=["Continue"],
         )

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -381,5 +381,21 @@ class OptionDisabledView(View):
             show_back_button=False,
             allow_text_overflow=True,  # Fit what we can, let the rest go off the edges
         ).display()
-        
+
+
+
+class RemoveMicroSDWarningView(View):
+    """
+        Warning to remove the microsd
+    """
+    def run(self):
+        self.run_screen(
+            WarningScreen,
+            title="Warning!",
+            status_headline="MicroSD is Inserted.",
+            text="It is strongly advised\nto remove it before\nloading any seeds.",
+            show_back_button=False,
+            button_data=["Continue"],
+        )
+
         return Destination(MainMenuView, clear_history=True)

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -185,6 +185,17 @@ class MainMenuView(View):
     TOOLS = ("Tools", SeedSignerIconConstants.TOOLS)
     SETTINGS = ("Settings", SeedSignerIconConstants.SETTINGS)
 
+    # returns a Destination for: RemoveMicroSDWarning or next_view
+    def microsd_warning_or_next_view(self, next_view):
+        if (self.settings.HOSTNAME == Settings.SEEDSIGNER_OS
+        and self.controller.microsd.is_inserted()
+        and self.controller.microsd.warn_to_remove
+        and len(self.controller.storage.seeds) == 0):
+            self.controller.microsd.warn_to_remove = False
+            return Destination(RemoveMicroSDWarningView, view_args={'next_view': next_view})
+        else:
+            return Destination(next_view)
+
     def run(self):
         button_data = [self.SCAN, self.SEEDS, self.TOOLS, self.SETTINGS]
         selected_menu_num = self.run_screen(
@@ -201,15 +212,15 @@ class MainMenuView(View):
 
         if button_data[selected_menu_num] == self.SCAN:
             from .scan_views import ScanView
-            return Destination(ScanView)
+            return self.microsd_warning_or_next_view(ScanView)
         
         elif button_data[selected_menu_num] == self.SEEDS:
             from .seed_views import SeedsMenuView
-            return Destination(SeedsMenuView)
+            return self.microsd_warning_or_next_view(SeedsMenuView)
 
         elif button_data[selected_menu_num] == self.TOOLS:
             from .tools_views import ToolsMenuView
-            return Destination(ToolsMenuView)
+            return self.microsd_warning_or_next_view(ToolsMenuView)
 
         elif button_data[selected_menu_num] == self.SETTINGS:
             from .settings_views import SettingsMenuView
@@ -388,14 +399,20 @@ class RemoveMicroSDWarningView(View):
     """
         Warning to remove the microsd
     """
+    def __init__(self, next_view: View):
+        super().__init__()
+        self.next_view = next_view
+
     def run(self):
         self.run_screen(
             WarningScreen,
-            title="Warning!",
-            status_headline="MicroSD is Inserted.",
-            text="It is strongly advised\nto remove it before\nloading any seeds.",
+            title="Best-Practice Tip",
+            status_icon_name=FontAwesomeIconConstants.SDCARD,
+            status_headline="Microsd is inserted!",
+            status_color="red",
+            text="For maximum security\nremove the MicroSD card\nbefore continuing.",
             show_back_button=False,
             button_data=["Continue"],
         )
 
-        return Destination(MainMenuView, clear_history=True)
+        return Destination(self.next_view, clear_history=True)

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,6 +7,7 @@ from typing import Callable
 # These must precede any SeedSigner imports.
 sys.modules['seedsigner.gui.renderer'] = MagicMock()
 sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
+sys.modules['seedsigner.gui.toast'] = MagicMock()
 sys.modules['seedsigner.views.screensaver'] = MagicMock()
 sys.modules['seedsigner.hardware.buttons'] = MagicMock()
 sys.modules['seedsigner.hardware.camera'] = MagicMock()

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -1,20 +1,27 @@
 import embit
 import os
 import sys
-from mock import Mock, MagicMock
+import time
+from mock import Mock, patch, MagicMock
+
 
 # Prevent importing modules w/Raspi hardware dependencies.
 # These must precede any SeedSigner imports.
 sys.modules['seedsigner.hardware.ST7789'] = MagicMock()
 sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
 sys.modules['seedsigner.views.screensaver'] = MagicMock()
-sys.modules['seedsigner.hardware.buttons'] = MagicMock()
+sys.modules['RPi'] = MagicMock()
+sys.modules['RPi.GPIO'] = MagicMock()
 sys.modules['seedsigner.hardware.camera'] = MagicMock()
 sys.modules['seedsigner.hardware.microsd'] = MagicMock()
 
 
 from seedsigner.controller import Controller
 from seedsigner.gui.renderer import Renderer
+from seedsigner.gui.toast import BaseToastOverlayManagerThread, RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
+from seedsigner.hardware.buttons import HardwareButtons
+from seedsigner.hardware.camera import Camera
+from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed
@@ -99,6 +106,9 @@ def test_generate_screenshots(target_locale):
     screenshot_sections = {
         "Main Menu Views": [
             MainMenuView,
+            (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_removed', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__REMOVED)),
+            (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_inserted', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__INSERTED)),
+            (MainMenuView, {}, 'MainMenuView_RemoveSDCardToast', RemoveSDCardToastManagerThread(activation_delay=0)),
             PowerOptionsView,
             RestartView,
             PowerOffView,
@@ -231,12 +241,15 @@ def test_generate_screenshots(target_locale):
                     view_name = view_cls.__name__
                 elif len(screenshot) == 3:
                     view_cls, view_args, view_name = screenshot
+                elif len(screenshot) == 4:
+                    view_cls, view_args, view_name, toast_thread = screenshot
             else:
                 view_cls = screenshot
                 view_args = {}
                 view_name = view_cls.__name__
+                toast_thread = None
 
-            screencap_view(view_cls, view_name, view_args)
+            screencap_view(view_cls, view_name, view_args, toast_thread=toast_thread)
             readme += """  <table align="left" style="border: 1px solid gray;">"""
             readme += f"""<tr><td align="center">{view_name}<br/><br/><img src="{subdir}/{view_name}.png"></td></tr>"""
             readme += """</table>\n"""

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -5,23 +5,58 @@ from base import BaseTest, FlowTest, FlowStep
 from base import FlowTestRunScreenNotExecutedException, FlowTestInvalidButtonDataSelectionException
 
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
-from seedsigner.models.settings import SettingsConstants
+from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import Seed
-from seedsigner.views.view import MainMenuView, View, NetworkMismatchErrorView
-from seedsigner.views import seed_views, scan_views, settings_views
+from seedsigner.views.view import MainMenuView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView
+from seedsigner.views import seed_views, scan_views, settings_views, tools_views
 
 
+def load_seed_into_decoder(view: scan_views.ScanView):
+    view.decoder.add_data("0000" * 11 + "0003")
 
 class TestSeedFlows(FlowTest):
+
+    def test_flow_thru_microsd_warning(self):
+        """
+            Selecting "Scan", "Seeds" or "Tools from the MainMenuView in ss-os with microsd inserted
+            will flow to RemoveMicroSDWarningView -- conditionally, then on to the intended next view
+        """
+        Settings.HOSTNAME = Settings.SEEDSIGNER_OS
+        # will be warned to remove microsd card
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),  # backed-out
+            FlowStep(MainMenuView),
+        ])
+        # but won't be warned again, because microsd.warn_to_remove was set False just above
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, screen_return_value=RET_CODE__BACK_BUTTON), # backed-out
+            FlowStep(MainMenuView),
+        ])
+        # unless the microsd was re-inserted, which resets microsd.warn_to_remove = True.
+        self.controller.microsd.warn_to_remove = True
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # this time, loaded a seed
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView),
+        ])
+        # won't get warned again if a seed is loaded (like was done above); it's already too late
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView),
+        ])
+
 
     def test_scan_seedqr_flow(self):
         """
             Selecting "Scan" from the MainMenuView and scanning a SeedQR should enter the
             Finalize Seed flow and end at the SeedOptionsView.
         """
-        def load_seed_into_decoder(view: scan_views.ScanView):
-            view.decoder.add_data("0000" * 11 + "0003")
-
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
@@ -36,6 +71,7 @@ class TestSeedFlows(FlowTest):
             the SeedOptionsView.
         """
         def test_with_mnemonic(mnemonic):
+            Settings.HOSTNAME = "not seedsigner-os"
             sequence = [
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
                 FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # When no seeds are loaded it auto-redirects to LoadSeedView

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -46,10 +46,13 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView),
         ])
         # won't get warned again if a seed is loaded (like was done above); it's already too late
+        self.controller.microsd.warn_to_remove = True
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
             FlowStep(seed_views.SeedsMenuView),
         ])
+        # no warning shown so this flag not cleared, cleanup else following tests will warn
+        self.controller.microsd.warn_to_remove = False
 
 
     def test_scan_seedqr_flow(self):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -14,46 +14,9 @@ from seedsigner.views import seed_views, scan_views, settings_views, tools_views
 def load_seed_into_decoder(view: scan_views.ScanView):
     view.decoder.add_data("0000" * 11 + "0003")
 
+
+
 class TestSeedFlows(FlowTest):
-
-    def test_flow_thru_microsd_warning(self):
-        """
-            Selecting "Scan", "Seeds" or "Tools from the MainMenuView in ss-os with microsd inserted
-            will flow to RemoveMicroSDWarningView -- conditionally, then on to the intended next view
-        """
-        Settings.HOSTNAME = Settings.SEEDSIGNER_OS
-        # will be warned to remove microsd card
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
-            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
-            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),  # backed-out
-            FlowStep(MainMenuView),
-        ])
-        # but won't be warned again, because microsd.warn_to_remove was set False just above
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
-            FlowStep(seed_views.LoadSeedView, screen_return_value=RET_CODE__BACK_BUTTON), # backed-out
-            FlowStep(MainMenuView),
-        ])
-        # unless the microsd was re-inserted, which resets microsd.warn_to_remove = True.
-        self.controller.microsd.warn_to_remove = True
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
-            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
-            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # this time, loaded a seed
-            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
-            FlowStep(seed_views.SeedOptionsView),
-        ])
-        # won't get warned again if a seed is loaded (like was done above); it's already too late
-        self.controller.microsd.warn_to_remove = True
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-            FlowStep(seed_views.SeedsMenuView),
-        ])
-        # no warning shown so this flag not cleared, cleanup else following tests will warn
-        self.controller.microsd.warn_to_remove = False
-
 
     def test_scan_seedqr_flow(self):
         """

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -6,7 +6,7 @@ from base import FlowTest, FlowStep
 from seedsigner.gui.screens.screen import RET_CODE__POWER_BUTTON
 from seedsigner.models.settings import Settings
 from seedsigner.views.tools_views import ToolsCalcFinalWordNumWordsView, ToolsMenuView
-from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View
+from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View, RemoveMicroSDWarningView
 
 
 
@@ -38,6 +38,7 @@ class TestViewFlows(FlowTest):
         # And again, but this time as if we were in the SeedSigner OS
         Settings.HOSTNAME = Settings.SEEDSIGNER_OS
         self.run_sequence([
+            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
             FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
             FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
             FlowStep(PowerOffView),  # returns BackStackView
@@ -65,6 +66,7 @@ class TestViewFlows(FlowTest):
         """
         Basic flow from any arbitrary View to the UnhandledExceptionView
         """
+        Settings.HOSTNAME = "NOT seedsigner-os"
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
             FlowStep(ToolsMenuView, button_data_selection=ToolsMenuView.KEYBOARD),

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -38,7 +38,6 @@ class TestViewFlows(FlowTest):
         # And again, but this time as if we were in the SeedSigner OS
         Settings.HOSTNAME = Settings.SEEDSIGNER_OS
         self.run_sequence([
-            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
             FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
             FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
             FlowStep(PowerOffView),  # returns BackStackView

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -6,7 +6,7 @@ from base import FlowTest, FlowStep
 from seedsigner.gui.screens.screen import RET_CODE__POWER_BUTTON
 from seedsigner.models.settings import Settings
 from seedsigner.views.tools_views import ToolsCalcFinalWordNumWordsView, ToolsMenuView
-from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View, RemoveMicroSDWarningView
+from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View
 
 
 


### PR DESCRIPTION
Alternative to #410 but builds upon behind-the-scenes updates from that branch. Would close #344 upon merge.

Display a toast notification popup on the Main Menu if the SD card is still inserted.

As has been thoroughly, arduously(!) discussed, my preferred presentation for this notification is to simply let the user know that they *can* remove the SD card, but omit any mention of security or warnings.

The precursor PR, #410 has evolved into an optional Must Remove hard stop which can work in conjunction with this notification:
* Default: no hard stop; user sees inobtrusive toast notification (this PR)
* Option enabled: User faces hard stop until card is removed; the unobtrusive toast notification probably doesn't need to be displayed (either by SD card state or explicit additional logic.

---

* waits 3s before displaying (if SD card is inserted).
* persists "forever" (1mil secs) while user remains on the Main Menu.
* dismissed with any user input (otherwise navigating to the bottom row would be slightly crappy).
* does not reappear after being dismissed while you're on that screen.
* does reappear on each subsequent visit to Main Menu (if SD card is inserted).
* Toast UI intentionally violates the normal 8px edge padding (see screenshot; toast edges are wider than the Main Menu button options).

![MainMenuView_RemoveSDCardToast](https://github.com/SeedSigner/seedsigner/assets/934746/6516f917-f525-44d9-aa96-fd11de8f4adc)

---

* Refactors the entire Toast system to move all timing and control logic out of the rendering components and into `BaseToastOverlayManagerThread` implementations.
* Adds `Controller.activate_toast()` to act as a central coordinator to manage the `Renderer.lock` between competing toasts, the screensaver, and the currently rendered/rendering Screen.
* Adds support for the screenshot generator to create screenshots that include toast overlays.
* Adds screenshots