### PR TITLE
Update README for SeedSigner OS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
   * [Verifying the Software](#verifying-the-software)
 * [Enclosure Designs](#enclosure-designs)
 * [SeedQR Printable Templates](#seedqr-printable-templates)
-* [Developer Build Instructions](#developer-build-instructions)
 * [Build from Source](#build-from-source)
+* [Developer Local Build Instructions](#developer-build-instructions)
 
 
 ---------------
@@ -85,7 +85,7 @@ Notes:
 ## A Special Note On Minimizing Trust
 As is the nature of pre-packaged software downloads, downloading and using the prepared SeedSigner release images means implicitly placing trust in the people preparing those images; in our project the released images are prepared and signed by the eponymous creator of the project, SeedSigner "the person". That individual is additionally the only person in possession of the PGP keys that are used to sign the release images.
 
-As of release 0.7.0 the images distributed via GitHub are reproducible. This means you and others can verify the released images are byte for byte the same when built from source. If you have the ability to read and understand source code; then you can contribute to this project by building from source and sharing the hash of the final images.
+Starting with v0.7.0, the images distributed via GitHub are reproducible. This means you and others can verify the released images are byte-for-byte the same when built from source. You can contribute to this project by building from source and sharing the hash of the final images.
 
 Instructions to build a SeedSigner OS image (using precisely the same process that is used to create the prepared release images) have been made available. We have put a lot of thought and work into making these instructions easy to understand and follow, even for less technical users. These instructions can be found [here](https://github.com/SeedSigner/seedsigner-os/blob/main/docs/building.md).
 
@@ -329,8 +329,8 @@ Letter templates(8.5in * 11in):
 * [29x29 - stores 24-word seeds ONLY as plaintext SeedQR format ONLY](docs/seed_qr/printable_templates/29x29_letter_trading_card_2sided.pdf)
 ---------------
 
-# Developer Build Instructions
-Raspberry Pi OS is commonly used for development. See the [Raspberry Pi OS Build Instructions](docs/raspberry_pi_os_build_instructions.md)
-
 # Build from Source
 See the [SeedSigner OS repo](https://github.com/SeedSigner/seedsigner-os/) for instructions.
+
+# Developer Local Build Instructions
+Raspberry Pi OS is commonly used for development. See the [Raspberry Pi OS Build Instructions](docs/raspberry_pi_os_build_instructions.md)

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Notes:
 # Software Installation
 
 ## A Special Note On Minimizing Trust
-As is the nature of pre-packaged software downloads, downloading and using the prepared SeedSigner release images means implicitly placing trust in the people preparing those images; in our project the release images are prepared and signed by the eponymous creator of the project, SeedSigner "the person". That individual is additionally the only person in possession of the PGP keys that are used to sign the release images.
+As is the nature of pre-packaged software downloads, downloading and using the prepared SeedSigner release images means implicitly placing trust in the people preparing those images; in our project the released images are prepared and signed by the eponymous creator of the project, SeedSigner "the person". That individual is additionally the only person in possession of the PGP keys that are used to sign the release images.
 
-As of release 0.7.0 the image released are reproducible. This  means you and others can verify the released images are byte for byte that same when built from source. If you have the ability to read and understand source code; then you can contribute to this project by building from source and sharing the hash of the final images.
+As of release 0.7.0 the images distributed via GitHub are reproducible. This means you and others can verify the released images are byte for byte the same when built from source. If you have the ability to read and understand source code; then you can contribute to this project by building from source and sharing the hash of the final images.
 
 Instructions to build a SeedSigner OS image (using precisely the same process that is used to create the prepared release images) have been made available. We have put a lot of thought and work into making these instructions easy to understand and follow, even for less technical users. These instructions can be found [here](https://github.com/SeedSigner/seedsigner-os/blob/main/docs/building.md).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
   * [Verifying the Software](#verifying-the-software)
 * [Enclosure Designs](#enclosure-designs)
 * [SeedQR Printable Templates](#seedqr-printable-templates)
-* [Manual Installation Instructions](#manual-installation-instructions)
+* [Developer Build Instructions](#developer-build-instructions)
+* [Build from Source](#build-from-source)
 
 
 ---------------
@@ -82,9 +83,11 @@ Notes:
 # Software Installation
 
 ## A Special Note On Minimizing Trust
-As is the nature of pre-packaged software downloads, downloading and using the prepared SeedSigner release images means implicitly placing trust in the individual preparing those images; in our project the release images are prepared and signed by the eponymous creator of the project, SeedSigner "the person". That individual is additionally the only person in possession of the PGP keys that are used to sign the release images.
+As is the nature of pre-packaged software downloads, downloading and using the prepared SeedSigner release images means implicitly placing trust in the people preparing those images; in our project the release images are prepared and signed by the eponymous creator of the project, SeedSigner "the person". That individual is additionally the only person in possession of the PGP keys that are used to sign the release images.
 
-However, one of the many advantages of the open source software model is that the need for this kind of trust can be negated by our users' ability to (1) review the project's source code and (2) assemble the operating image necessary to use the software themselves. From our project's inception, instructions to build a SeedSigner operating image (using precisely the same process that is used to create the prepared release images) have been made available. We have put a lot of thought and work into making these instructions easy to understand and follow, even for less technical users. These instructions can be found [here](docs/manual_installation.md).
+As of release 0.7.0 the image released are reproducible. This  means you and others can verify the released images are byte for byte that same when built from source. If you have the ability to read and understand source code; then you can contribute to this project by building from source and sharing the hash of the final images.
+
+Instructions to build a SeedSigner OS image (using precisely the same process that is used to create the prepared release images) have been made available. We have put a lot of thought and work into making these instructions easy to understand and follow, even for less technical users. These instructions can be found [here](https://github.com/SeedSigner/seedsigner-os/blob/main/docs/building.md).
 
 ## Downloading the Software
 
@@ -326,5 +329,8 @@ Letter templates(8.5in * 11in):
 * [29x29 - stores 24-word seeds ONLY as plaintext SeedQR format ONLY](docs/seed_qr/printable_templates/29x29_letter_trading_card_2sided.pdf)
 ---------------
 
-# Manual Installation Instructions
-see the docs: [Manual Installation Instructions](docs/manual_installation.md)
+# Developer Build Instructions
+Raspberry Pi OS is commonly used for development. See the [Raspberry Pi OS Build Instructions](docs/raspberry_pi_os_build_instructions.md)
+
+# Build from Source
+See the [SeedSigner OS repo](https://github.com/SeedSigner/seedsigner-os/) for instructions.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * [Enclosure Designs](#enclosure-designs)
 * [SeedQR Printable Templates](#seedqr-printable-templates)
 * [Build from Source](#build-from-source)
-* [Developer Local Build Instructions](#developer-build-instructions)
+* [Developer Local Build Instructions](#developer-local-build-instructions)
 
 
 ---------------

--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -1,6 +1,6 @@
-# Raspberry Pi OS Build Instructions
+# Raspberry Pi OS Local Dev Build Instructions
 
-The released version of [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) does not use Raspberry Pi OS since version 0.6.0. These build instructions (previously referred to as "Manual Installation Instructions") are most commonly used by project contributors looking to do rapid development cycles. If this is what you'd like to do, then continue reading.
+Since v0.6.0, official releases use our custom [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) However, project contributors looking to do rapid development cycles typically use the older Raspberry Pi OS that we had previously built on prior to v0.6.0. If you're here to set up your SeedSigner for local development, continue reading.
 
 Begin by acquiring the latest 32-bit, Buster-based Raspberry Pi Lite operating system. This guide was tested using the version dated 2023-05-03; which can be found here:
 

--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -1,4 +1,6 @@
-# Manual Installation Instructions
+# Raspberry Pi OS Build Instructions
+
+The released version of [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) does not use Raspberry Pi OS since version 0.6.0. These build instructions (previously referred to as "Manual Installation Instructions") are most commonly used by projects contributors looking to do rapid development cycles and testing to app code. If this is what you'd like to do, then continue reading.
 
 Begin by acquiring the latest 32-bit, Buster-based Raspberry Pi Lite operating system. This guide was tested using the version dated 2023-05-03; which can be found here:
 

--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -1,6 +1,6 @@
 # Raspberry Pi OS Build Instructions
 
-The released version of [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) does not use Raspberry Pi OS since version 0.6.0. These build instructions (previously referred to as "Manual Installation Instructions") are most commonly used by project contributors looking to do rapid development cycles and testing to app code. If this is what you'd like to do, then continue reading.
+The released version of [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) does not use Raspberry Pi OS since version 0.6.0. These build instructions (previously referred to as "Manual Installation Instructions") are most commonly used by project contributors looking to do rapid development cycles. If this is what you'd like to do, then continue reading.
 
 Begin by acquiring the latest 32-bit, Buster-based Raspberry Pi Lite operating system. This guide was tested using the version dated 2023-05-03; which can be found here:
 

--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -1,6 +1,6 @@
 # Raspberry Pi OS Build Instructions
 
-The released version of [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) does not use Raspberry Pi OS since version 0.6.0. These build instructions (previously referred to as "Manual Installation Instructions") are most commonly used by projects contributors looking to do rapid development cycles and testing to app code. If this is what you'd like to do, then continue reading.
+The released version of [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os/) does not use Raspberry Pi OS since version 0.6.0. These build instructions (previously referred to as "Manual Installation Instructions") are most commonly used by project contributors looking to do rapid development cycles and testing to app code. If this is what you'd like to do, then continue reading.
 
 Begin by acquiring the latest 32-bit, Buster-based Raspberry Pi Lite operating system. This guide was tested using the version dated 2023-05-03; which can be found here:
 


### PR DESCRIPTION
## Description

The main README does not point to SeedSigner OS build instructions. This change keeps the old build instructions but retitles them as Raspberry Pi OS developer build instructions and also links to SeedSigner OS reproducible build steps.

This pull request is categorized as a:

- [X] Documentation

If you modified or added functionality/workflow, did you add new unit tests?

- [X] N/A
