### PR TITLE
Yet Another MicroSD Card Removal PR

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -275,6 +275,7 @@ class Controller(Singleton):
                 next_destination = initial_destination
             else:
                 next_destination = Destination(MainMenuView)
+
             while True:
                 # Destination(None) is a special case; render the Home screen
                 if next_destination.View_cls is None:

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -1,55 +1,66 @@
 import time
+import os
 
 from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
 from seedsigner.models.settings import Settings
-#from seedsigner.views.view import MicroSDToastView
-from seedsigner.gui.screens.screen import MicroSDToastScreen
 
 class MicroSD(Singleton, BaseThread):
-	
-	ACTION__INSERTED = "add"
-	ACTION__REMOVED = "remove"
+    
+    MOUNT_POINT = "/mnt/microsd"
+    FIFO_PATH = "/tmp/mdev_fifo"
+    FIFO_MODE = 0o600
+    ACTION__INSERTED = "add"
+    ACTION__REMOVED = "remove"
+    warn_to_remove = True
 
-	settings_handler = None
-	
-	@classmethod
-	def get_instance(cls):
-		# This is the only way to access the one and only instance
-		if cls._instance is None:
-			# Instantiate the one and only instance
-			microsd = cls.__new__(cls)
-			cls._instance = microsd
-			
-			# explicitly call BaseThread __init__ since multiple class inheritance
-			BaseThread.__init__(microsd)
-	
-		return cls._instance
-	
-	def start_detection(self):
-		self.start()
-	
-	def run(self):
-		import os
-		
-		FIFO_PATH = "/tmp/mdev_fifo"
-		FIFO_MODE = 0o600
-		action = ""
-		
-		# explicitly only microsd add/remove detection in seedsigner-os
-		if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
-			
-			if os.path.exists(FIFO_PATH):
-				os.remove(FIFO_PATH)
-			
-			os.mkfifo(FIFO_PATH, FIFO_MODE)
-			
-			while self.keep_running:
-				with open(FIFO_PATH) as fifo:
-					action = fifo.read()
-					print(f"fifo message: {action}")
-			
-					Settings.microsd_handler(action=action)
-							
-					toastscreen = MicroSDToastScreen(action=action)
-					toastscreen.display()
+    @classmethod
+    def get_instance(cls):
+        # This is the only way to access the one and only instance
+        if cls._instance is None:
+            # Instantiate the one and only instance
+            microsd = cls.__new__(cls)
+            cls._instance = microsd
+            
+            # explicitly call BaseThread __init__ since multiple class inheritance
+            BaseThread.__init__(microsd)
+    
+        return cls._instance
+    
+    def start_detection(self):
+        self.start()
+
+    def is_inserted(self):
+        # could only be False in seedsigner-os, else True
+        if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+            return os.path.exists(self.MOUNT_POINT)
+        else:
+            return True
+
+
+    def run(self):
+        action = ""
+        
+        # explicitly only microsd add/remove detection in seedsigner-os
+        if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+
+            # at start-up, get current status and inform Settings
+            if self.is_inserted():
+                Settings.microsd_handler(self.ACTION__INSERTED)
+            else:
+                Settings.microsd_handler(self.ACTION__REMOVED)
+
+            if os.path.exists(self.FIFO_PATH):
+                os.remove(self.FIFO_PATH)
+            
+            os.mkfifo(self.FIFO_PATH, self.FIFO_MODE)
+
+            while self.keep_running:
+                with open(self.FIFO_PATH) as fifo:
+                    action = fifo.read()
+                    print(f"fifo message: {action}")
+            
+                    Settings.microsd_handler(action=action)
+
+                    if action == self.ACTION__INSERTED:
+                        self.warn_to_remove = True

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -155,6 +155,7 @@ class SettingsConstants:
     SETTING__SCRIPT_TYPES = "script_types"
     SETTING__XPUB_DETAILS = "xpub_details"
     SETTING__PASSPHRASE = "passphrase"
+    SETTING__STORAGE_REMOVAL = "storage_removal"
     SETTING__CAMERA_ROTATION = "camera_rotation"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
