### PR TITLE
Message signing network mismatch bugfix; `OptionDisabledView` bugfix

### DIFF
--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -136,19 +136,16 @@ class ScanView(View):
                 )
             
             elif self.decoder.is_sign_message:
-                if self.settings.get_value(SettingsConstants.SETTING__MESSAGE_SIGNING) == SettingsConstants.OPTION__ENABLED:
-                    from seedsigner.views.seed_views import SeedSignMessageStartView
-                    qr_data = self.decoder.get_qr_data()
+                from seedsigner.views.seed_views import SeedSignMessageStartView
+                qr_data = self.decoder.get_qr_data()
 
-                    return Destination(
-                        SeedSignMessageStartView,
-                        view_args=dict(
-                            derivation_path=qr_data["derivation_path"],
-                            message=qr_data["message"],
-                        )
+                return Destination(
+                    SeedSignMessageStartView,
+                    view_args=dict(
+                        derivation_path=qr_data["derivation_path"],
+                        message=qr_data["message"],
                     )
-                else:
-                    return Destination(OptionDisabledView, view_args=dict(error_msg="Message signing is currently disabled in Settings"))
+                )
             
             else:
                 return Destination(NotYetImplementedView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -23,7 +23,7 @@ from seedsigner.models.seed import InvalidSeedException, Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
-from seedsigner.views.view import NotYetImplementedView, View, Destination, BackStackView, MainMenuView
+from seedsigner.views.view import NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView
 
 
 
@@ -1920,6 +1920,10 @@ class SeedSignMessageStartView(View):
         super().__init__()
         self.derivation_path = derivation_path
         self.message = message
+
+        if self.settings.get_value(SettingsConstants.SETTING__MESSAGE_SIGNING) == SettingsConstants.OPTION__DISABLED:
+            self.set_redirect(Destination(OptionDisabledView, view_args=dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)))
+            return
 
         # calculate the actual receive address
         addr_format = embit_utils.parse_derivation_path(derivation_path)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1991,7 +1991,7 @@ class SeedSignMessageConfirmAddressView(View):
         if not addr_format["clean_match"]:
             raise Exception("Signing messages for custom derivation paths not supported")
 
-        # addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
+        # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
         if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in addr_format["network"]:
             # Does nothing for MAINNET, but uses current setting to decide between TESTNET and REGTEST
             addr_format["network"] = self.settings.get_value(SettingsConstants.SETTING__NETWORK)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1992,11 +1992,7 @@ class SeedSignMessageConfirmAddressView(View):
             raise Exception("Signing messages for custom derivation paths not supported")
 
         # addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
-        message_network = addr_format["network"]
-        if type(message_network) == str:
-            message_network = [message_network]
-
-        if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in message_network:
+        if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in addr_format["network"]:
             # Does nothing for MAINNET, but uses current setting to decide between TESTNET and REGTEST
             addr_format["network"] = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         else:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1921,23 +1921,37 @@ class SeedSignMessageStartView(View):
         self.derivation_path = derivation_path
         self.message = message
 
+        # calculate the actual receive address
+        addr_format = embit_utils.parse_derivation_path(derivation_path)
+        if not addr_format["clean_match"]:
+            raise NotYetImplementedView("Signing messages for custom derivation paths not supported")
+
+        # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
+        if self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:
+            from seedsigner.views.view import NetworkMismatchErrorView
+            self.set_redirect(Destination(NetworkMismatchErrorView, view_args=dict(text=f"Current network setting ({self.settings.get_value_display_name(SettingsConstants.SETTING__NETWORK)}) doesn't match {self.derivation_path}")))
+
+            # cleanup. Note: We could leave this in place so the user can resume the
+            # flow, but for now we avoid complications and keep things simple.
+            self.controller.resume_main_flow = None
+            return
+
         data = self.controller.sign_message_data
         if not data:
             data = {}
             self.controller.sign_message_data = data
         data["derivation_path"] = derivation_path
         data["message"] = message
+        data["addr_format"] = addr_format
 
         # May be None
         self.seed_num = data.get("seed_num")
     
-
-    def run(self):
         if self.seed_num is not None:
             # We already know which seed we're signing with
-            return Destination(SeedSignMessageConfirmMessageView, skip_current_view=True)
+            self.set_redirect(Destination(SeedSignMessageConfirmMessageView, skip_current_view=True))
         else:
-            return Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__SIGN_MESSAGE), skip_current_view=True)
+            self.set_redirect(Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__SIGN_MESSAGE), skip_current_view=True))
 
 
 
