### PR TITLE
Inserting a microsd w/ settings.json implies nothing

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -244,11 +244,12 @@ class Settings(Singleton):
                 # settings) should overwrite the settings on disk, if they differ:
                 # - Overwrite settings on the SD?
                 # - Load settings from SD?
+                # - Do nothing without informing the user first?
                 # if Settings file exists (meaning persistent settings was previously enabled), write out current settings to disk
-                if os.path.exists(Settings.SETTINGS_FILENAME):
-                    # enable persistent settings first, then save
-                    Settings.get_instance()._data[SettingsConstants.SETTING__PERSISTENT_SETTINGS] = SettingsConstants.OPTION__ENABLED
-                    Settings.get_instance().save()
+                #if os.path.exists(Settings.SETTINGS_FILENAME):
+                #    # enable persistent settings first, then save
+                #    Settings.get_instance()._data[SettingsConstants.SETTING__PERSISTENT_SETTINGS] = SettingsConstants.OPTION__ENABLED
+                #    Settings.get_instance().save()
 
             elif action == MicroSD.ACTION__REMOVED:
                 # SD card was just removed.


### PR DESCRIPTION
This pr CHANGES EXISTING BEHAVIOR SINCE RELEASE 0.6.0

Where inserting a microsd w/ a settings.json file assumes that the user wants:
1) persistent settings to be enabled, and
2) for settings.json to be written by the current settings values immediately.

This existing behavior could be fine if the user always waits for seedsigner to start-up first before removing their microsd, but it is too much implied action w/o informing the user about what is happening in the case that they have pulled the microsd by habit before seedsigner starts, and are re-inserting the microsd so that they can restart the app to regain the persistent settings on the microsd.  The existing 'magic' more likely replaces the user's custom persistent settings with defaults that were set when seedsigner started w/o microsd.

This pr does NOT add any notifications, it does NOT read the existing settings.json file, it does NOT assume to enable persistent settings, and it does not write current settings... though all of these actions MIGHT be a better solution than this pr, as long as the user is notified.

What this pr does do, is to remove assumptions that anything 'magic' should happen just because the user re-inserted the microsd with a settings.json file... and it enables them to restart the app regaining their persistent settings.  Knowing that they previously removed the sdcard, they'll understand, or quickly learn, that persistent_settings were disabled at that time.  They can continue using their seedsigner with current settings (defaults or whatever they've changed since boot) and must explicitely re-enable persistent-settings to replace whatever settings.json is already on the microsd.

Also, this pr does not remove any lines of code or any existing comments, because they are all still valid and informative.  It simply comments-out logic until better notifications and/or user choices can be added.