### PR TITLE
[bugfix] Final word calc UI spacing fix; `TextArea` consistency/placement improvements

### DIFF
--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -240,12 +240,13 @@ class ToolsCalcFinalWordScreen(ButtonListScreen):
 
         self.components.append(TextArea(
             text=f"""Your input: \"{selection_text}\"""",
-            screen_y=self.top_nav.height,
+            screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING - 2,  # Nudge to last line doesn't get too close to "Next" button
+            height_ignores_below_baseline=True,  # Keep the next line (bits display) snugged up, regardless of text rendering below the baseline
         ))
 
         # ...and that entropy's associated 11 bits
-        screen_y=self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING
-        self.components.append(TextArea(
+        screen_y = self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING
+        first_bits_line = TextArea(
             text=keeper_selected_bits,
             font_name=GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME,
             font_size=bit_font_size,
@@ -253,10 +254,13 @@ class ToolsCalcFinalWordScreen(ButtonListScreen):
             screen_x=bit_display_x,
             screen_y=screen_y,
             is_text_centered=False,
-        ))
+        )
+        self.components.append(first_bits_line)
 
         # Render the least significant bits that will be replaced by the checksum in a
         # de-emphasized font color.
+        if "_" in discard_selected_bits:
+            screen_y += int(first_bits_line.height/2)  # center the underscores vertically like hypens
         self.components.append(TextArea(
             text=discard_selected_bits,
             font_name=GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME,
@@ -272,7 +276,7 @@ class ToolsCalcFinalWordScreen(ButtonListScreen):
         self.components.append(TextArea(
             text="Checksum",
             edge_padding=0,
-            screen_y=self.components[-1].screen_y + self.components[-1].height + 2*GUIConstants.COMPONENT_PADDING,
+            screen_y=first_bits_line.screen_y + first_bits_line.height + 2*GUIConstants.COMPONENT_PADDING,
         ))
 
         # ...and its actual bits. Prepend spacers to keep vertical alignment
@@ -288,7 +292,7 @@ class ToolsCalcFinalWordScreen(ButtonListScreen):
             font_size=bit_font_size,
             edge_padding=0,
             screen_x=bit_display_x,
-            screen_y=screen_y,
+            screen_y=screen_y + int(first_bits_line.height/2),  # center the underscores vertically like hypens
             is_text_centered=False,
         ))
 
@@ -308,6 +312,7 @@ class ToolsCalcFinalWordScreen(ButtonListScreen):
         self.components.append(TextArea(
             text=f"""Final Word: \"{self.actual_final_word}\"""",
             screen_y=self.components[-1].screen_y + self.components[-1].height + 2*GUIConstants.COMPONENT_PADDING,
+            height_ignores_below_baseline=True,  # Keep the next line (bits display) snugged up, regardless of text rendering below the baseline
         ))
 
         # Once again show the bits that came from the user's entropy...

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -38,15 +38,12 @@ class ToastOverlay(BaseComponent):
             auto_line_break=True,
             width=self.canvas_width - self.icon.screen_x - self.icon.width - GUIConstants.COMPONENT_PADDING - self.outline_thickness,
             screen_x=self.icon.screen_x + self.icon.width + GUIConstants.COMPONENT_PADDING,
-            allow_text_overflow=False
+            allow_text_overflow=False,
         )
-        # Single-line toast messages need their vertical centering nudged down to account
-        # for TextArea including below the baseline in its height calculation.
-        below_baseline = self.label.text_height_below_baseline if len(self.label.text_lines) == 1 else 0
 
         # Vertically center the message within the toast (for single- or multi-line
         # messages).
-        self.label.screen_y = self.canvas_height - self.height + self.outline_thickness + int((self.height - 2*self.outline_thickness - (self.label.height - below_baseline))/2)
+        self.label.screen_y = self.canvas_height - self.height + self.outline_thickness + int((self.height - 2*self.outline_thickness - self.label.height)/2)
 
 
     def render(self):
@@ -64,7 +61,6 @@ class ToastOverlay(BaseComponent):
         self.label.render()
 
         self.renderer.show_image()
-
 
 
 

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -63,6 +63,11 @@ class SeedStorage:
 
 
     def update_pending_mnemonic(self, word: str, index: int):
+        """
+        Replaces the nth word in the pending mnemonic.
+
+        * may specify a negative `index` (e.g. -1 is the last word).
+        """
         if index >= len(self._pending_mnemonic):
             raise Exception(f"index {index} is too high")
         self._pending_mnemonic[index] = word

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -342,6 +342,19 @@ class ToolsCalcFinalWordShowFinalWordView(View):
         #   * 7 bits to a 12-word seed (plus 4-bit checksum)
         from seedsigner.helpers import mnemonic_generation
 
