### PR TITLE
Fixes `button_data` bug in psbt_views.py

### DIFF
--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -46,7 +46,7 @@ class TestPSBTFlows(FlowTest):
 			FlowStep(seed_views.SeedOptionsView, is_redirect=True),
 			FlowStep(psbt_views.PSBTOverviewView),
 			FlowStep(psbt_views.PSBTMathView),
-			FlowStep(psbt_views.PSBTAddressDetailsView, button_data_selection=psbt_views.PSBTAddressDetailsView.NEXT),
+			FlowStep(psbt_views.PSBTAddressDetailsView, button_data_selection=0),
 			FlowStep(psbt_views.PSBTChangeDetailsView, button_data_selection=psbt_views.PSBTChangeDetailsView.NEXT),
 			FlowStep(psbt_views.PSBTChangeDetailsView, button_data_selection=psbt_views.PSBTChangeDetailsView.NEXT),
 			FlowStep(psbt_views.PSBTChangeDetailsView, button_data_selection=psbt_views.PSBTChangeDetailsView.NEXT),


### PR DESCRIPTION
A previous merge implemented `PSBTSelectSeedView.button_data` as a class member var which causes a bug where each subsequent visit to that View appends additional `button_data` entries to the list, rather than re-creating it each time.

This PR fixes that bug and ensures that `button_data` is only defined within the scope of `run()`.

tldr: Potential trouble if you see any `self.button_data` references in a View (but it's expected in a Screen).

Misc notes:
* Removed other instances of `button_data` being defined as a class member, even though it doesn't cause any bugs in those other cases.
* `NEXT` removed from `PSBTAddressDetailsView` as it's a dynamic value and there are no other menu items to differentiate from in the logic anyway (minor edit to the flow test to account for this change).