### PR TITLE
unittests for new settings defaults: msg-signing/qr-brightness-tips

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -105,8 +105,10 @@ class TestController(BaseTest):
         assert controller.settings.get_value(SettingsConstants.SETTING__CAMERA_ROTATION) == SettingsConstants.CAMERA_ROTATION__180
         assert controller.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) == SettingsConstants.OPTION__ENABLED
         assert controller.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS) == SettingsConstants.OPTION__DISABLED
+        assert controller.settings.get_value(SettingsConstants.SETTING__MESSAGE_SIGNING) == SettingsConstants.OPTION__DISABLED
         assert controller.settings.get_value(SettingsConstants.SETTING__PRIVACY_WARNINGS) == SettingsConstants.OPTION__ENABLED
         assert controller.settings.get_value(SettingsConstants.SETTING__DIRE_WARNINGS) == SettingsConstants.OPTION__ENABLED
+        assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS_TIPS) == SettingsConstants.OPTION__ENABLED
         assert controller.settings.get_value(SettingsConstants.SETTING__PARTNER_LOGOS) == SettingsConstants.OPTION__ENABLED
 
         # Hidden Settings defaults


### PR DESCRIPTION
Adds 2 unit-tests for new settings defaults in 0.7.0.

The tests/test_controller.py tests all settings defaults as its last test.  It's extra maintenance, but it's also helpful for us not to accidentally change defaults without also updating the unit-test, also helpful for keeping settings-generator in line with seedsigner settings defaults.