### PR TITLE
Fix extension in font not found exception message

### DIFF
--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -215,7 +215,7 @@ class Fonts(Singleton):
                 cls.fonts[font_name][size] = ImageFont.truetype(os.path.join(cls.font_path, f"{font_name}.{file_extension}"), size)
             except OSError as e:
                 if "cannot open resource" in str(e):
-                    raise Exception(f"Font {font_name}.ttf not found: {repr(e)}")
+                    raise Exception(f"Font {font_name}.{file_extension} not found: {repr(e)}")
                 else:
                     raise e
 


### PR DESCRIPTION
The exception had the `.ttf` extension hardcoded, which lead to error messages like `seedsigner-icons.ttf` not found, which is missleading as there only is a `seedsigner-icons.otf` file. Also add the full font file path to the exception to know where the file is actually expected.

This was found while working on https://github.com/SeedSigner/seedsigner/pull/469 before the font setup was correct in the PR.