### PR TITLE
[bugfix] Reset state upon reading an invalid QR

### DIFF
--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -151,12 +151,15 @@ class ScanView(View):
                 return Destination(NotYetImplementedView)
 
         elif self.decoder.is_invalid:
+            # For now, don't even try to re-do the attempted operation, just reset and
+            # start everything over.
+            self.controller.resume_main_flow = None
             return Destination(ErrorView, view_args=dict(
                 title="Error",
                 status_headline="Unknown QR Type",
                 text="QRCode is invalid or is a data format not yet supported.",
-                button_text="Back",
-                next_destination=Destination(BackStackView, skip_current_view=True),
+                button_text="Done",
+                next_destination=Destination(MainMenuView, clear_history=True),
             ))
 
         return Destination(MainMenuView)

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -502,4 +502,4 @@ class TestMessageSigningFlows(FlowTest):
             FlowStep(MainMenuView),
         ])
 
-        assert(self.controller.resume_main_flow is None)
+        assert self.controller.resume_main_flow is None

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -8,7 +8,7 @@ from base import FlowTestRunScreenNotExecutedException, FlowTestInvalidButtonDat
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import Seed
-from seedsigner.views.view import MainMenuView, OptionDisabledView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView
+from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView
 from seedsigner.views import seed_views, scan_views, settings_views, tools_views
 
 
@@ -477,3 +477,29 @@ class TestMessageSigningFlows(FlowTest):
                 FlowStep(MainMenuView),
             ]
         )
+
+
+    def test_sign_message_invalid_qr_flow(self):
+        """
+        Should clear `Controller.resume_main_flow` and redirect to ErrorView if an
+        invalid signmessage QR is scanned.
+
+        The error view should then forward to MainMenuView.
+        """
+        # Ensure message signing is enabled
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        def load_invalid_signmessage_qr(view: scan_views.ScanView):
+            view.decoder.add_data("this text will not make sense to the decoder")
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+            FlowStep(scan_views.ScanView, before_run=load_invalid_signmessage_qr),  # simulate read message QR; ret val is ignored
+            FlowStep(ErrorView),
+            FlowStep(MainMenuView),
+        ])
+
+        assert(self.controller.resume_main_flow is None)


### PR DESCRIPTION
fixes #456

## The problem
The BackStack and the `Controller.resume_main_flow` can create some confusing debugging when an error happens mid-flow.

In this case it was:
* Load a seed
* In Seed Options, select Sign Message
* Scan an invalid QR (not a format recognized by any of our decoders)

That would route you to the ErrorView which would then take you BACK, which routes you to SeedOptionsView. That detected the `Controller.resume_main_flow` which then routes to `SeedSignMessageConfirmMessageView` which assumes by that point that all necessary data has been loaded, yielding a second error screen.

---

## The fix
Don't attempt any kind of resumption of flow when an invalid QR is scanned. Just clear and reset the state (`Controller.resume_main_flow = None`), show ErrorView, and return to the MainMenuView.

This PR adds the above change and a matching new test for that flow.