@@ -1979,34 +1993,14 @@ class SeedSignMessageConfirmAddressView(View):
     def __init__(self):
         super().__init__()
         data = self.controller.sign_message_data
-        self.seed_num = data.get("seed_num")
+        seed = self.controller.storage.seeds[data.get("seed_num")]
         self.derivation_path = data.get("derivation_path")
+        addr_format = data.get("addr_format")
 
-        if self.seed_num is None or not self.derivation_path:
-            raise Exception("Routing error: sign_message_data hasn't been set")
-
-        # calculate the actual receive address
-        seed = self.controller.storage.seeds[self.seed_num]
-        addr_format = embit_utils.parse_derivation_path(self.derivation_path)
-        if not addr_format["clean_match"]:
-            raise Exception("Signing messages for custom derivation paths not supported")
-
-        # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
-        if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in addr_format["network"]:
-            # Does nothing for MAINNET, but uses current setting to decide between TESTNET and REGTEST
-            addr_format["network"] = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
-        else:
-            from seedsigner.views.view import NetworkMismatchErrorView
-            self.set_redirect(Destination(NetworkMismatchErrorView, view_args=dict(text=f"Current network setting ({self.settings.get_value_display_name(SettingsConstants.SETTING__NETWORK)}) doesn't match {self.derivation_path}")))
-
-            # cleanup. Note: We could leave this in place so the user can resume the
-            # flow, but for now we avoid complications and keep things simple.
-            self.controller.resume_main_flow = None
-            self.controller.sign_message_data = None
-            return
-
-        xpub = seed.get_xpub(wallet_path=self.derivation_path, network=addr_format["network"])
-        embit_network = embit_utils.get_embit_network_name(addr_format["network"])
+        # Current settings will differentiate TESTNET and REGTEST (since derivation path
+        # alone doesn't specify which one we're using).
+        xpub = seed.get_xpub(wallet_path=self.derivation_path, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+        embit_network = embit_utils.get_embit_network_name(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
         self.address = embit_utils.get_single_sig_address(xpub=xpub, script_type=addr_format["script_type"], index=addr_format["index"], is_change=addr_format["is_change"], embit_network=embit_network)
 
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -426,12 +426,6 @@ class TestMessageSigningFlows(FlowTest):
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
                 FlowStep(scan_views.ScanView, before_run=load_message),  # simulate read message QR; ret val is ignored
                 FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
-                FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
-                FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
-                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
-                FlowStep(seed_views.SeedOptionsView, is_redirect=True),
-                FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
-                FlowStep(seed_views.SeedSignMessageConfirmAddressView, is_redirect=True),
                 FlowStep(NetworkMismatchErrorView),
                 FlowStep(settings_views.SettingsEntryUpdateSelectionView),
             ])

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -421,7 +421,7 @@ class TestMessageSigningFlows(FlowTest):
         # Ensure message signing is enabled
         self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
 
-        def expect_network_mismatch_error(load_message: Callable[[str], None]):
+        def expect_network_mismatch_error(load_message: Callable):
             self.run_sequence([
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
                 FlowStep(scan_views.ScanView, before_run=load_message),  # simulate read message QR; ret val is ignored


### PR DESCRIPTION
Message signing was already checking for "Network Mismatch" if a user was configured for MAINNET in Settings but scanned in a `signmessage` QR with a TESTNET/REGTEST derivation path specified.

However, it was not checking the opposite: Settings configured for TESTNET or REGTEST but scan in a `signmessage` QR for MAINNET.

Second bug: When message signing is disabled in Settings, the `OptionDisabledView` appears but then did not return any values, resulting in a second error screen.

This PR:
* Adds that opposite check (Settings configured for TESTNET/REGTEST, `signmessage` QR for MAINNET).
* Moves the network check to be as early as possible in the flow.
* Updates the `test_sign_message_network_mismatch_flow` to test for all possible network mismatches and DRY-ifies it for internal reuse.
* Adds option on `OptionDisabledView` to jump straight to the relevant Settings update.
* Moves message signing-related decision logic out of `ScanView` and into `SeedSignMessageStartView`
* Adds `OptionDisabledView` to screenshot generator.
* Adds test for sign message being disabled.

---

![OptionDisabledView](https://github.com/SeedSigner/seedsigner/assets/934746/a7848fcd-594c-44ed-aa3a-2171905681eb)
