### PR TITLE
Set 0.7.0 to RC1

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -93,7 +93,7 @@ class Controller(Singleton):
         rather than at the top in order avoid circular imports.
     """
 
-    VERSION = "0.7.0"
+    VERSION = "0.7.0-rc1"
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.


### PR DESCRIPTION
project team decided to visually indicate the 0.7.0 release candidate as "0.7.0-rc1"