### PR TITLE
[Enhancement] Additional edge padding for Warning Screen body text

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -826,6 +826,7 @@ class LargeIconStatusScreen(ButtonListScreen):
     status_color: str = GUIConstants.SUCCESS_COLOR
     status_headline: str = "Success!"  # The colored text under the large icon
     text: str = ""                          # The body text of the screen
+    text_edge_padding: int = GUIConstants.EDGE_PADDING
     button_data: list = None
     allow_text_overflow: bool = False
 
@@ -861,7 +862,7 @@ class LargeIconStatusScreen(ButtonListScreen):
             height=self.buttons[0].screen_y - next_y,
             text=self.text,
             width=self.canvas_width,
-            edge_padding=GUIConstants.EDGE_PADDING,  # Don't render all the way up to the far left/right edges
+            edge_padding=self.text_edge_padding,  # Don't render all the way up to the far left/right edges
             screen_y=next_y,
             allow_text_overflow=self.allow_text_overflow,
         ))
@@ -935,6 +936,7 @@ class WarningEdgesThread(BaseThread):
 @dataclass
 class WarningEdgesMixin:
     status_color: str = GUIConstants.WARNING_COLOR
+    text_edge_padding: int = 2 * GUIConstants.EDGE_PADDING
 
     def __post_init__(self):
         super().__post_init__()

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -31,7 +31,7 @@ from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views)
-from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView, View
+from seedsigner.views.view import ErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView, View
 
 from .utils import ScreenshotComplete, ScreenshotRenderer
 
@@ -123,13 +123,7 @@ def test_generate_screenshots(target_locale):
             PowerOptionsView,
             RestartView,
             PowerOffView,
-            NotYetImplementedView,
-            (UnhandledExceptionView, dict(error=UnhandledExceptionViewFood)),
-            (settings_views.SettingsIngestSettingsQRView, dict(data="settings::v1 name=factory_reset")),
-            NetworkMismatchErrorView,
-            (OptionDisabledView, dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
-
-
+            (settings_views.SettingsIngestSettingsQRView, dict(data="settings::v1 name=Uncle_Jim's_noob_mode")),
         ],
         "Seed Views": [
             seed_views.SeedsMenuView,
@@ -222,6 +216,18 @@ def test_generate_screenshots(target_locale):
             #tools_views.ToolsAddressExplorerAddressView,
         ],
         "Settings Views": settings_views_list,
+        "Misc Error Views": [
+            NotYetImplementedView,
+            (UnhandledExceptionView, dict(error=UnhandledExceptionViewFood)),
+            NetworkMismatchErrorView,
+            (OptionDisabledView, dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
+            (ErrorView, dict(
+                title="Error",
+                status_headline="Unknown QR Type",
+                text="QRCode is invalid or is a data format not yet supported.",
+                button_text="Back",
+            )),
+        ],
     }
 
     readme = f"""# SeedSigner Screenshots\n"""


### PR DESCRIPTION
## The problem
Current Warning Screens use the standard `GUIConstants.EDGE_PADDING` for the left and right limits for the body text. But the pulsing yellow or red warning edges fill that edge padding. Depending on the line breaks, text can potentially directly touch the pulsing warning edges.

## The fix
Double the default edge padding for Warning Screens.

---
Before / After
(unfortunately we can't currently render the yellow/red warning edges, so just imagine the edges being filled in)

![ErrorView-before](https://github.com/SeedSigner/seedsigner/assets/934746/822b7fe7-1b2f-40c7-ac85-d7266f069c27) ![ErrorView-after](https://github.com/SeedSigner/seedsigner/assets/934746/d5bc952f-d688-4425-9d6a-f57f36b54a09)

This change affects all Warning Screens, so you must regenerate screenshots to see the changes.

![PSBTNoChangeWarningView-before](https://github.com/SeedSigner/seedsigner/assets/934746/5f4e3c43-24a7-4b55-8038-55b44aefa361) ![PSBTNoChangeWarningView-after](https://github.com/SeedSigner/seedsigner/assets/934746/4d320921-23ad-49dc-bf84-d0d9e6c38540)

---

## Additional changes
* Adds a screenshot for the generic `ErrorView`
* Pulls the more general errors out into their own section at the end of the screenshot generator output
* Renames the example SettingsQR since "factory reset" terminology only makes sense for a retail product.

---

## Follow-up steps
If merged, generate new screenshots and update https://github.com/SeedSigner/seedsigner-screenshots