### PR TITLE
fix: avoid execption by calling parent class's constructor #434

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1113,6 +1113,7 @@ class SeedBIP85InvalidChildIndexView(View):
 ****************************************************************************"""
 class SeedWordsBackupTestPromptView(View):
     def __init__(self, seed_num: int, bip85_data: dict = None):
+        super().__init__()
         self.seed_num = seed_num
         self.bip85_data = bip85_data
 
@@ -1257,6 +1258,7 @@ class SeedWordsBackupTestMistakeView(View):
 
 class SeedWordsBackupTestSuccessView(View):
     def __init__(self, seed_num: int):
+        super().__init__()
         self.seed_num = seed_num
 
     def run(self):


### PR DESCRIPTION
Please verify this change will not have any unintended consequences.

My proposed change seems safe, but I can't be sure that this wasn't omitted intentionally and calling the parent's constructor won't have some unintended consequences.

Closes https://github.com/SeedSigner/seedsigner/issues/434