### PR TITLE
[Enhancement] Render SeedQR small registration block in solid squares

### DIFF
--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -163,7 +163,7 @@ def test_generate_screenshots(target_locale):
             (seed_views.SeedTranscribeSeedQRWholeQRView, dict(seed_num=2, seedqr_format=QRType.SEED__SEEDQR, num_modules=29), "SeedTranscribeSeedQRWholeQRView_24_Standard"),
 
             # Screenshot doesn't render properly due to how the transparency mask is pre-rendered
-            (seed_views.SeedTranscribeSeedQRZoomedInView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR)),
+            # (seed_views.SeedTranscribeSeedQRZoomedInView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR)),
 
             (seed_views.SeedTranscribeSeedQRConfirmQRPromptView, dict(seed_num=0)),
 

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -65,10 +65,12 @@ def test_generate_screenshots(target_locale):
     mnemonic_12b = ["abandon"] * 11 + ["about"]
     seed_12 = Seed(mnemonic=mnemonic_12, passphrase="cap*BRACKET3stove", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
     seed_12b = Seed(mnemonic=mnemonic_12b, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
-    seed_24 = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    seed_24 = Seed(mnemonic=mnemonic_24, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    seed_24_w_passphrase = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
     controller.storage.seeds.append(seed_12)
     controller.storage.seeds.append(seed_12b)
-    controller.storage.set_pending_seed(seed_24)
+    controller.storage.seeds.append(seed_24)
+    controller.storage.set_pending_seed(seed_24_w_passphrase)
     UnhandledExceptionViewFood = ["IndexError", "line 1, in some_buggy_code.py", "list index out of range"]
 
     # Pending mnemonic for ToolsCalcFinalWordShowFinalWordView
@@ -155,11 +157,13 @@ def test_generate_screenshots(target_locale):
             (seed_views.SeedWordsBackupTestSuccessView, dict(seed_num=0)),
             (seed_views.SeedTranscribeSeedQRFormatView, dict(seed_num=0)),
             (seed_views.SeedTranscribeSeedQRWarningView, dict(seed_num=0)),
-            (seed_views.SeedTranscribeSeedQRWholeQRView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR, num_modules=25), "SeedTranscribeSeedQRWholeQRView_12_Standard"),
             (seed_views.SeedTranscribeSeedQRWholeQRView, dict(seed_num=0, seedqr_format=QRType.SEED__COMPACTSEEDQR, num_modules=21), "SeedTranscribeSeedQRWholeQRView_12_Compact"),
+            (seed_views.SeedTranscribeSeedQRWholeQRView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR, num_modules=25), "SeedTranscribeSeedQRWholeQRView_12_Standard"),
+            (seed_views.SeedTranscribeSeedQRWholeQRView, dict(seed_num=2, seedqr_format=QRType.SEED__COMPACTSEEDQR, num_modules=25), "SeedTranscribeSeedQRWholeQRView_24_Compact"),
+            (seed_views.SeedTranscribeSeedQRWholeQRView, dict(seed_num=2, seedqr_format=QRType.SEED__SEEDQR, num_modules=29), "SeedTranscribeSeedQRWholeQRView_24_Standard"),
 
             # Screenshot doesn't render properly due to how the transparency mask is pre-rendered
-            # (seed_views.SeedTranscribeSeedQRZoomedInView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR)),
+            (seed_views.SeedTranscribeSeedQRZoomedInView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR)),
 
             (seed_views.SeedTranscribeSeedQRConfirmQRPromptView, dict(seed_num=0)),
 


### PR DESCRIPTION
fixes #483

Renders the lower-right registration block in 25x25 and 29x29 SeedQRs as solid squares instead of dots.

Before vs after:
![SeedTranscribeSeedQRWholeQRView_12_Standard](https://github.com/SeedSigner/seedsigner/assets/934746/d015eddd-dc80-44b6-90b3-94eed541590f) ![SeedTranscribeSeedQRWholeQRView_12_Standard](https://github.com/SeedSigner/seedsigner/assets/934746/75c65b37-a398-4269-adf8-e197859c33a2)

And the same rendering improvement is continued in the zoomed-in transcription UI:
<img width="50%" src="https://github.com/SeedSigner/seedsigner/assets/934746/b71a90e5-b0f3-444d-abe2-7a8a15568eb1">

---

Supplements screenshot generator with:
* 12-word, standard SeedQR WholeQRView
* 24-word, compact SeedQR WholeQRView
* 24-word, standard SeedQR WholeQRView

--- 

Briefly tried and quickly gave up on getting the zoomed in transcription UI to render in the screenshot generator (just comes out all black). TODO for another day.