@@ -433,6 +434,14 @@ class SettingsDefinition:
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.OPTIONS__ENABLED_DISABLED_REQUIRED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+                      
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__STORAGE_REMOVAL,
+                      display_name="SD card removal",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.OPTIONS__PROMPT_REQUIRED_DISABLED,
+                      default_value=SettingsConstants.OPTION__PROMPT),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__CAMERA_ROTATION,
@@ -562,7 +571,7 @@ if __name__ == "__main__":
 
     hostname = os.uname()[1]
   
-    if hostname == "seedsigner-os":
+    if hostname == "seedsigner":
         output_file = "/mnt/microsd/settings_definition.json"
     else:
         output_file = "settings_definition.json"

--- a/src/seedsigner/models/threads.py
+++ b/src/seedsigner/models/threads.py
@@ -44,3 +44,21 @@ class ThreadsafeCounter:
             self.count = value
 
 
+
+     
+class ThreadsafeBool:
+    def __init__(self, initial_value: bool = False):
+        self.val = initial_value
+        self._lock = Lock()
+    
+    @property
+    def value(self):
+        # Reads don't require the lock
+        return self.val
+        
+    def set_value(self, value: bool):
+        with self._lock:
+            self.val = value
+    
+
+

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -190,14 +190,21 @@ class MainMenuView(View):
         
         user_preference = self.settings.get_value(SettingsConstants.SETTING__STORAGE_REMOVAL)
         
