### PR TITLE
Update Pillow to 9.4.0 and fix deprecations related to font.getsize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 embit==0.7.0
 numpy==1.21.1
-Pillow==8.2.0
+Pillow==9.5.0
 -e git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03#egg=pyzbar
 qrcode==7.3.1
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 embit==0.7.0
 numpy==1.21.1
-Pillow==9.5.0
+Pillow==9.4.0
 -e git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03#egg=pyzbar
 qrcode==7.3.1
 six==1.16.0

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -610,7 +610,8 @@ class FormattedAddress(BaseComponent):
         self.accent_font = Fonts.get_font(GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME, self.font_size)
 
         # Fixed width font means we only have to measure one max-height character
-        char_width, char_height = self.font.getsize("Q")
+        left, top, right, bottom  = self.font.getbbox("Q")
+        char_width, char_height = right - left, bottom - top
 
         n = 7
         display_str = f"{self.address[:n]} {self.address[n:-1*n]} {self.address[-1*n:]}"

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -591,7 +591,8 @@ class TextEntryDisplay(TextEntryDisplayConstants):
             if end_pos_x < self.width:
                 # The entire cur_text plus the cursor bar fits
                 self.text_offset = 3 + cursor_bar_serif_half_width
-                tw_left, th = self.font.getsize(self.cur_text[:cursor_position])
+                left, top, right, bottom  = self.font.getbbox(self.cur_text[:cursor_position])
+                tw_left, th = right - left, bottom - top
                 cursor_bar_x = self.text_offset + tw_left
 
             else:
@@ -599,7 +600,8 @@ class TextEntryDisplay(TextEntryDisplayConstants):
                     cursor_position = len(self.cur_text)
 
                 # Is the cursor at either extreme?
-                tw_left, th = self.font.getsize(self.cur_text[:cursor_position])
+                left, top, right, bottom  = self.font.getbbox(self.cur_text[:cursor_position])
+                tw_left, th = right - left, bottom - top
 
                 if self.text_offset + tw_left + cursor_bar_serif_half_width + 3 >= self.width:
                     # Cursor is at the extreme right; have to push the full tw_right off

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -97,7 +97,8 @@ class PSBTOverviewScreen(ButtonListScreen):
 
         max_inputs_text_width = 0
         for input in inputs_column:
-            tw, th = font.getsize(input)
+            left, top, right, bottom  = font.getbbox(input)
+            tw, th = right - left, bottom - top
             max_inputs_text_width = max(tw, max_inputs_text_width)
 
         # Given how wide we want our curves on each side to be...
@@ -148,7 +149,8 @@ class PSBTOverviewScreen(ButtonListScreen):
 
             max_destination_text_width = 0
             for destination in destination_column:
-                tw, th = font.getsize(destination)
+                left, top, right, bottom  = font.getbbox(destination)
+                tw, th = right - left, bottom - top
                 max_destination_text_width = max(tw, max_destination_text_width)
             
             return (max_destination_text_width, destination_column)
@@ -194,7 +196,9 @@ class PSBTOverviewScreen(ButtonListScreen):
         input_curves = []
         for input in inputs_column:
             # Calculate right-justified input display
-            tw, th = font.getsize(input)
+            left, top, right, bottom  = font.getbbox(input)
+            tw, th = right - left, bottom - top
+            
             cur_x = inputs_x + max_inputs_text_width - tw
             draw.text(
                 (cur_x, inputs_y),
@@ -503,7 +507,8 @@ class PSBTMathScreen(ButtonListScreen):
 
         body_font = Fonts.get_font(GUIConstants.BODY_FONT_NAME, (GUIConstants.BODY_FONT_SIZE)*ssf)
         fixed_width_font = Fonts.get_font(GUIConstants.FIXED_WIDTH_FONT_NAME, (GUIConstants.BODY_FONT_SIZE + 6)*ssf)
-        digits_width, digits_height = fixed_width_font.getsize(self.input_amount + "+")
+        left, top, right, bottom  = fixed_width_font.getbbox(self.input_amount + "+")
+        digits_width, digits_height = right - left, bottom - top
 
         # Draw each line of the equation
         cur_y = 0
@@ -520,8 +525,10 @@ class PSBTMathScreen(ButtonListScreen):
                 main_zone = display_str[:-6]
                 mid_zone = display_str[-6:-3]
                 end_zone = display_str[-3:]
-                main_zone_width, th = fixed_width_font.getsize(main_zone)
-                mid_zone_width, th = fixed_width_font.getsize(end_zone)
+                left, top, right, bottom  = fixed_width_font.getbbox(main_zone)
+                main_zone_width, th = right - left, bottom - top
+                left, top, right, bottom  = fixed_width_font.getbbox(end_zone)
+                mid_zone_width, th = right - left, bottom - top
                 draw.text((0, cur_y), text=main_zone, font=fixed_width_font, fill=GUIConstants.BODY_FONT_COLOR)
                 draw.text((main_zone_width + digit_group_spacing, cur_y), text=mid_zone, font=fixed_width_font, fill=secondary_digit_color)
                 draw.text((main_zone_width + digit_group_spacing + mid_zone_width + digit_group_spacing, cur_y), text=end_zone, font=fixed_width_font, fill=tertiary_digit_color)

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1043,7 +1043,8 @@ class SeedReviewPassphraseScreen(ButtonListScreen):
             if found_solution:
                 break
             font = Fonts.get_font(font_name=GUIConstants.FIXED_WIDTH_FONT_NAME, size=font_size)
-            char_width, char_height = font.getsize("X")
+            left, top, right, bottom  = font.getbbox("X")
+            char_width, char_height = right - left, bottom - top
             for num_lines in range(1, max_lines+1):
                 # Break the passphrase into n lines
                 chars_per_line = math.ceil(len(self.passphrase) / num_lines)


### PR DESCRIPTION
Upgrade Pillow install requirement from 8.2.0 to 9.4.0. This makes the requirements.txt match what is used in SeedSignerOS for 0.7.0.

Eventually when we upgrade to Pillow 10.0 `font.getsize` will stop working. This PR also replaces `font.getsize` with `font.getbbox`. See Pillow notes here: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html

Pillow 9.4 has this deprecation warnings before this PR.
```
DeprecationWarning: getsize is deprecated and will be removed in Pillow 10 (2023-07-01). Use getbbox or getlength instead
```