+        wordlist_language_code = self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE)
+        wordlist = Seed.get_wordlist(wordlist_language_code)
+
+        # Prep the user's selected word / coin flips and the actual final word for
+        # the display.
+        if coin_flips:
+            self.selected_final_word = None
+            self.selected_final_bits = coin_flips
+        else:
+            # Convert the user's final word selection into its binary index equivalent
+            self.selected_final_word = self.controller.storage.pending_mnemonic[-1]
+            self.selected_final_bits = format(wordlist.index(self.selected_final_word), '011b')
+
         if coin_flips:
             # fill the last bits (what will eventually be the checksum) with zeros
             binary_string = coin_flips + "0" * (11 - len(coin_flips))
@@ -354,8 +367,6 @@ class ToolsCalcFinalWordShowFinalWordView(View):
             # update the pending mnemonic with our new "final" (pre-checksum) word
             self.controller.storage.update_pending_mnemonic(word, -1)
 
-        wordlist_language_code = self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE)
-
         # Now calculate the REAL final word (has a proper checksum)
         final_mnemonic = mnemonic_generation.calculate_checksum(
             mnemonic=self.controller.storage.pending_mnemonic,
@@ -367,17 +378,6 @@ class ToolsCalcFinalWordShowFinalWordView(View):
 
         mnemonic = self.controller.storage.pending_mnemonic
         mnemonic_length = len(mnemonic)
-        wordlist = Seed.get_wordlist(wordlist_language_code)
-
-        # Prep the user's selected word / coin flips and the actual final word for
-        # the display.
-        if coin_flips:
-            self.selected_final_word = None
-            self.selected_final_bits = coin_flips
-        else:
-            # Convert the user's final word selection into its binary index equivalent
-            self.selected_final_word = mnemonic[-1]
-            self.selected_final_bits = format(wordlist.index(self.selected_final_word), '011b')
 
         # And grab the actual final word's checksum bits
         self.actual_final_word = self.controller.storage.pending_mnemonic[-1]

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -68,6 +68,12 @@ def test_generate_screenshots(target_locale):
     controller.storage.set_pending_seed(seed_24)
     UnhandledExceptionViewFood = ["IndexError", "line 1, in some_buggy_code.py", "list index out of range"]
 
+    # Pending mnemonic for ToolsCalcFinalWordShowFinalWordView
+    controller.storage.init_pending_mnemonic(num_words=12)
+    for i, word in enumerate(mnemonic_12[:11]):
+        controller.storage.update_pending_mnemonic(word=word, index=i)
+    controller.storage.update_pending_mnemonic(word="satoshi", index=11)  # random last word; not supposed to be a valid checksum (yet)
+
     # Load a PSBT into memory
     BASE64_PSBT_1 = """cHNidP8BAP06AQIAAAAC5l4E3oEjI+H0im8t/K2nLmF5iJFdKEiuQs8ESveWJKcAAAAAAP3///8iBZMRhYIq4s/LmnTmKBi79M8ITirmsbO++63evK4utwAAAAAA/f///wZYQuoDAAAAACIAIAW5jm3UnC5fyjKCUZ8LTzjENtb/ioRTaBMXeSXsB3n+bK2fCgAAAAAWABReJY7akT1+d+jx475yBRWORdBd7VxbUgUAAAAAFgAU4wj9I/jB3GjNQudNZAca+7g9R16iWtYOAAAAABYAFIotPApLZlfscg8f3ppKqO3qA5nv7BnMFAAAAAAiACAs6SGc8qv4FwuNl0G0SpMZG8ODUEk5RXiWUcuzzw5iaRSfAhMAAAAAIgAgW0f5QxQIgVCGQqKzsvfkXZjUxdFop5sfez6Pt8mUbmZ1AgAAAAEAkgIAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////BQIRAgEB/////wJAvkAlAAAAACIAIIRPoo2LvkrwrhrYFhLhlP43izxbA4Eo6Y6iFFiQYdXRAAAAAAAAAAAmaiSqIant4vYcP3HR3v0/qZnfo2lTdVxpBol5mWK0i+vYNpdOjPkAAAAAAQErQL5AJQAAAAAiACCET6KNi75K8K4a2BYS4ZT+N4s8WwOBKOmOohRYkGHV0QEFR1EhArGhNdUqlR4BAOLGTMrY2ZJYTQNRudp7fU7i8crRJqgEIQNDxn7PjUzvsP6KYw4s7dmoZE0qO1K6MaM+2ScRZ7hyxFKuIgYCsaE11SqVHgEA4sZMytjZklhNA1G52nt9TuLxytEmqAQcc8XaCjAAAIABAACAAAAAgAIAAIAAAAAAAwAAACIGA0PGfs+NTO+w/opjDizt2ahkTSo7Uroxoz7ZJxFnuHLEHCK94akwAACAAQAAgAAAAIACAACAAAAAAAMAAAAAAQCSAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8FAhACAQH/////AkC+QCUAAAAAIgAghE+ijYu+SvCuGtgWEuGU/jeLPFsDgSjpjqIUWJBh1dEAAAAAAAAAACZqJKohqe3i9hw/cdHe/T+pmd+jaVN1XGkGiXmZYrSL69g2l06M+QAAAAABAStAvkAlAAAAACIAIIRPoo2LvkrwrhrYFhLhlP43izxbA4Eo6Y6iFFiQYdXRAQVHUSECsaE11SqVHgEA4sZMytjZklhNA1G52nt9TuLxytEmqAQhA0PGfs+NTO+w/opjDizt2ahkTSo7Uroxoz7ZJxFnuHLEUq4iBgKxoTXVKpUeAQDixkzK2NmSWE0DUbnae31O4vHK0SaoBBxzxdoKMAAAgAEAAIAAAACAAgAAgAAAAAADAAAAIgYDQ8Z+z41M77D+imMOLO3ZqGRNKjtSujGjPtknEWe4csQcIr3hqTAAAIABAACAAAAAgAIAAIAAAAAAAwAAAAABAUdRIQJ5XLCBS0hdo4NANq4lNhimzhyHj7dvObmPAwNj8L2xASEC9mwwoH28/WHnxbb6z05sJ/lHuvrLs/wOooHgFn5ulI1SriICAnlcsIFLSF2jg0A2riU2GKbOHIePt285uY8DA2PwvbEBHCK94akwAACAAQAAgAAAAIACAACAAQAAAAEAAAAiAgL2bDCgfbz9YefFtvrPTmwn+Ue6+suz/A6igeAWfm6UjRxzxdoKMAAAgAEAAIAAAACAAgAAgAEAAAABAAAAAAAAAAEBR1EhAgpbWcEh7rgvRE5UaCcqzWL/TR1B/DS8UeZsKVEvuKLrIQOwLg0emiQbbxafIh69Xjtpj4eclsMhKq1y/7vYDdE7LVKuIgICCltZwSHuuC9ETlRoJyrNYv9NHUH8NLxR5mwpUS+4ouscc8XaCjAAAIABAACAAAAAgAIAAIAAAAAABQAAACICA7AuDR6aJBtvFp8iHr1eO2mPh5yWwyEqrXL/u9gN0TstHCK94akwAACAAQAAgAAAAIACAACAAAAAAAUAAAAAAQFHUSECk50GLh/YhZaLJkDq/dugU3H/WvE6rTgQuY6N57pI4ykhA/H8MdLVP9SA/Hg8l3hvibSaC1bCBzwz7kTW+rsEZ8uFUq4iAgKTnQYuH9iFlosmQOr926BTcf9a8TqtOBC5jo3nukjjKRxzxdoKMAAAgAEAAIAAAACAAgAAgAAAAAAGAAAAIgID8fwx0tU/1ID8eDyXeG+JtJoLVsIHPDPuRNb6uwRny4UcIr3hqTAAAIABAACAAAAAgAIAAIAAAAAABgAAAAA="""
     decoder = DecodeQR()
@@ -201,7 +207,8 @@ def test_generate_screenshots(target_locale):
             tools_views.ToolsCalcFinalWordNumWordsView,
             tools_views.ToolsCalcFinalWordFinalizePromptView,
             tools_views.ToolsCalcFinalWordCoinFlipsView,
-            #(tools_views.ToolsCalcFinalWordShowFinalWordView, dict(coin_flips=3)),
+            (tools_views.ToolsCalcFinalWordShowFinalWordView, {}, "ToolsCalcFinalWordShowFinalWordView_pick_word"),
+            (tools_views.ToolsCalcFinalWordShowFinalWordView, dict(coin_flips="0010101"), "ToolsCalcFinalWordShowFinalWordView_coin_flips"),
             #tools_views.ToolsCalcFinalWordDoneView,
             tools_views.ToolsAddressExplorerSelectSourceView,
             tools_views.ToolsAddressExplorerAddressTypeView,
@@ -231,7 +238,8 @@ def test_generate_screenshots(target_locale):
             print(f"Completed {view_name}")
         except Exception as e:
             # Something else went wrong
-            print(repr(e))
+            from traceback import print_exc
+            print_exc()
             raise e
         finally:
             if toast_thread:


### PR DESCRIPTION
* Fixes rendering on `ToolsCalcFinalWordShowFinalWordView`
* Updates `TextArea` to be more internally consistent and easier to work with (with respect to text height and positioning). Now the Screen has full control over whether or not the TextArea includes pixels rendered below the baseline in its height/spacing calculations.
* Light refactor in the Calc Final Word Views to move the actual final words calcs into `ToolsCalcFinalWordShowFinalWordView` in order to make that View independent (necessary in order to generate screenshots).
* Adds screenshots for `ToolsCalcFinalWordShowFinalWordView` variations.
* Improves screenshot generator's error reporting to aid in debugging failed screenshots.

---

![ToolsCalcFinalWordShowFinalWordView_coin_flips](https://github.com/SeedSigner/seedsigner/assets/934746/7deb4f82-3838-4a37-ba56-76020b3aa4d6)&nbsp;&nbsp;&nbsp;![ToolsCalcFinalWordShowFinalWordView_pick_word](https://github.com/SeedSigner/seedsigner/assets/934746/298c67fb-2fac-4703-aab8-9ec8be55bcbb)