+        '''
+            Skip MicroSD Removal Warning screen if disabled in settings.
+            If Prompt is selected in setting for MicroSD removal then only warn once per session
+            If Required is selected force a hard stop to remove MicroSD even if the warning has been seen before
+            or if there is already private key material in RAM.
+        '''
         if user_preference == SettingsConstants.OPTION__DISABLED:
             return Destination(next_view)
         
         elif (user_preference in (SettingsConstants.OPTION__PROMPT, SettingsConstants.OPTION__REQUIRED)
         and self.settings.HOSTNAME == Settings.SEEDSIGNER_OS
-        and (( self.controller.microsd.warn_to_remove and user_preference == SettingsConstants.OPTION__PROMPT )
+        and (( self.controller.microsd.warn_to_remove 
+               and user_preference == SettingsConstants.OPTION__PROMPT
+               and len(self.controller.storage.seeds) == 0)
             or (user_preference == SettingsConstants.OPTION__REQUIRED))
-        and len(self.controller.storage.seeds) == 0
         and self.controller.microsd.is_inserted()):
         
             if user_preference == SettingsConstants.OPTION__PROMPT:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -8,7 +8,7 @@ from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.views.seed_views import SeedBackupView, SeedMnemonicEntryView, SeedOptionsView, SeedWordsWarningView
-from seedsigner.views.view import MainMenuView, PowerOptionsView, UnhandledExceptionView
+from seedsigner.views.view import MainMenuView, PowerOptionsView, UnhandledExceptionView, RemoveMicroSDWarningView
 from seedsigner.views.tools_views import ToolsMenuView, ToolsCalcFinalWordNumWordsView
 
 
@@ -22,6 +22,7 @@ class TestFlowTest(FlowTest):
         """
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(RemoveMicroSDWarningView, button_data_selection=RemoveMicroSDWarningView.I_UNDERSTAND),
             FlowStep(ToolsMenuView, button_data_selection=ToolsMenuView.KEYBOARD),
             FlowStep(ToolsCalcFinalWordNumWordsView, button_data_selection=ToolsCalcFinalWordNumWordsView.TWELVE),
             FlowStep(SeedMnemonicEntryView),

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -4,24 +4,64 @@ import pytest
 from base import BaseTest, FlowTest, FlowStep
 from base import FlowTestRunScreenNotExecutedException, FlowTestInvalidButtonDataSelectionException
 
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
-from seedsigner.models.settings import SettingsConstants
+import pytest
+from seedsigner.models.settings import SettingsConstants, Settings
 from seedsigner.models.seed import Seed
-from seedsigner.views.view import MainMenuView, View, NetworkMismatchErrorView
-from seedsigner.views import seed_views, scan_views, settings_views
+from seedsigner.views.view import MainMenuView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView
+from seedsigner.views import seed_views, scan_views, tools_views, settings_views
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 
 
+def load_seed_into_decoder(view: scan_views.ScanView):
+    view.decoder.add_data("0000" * 11 + "0003")
 
 class TestSeedFlows(FlowTest):
+
+    def test_flow_thru_microsd_warning(self):
+        """
+            Selecting "Scan", "Seeds" or "Tools from the MainMenuView in ss-os with microsd inserted
+            will flow to RemoveMicroSDWarningView -- conditionally, then on to the intended next view
+        """
+        Settings.HOSTNAME = Settings.SEEDSIGNER_OS
+        # will be warned to remove microsd card
+        self.controller.get_instance().microsd.warn_to_remove = True
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(RemoveMicroSDWarningView, screen_return_value=RemoveMicroSDWarningView.I_UNDERSTAND),
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),  # backed-out
+            FlowStep(MainMenuView),
+        ])
+        # but won't be warned again, because microsd.warn_to_remove was set False just above
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, screen_return_value=RET_CODE__BACK_BUTTON), # backed-out
+            FlowStep(MainMenuView),
+        ])
+        # unless the microsd was re-inserted, which resets microsd.warn_to_remove = True.
+        self.controller.microsd.warn_to_remove = True
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # this time, loaded a seed
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView),
+        ])
+        # won't get warned again if a seed is loaded (like was done above); it's already too late
+        self.controller.microsd.warn_to_remove = True
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView),
+        ])
+        # no warning shown so this flag not cleared, cleanup else following tests will warn
+        self.controller.microsd.warn_to_remove = False
+
 
     def test_scan_seedqr_flow(self):
         """
             Selecting "Scan" from the MainMenuView and scanning a SeedQR should enter the
             Finalize Seed flow and end at the SeedOptionsView.
         """
-        def load_seed_into_decoder(view: scan_views.ScanView):
-            view.decoder.add_data("0000" * 11 + "0003")
-
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
@@ -36,6 +76,7 @@ class TestSeedFlows(FlowTest):
             the SeedOptionsView.
         """
         def test_with_mnemonic(mnemonic):
+            Settings.HOSTNAME = "not seedsigner-os"
             sequence = [
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
                 FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # When no seeds are loaded it auto-redirects to LoadSeedView

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -6,7 +6,7 @@ from base import FlowTest, FlowStep
 from seedsigner.gui.screens.screen import RET_CODE__POWER_BUTTON
 from seedsigner.models.settings import Settings
 from seedsigner.views.tools_views import ToolsCalcFinalWordNumWordsView, ToolsMenuView
-from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View
+from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View, RemoveMicroSDWarningView
 
 
 
@@ -65,6 +65,7 @@ class TestViewFlows(FlowTest):
         """
         Basic flow from any arbitrary View to the UnhandledExceptionView
         """
+        Settings.HOSTNAME = "NOT seedsigner-os"
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
             FlowStep(ToolsMenuView, button_data_selection=ToolsMenuView.KEYBOARD),


### PR DESCRIPTION
This PR builds on #410. I don't anticipate to actually merge this PR. I expect to just close it. I went ahead and created it anyway since I felt this was the best way share my preferred flow related to microSD removal notifications. Lots of credit to @jpph for the work in PR #410.

My main criticism of PR #424 is that is prioritizes zero clicks / interuptions to a fault. I actually find the toast overlay more interruptive and unexpected. The user performs no action and then suddenly a message appears. This can happen on a non MainMenuView if the user gets a fast start after boot. They can be selecting menu items and suddenly a message appears. I actually find this more jarring/interruptive then a more "native" view the user is accustom to in general navigation.

Primary Differences:
- Removing the MicroSD dismisses the warning screen (for both prompt and required)
- Changing the MicroSD removal settings to "Required" is a hard stop even if the warning was previously dismissed
- The Required MicroSD removal setting is a hard stop even if there is a seed phrase (private key material) on device. This can happen if someone changes the setting after entering/generating a seed phrase.
- I remove from the code of the toast overlay insert/remove notifications for microsd completely. I don't see the benefit of having them if the default is to inform the user the microsd can be removed.