### PR TITLE
MicroSD.is_inserted as an unsettable attribute

### DIFF
--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -210,7 +210,7 @@ class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
     def should_keep_running(self) -> bool:
         """ Custom exit condition: keep running until the SD card is removed """
         from seedsigner.hardware.microsd import MicroSD
-        return MicroSD.is_inserted()
+        return MicroSD.get_instance().is_inserted
 
 
 

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -52,7 +52,7 @@ class MicroSD(Singleton, BaseThread):
 
             # at start-up, get current status and inform Settings
             Settings.handle_microsd_state_change(
-                action=MicroSD.ACTION__INSERTED if MicroSD.is_inserted else MicroSD.ACTION__REMOVED
+                action=MicroSD.ACTION__INSERTED if MicroSD.is_inserted() else MicroSD.ACTION__REMOVED
             )
 
             if os.path.exists(self.FIFO_PATH):

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -29,8 +29,8 @@ class MicroSD(Singleton, BaseThread):
         return cls._instance
 
 
-    @classmethod
-    def is_inserted(cls):
+    @property
+    def is_inserted(self):
         if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
             return os.path.exists(MicroSD.MOUNT_POINT)
         else:
@@ -52,7 +52,7 @@ class MicroSD(Singleton, BaseThread):
 
             # at start-up, get current status and inform Settings
             Settings.handle_microsd_state_change(
-                action=MicroSD.ACTION__INSERTED if MicroSD.is_inserted() else MicroSD.ACTION__REMOVED
+                action=MicroSD.ACTION__INSERTED if self.is_inserted else MicroSD.ACTION__REMOVED
             )
 
             if os.path.exists(self.FIFO_PATH):


### PR DESCRIPTION
This pr resolves an error-prone is_enabled() method call by accessing that name as an attribute ~~unintended reference to a class attribute instead of calling the name as a class method~~ effectively enabling user to pull the microsd before startup and allowing seedsigner to learn the microsd inserted/removed state.