### PR TITLE
Updating requirements.txt for Python 3.10.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 embit==0.7.0
 numpy==1.21.1
-Pillow==8.2.0
+Pillow==9.5.0
 -e git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03#egg=pyzbar
 qrcode==7.3.1
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 embit==0.7.0
 numpy==1.25.2
-Pillow==9.5.0
+Pillow==9.4.0
 -e git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03#egg=pyzbar
 qrcode==7.3.1
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 embit==0.7.0
-numpy==1.21.1
+numpy==1.25.2
 Pillow==9.5.0
 -e git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03#egg=pyzbar
 qrcode==7.3.1


### PR DESCRIPTION
In order to run requirements.txt on Python 3.10.12, it requires updating: numpy from 1.21.1 to 1.25.2 as well as updating Pillow from 8.2.0 to 9.4.0