### PR TITLE
Increase min Python version to 3.10 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.6",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
The codebase makes usage of typing features present only in Python >= 3.10. Updating the setup.py to reflect this.

This was found by working on https://github.com/SeedSigner/seedsigner/pull/469 and trying to run the tests against Python <3.10.