### PR TITLE
Enable code linting via pre-commit + ruff and fix all findings

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+
+name: pre-commit
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Apply to all files without commiting:
+#   pre-commit run --all-files
+# Or enabled to run as git pre-commit hook:
+#   pre-commit install
+# Update this file:
+#   pre-commit autoupdate
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.289
+    hooks:
+      - id: ruff
+        # enable locally for auto-fixing what is possible
+        # args: [--fix]
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+# List of rules https://beta.ruff.rs/docs/rules/
+select = ["F"]

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -52,7 +52,7 @@ class BackgroundImportThread(BaseThread):
         # import seedsigner.hardware.buttons # slowly imports GPIO along the way
 
         def time_import(module_name):
-            last = time.time()
+            # last = time.time()
             import_module(module_name)
             # print(time.time() - last, module_name)
 
@@ -97,18 +97,18 @@ class Controller(Singleton):
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.
-    _storage: 'SeedStorage' = None   # TODO: Rename "storage" to something more indicative of its temp, in-memory state
+    _storage: 'SeedStorage' = None   # TODO: Rename "storage" to something more indicative of its temp, in-memory state # noqa
     settings: Settings = None
 
     # TODO: Refactor these flow-related attrs that survive across multiple Screens.
     # TODO: Should all in-memory flow-related attrs get wiped on MainMenuView?
-    psbt: 'embit.psbt.PSBT' = None
-    psbt_seed: 'Seed' = None
-    psbt_parser: 'PSBTParser' = None
+    psbt: 'embit.psbt.PSBT' = None  # noqa
+    psbt_seed: 'Seed' = None  # noqa
+    psbt_parser: 'PSBTParser' = None  # noqa
 
     unverified_address = None
 
-    multisig_wallet_descriptor: 'embit.descriptor.Descriptor' = None
+    multisig_wallet_descriptor: 'embit.descriptor.Descriptor' = None  # noqa
 
     image_entropy_preview_frames: list[Image] = None
     image_entropy_final_image: Image = None
@@ -129,8 +129,8 @@ class Controller(Singleton):
     resume_main_flow: str = None
 
     back_stack: BackStack = None
-    screensaver: 'ScreensaverScreen' = None
-    toast_notification_thread: 'BaseToastOverlayManagerThread' = None
+    screensaver: 'ScreensaverScreen' = None  # noqa
+    toast_notification_thread: 'BaseToastOverlayManagerThread' = None  # noqa
 
 
     @classmethod
@@ -205,7 +205,7 @@ class Controller(Singleton):
         return self._storage
 
 
-    def get_seed(self, seed_num: int) -> 'Seed':
+    def get_seed(self, seed_num: int) -> 'Seed':  # noqa
         if seed_num < len(self.storage.seeds):
             return self.storage.seeds[seed_num]
         else:
@@ -394,7 +394,7 @@ class Controller(Singleton):
         print("Controller: Screensaver started")
 
 
-    def activate_toast(self, toast_manager_thread: 'BaseToastOverlayManagerThread'):
+    def activate_toast(self, toast_manager_thread: 'BaseToastOverlayManagerThread'):  # noqa
         """
         Ensures that the Controller has explicit control over which processes get to
         claim the Renderer.lock and which need to (potentially) release it.

--- a/src/seedsigner/gui/__init__.py
+++ b/src/seedsigner/gui/__init__.py
@@ -1,1 +1,1 @@
-from .renderer import Renderer
+from .renderer import Renderer   # noqa

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -2,7 +2,6 @@ import math
 import os
 import pathlib
 import re
-from time import time
 
 from dataclasses import dataclass
 from decimal import Decimal
@@ -339,7 +338,7 @@ class TextArea(BaseComponent):
             # Multiply for the number of lines plus the spacer
             total_text_height = self.text_height_above_baseline * len(self.text_lines) + self.line_spacing * (len(self.text_lines) - 1)
 
-            if not self.height_ignores_below_baseline and re.findall(f"[gjpqy]", self.text_lines[-1]["text"]):
+            if not self.height_ignores_below_baseline and re.findall("[gjpqy]", self.text_lines[-1]["text"]):
                 # Last line has at least one char that dips below baseline
                 total_text_height += self.text_height_below_baseline
 
@@ -1346,7 +1345,6 @@ def reflow_text_for_width(text: str,
     # We have to figure out if and where to make line breaks in the text so that it
     #   fits in its bounding rect (plus accounting for edge padding) using its given
     #   font.
-    start = time()
     font = Fonts.get_font(font_name=font_name, size=font_size)
     # Measure from left baseline ("ls")
     (left, top, full_text_width, bottom) = font.getbbox(text, anchor="ls")

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 from typing import Tuple
 
 from seedsigner.gui.components import Fonts, GUIConstants
@@ -318,7 +318,6 @@ class Keyboard:
                 return None
 
         effective_index = 0
-        key = None
         for cur_key in self.keys[index_y]:
             if index_x >= effective_index and index_x < effective_index + cur_key.size:
                 return cur_key
@@ -552,7 +551,6 @@ class TextEntryDisplay(TextEntryDisplayConstants):
 
         if self.cursor_mode == TextEntryDisplay.CURSOR_MODE__BLOCK:
             cursor_block_width = 18
-            cursor_block_height = 33
 
             # Draw n-1 of the selected letters
             (left, top, right, bottom) = self.font.getbbox(self.cur_text[:-1], anchor="ls")

--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -1,7 +1,6 @@
 from PIL import Image, ImageDraw
 from threading import Lock
 
-from seedsigner.gui.components import Fonts, GUIConstants
 from seedsigner.hardware.ST7789 import ST7789
 from seedsigner.models.singleton import ConfigurableSingleton
 

--- a/src/seedsigner/gui/screens/__init__.py
+++ b/src/seedsigner/gui/screens/__init__.py
@@ -1,1 +1,1 @@
-from .screen import *
+from .screen import *  # noqa

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -6,8 +6,8 @@ import time
 from seedsigner.gui.renderer import Renderer
 from seedsigner.models.threads import BaseThread
 
-from .screen import ButtonListScreen, WarningScreen
-from ..components import (BtcAmount, Button, Icon, FontAwesomeIconConstants, IconTextLine, FormattedAddress, GUIConstants, Fonts, SeedSignerIconConstants, TextArea,
+from .screen import ButtonListScreen
+from ..components import (BtcAmount, Icon, FontAwesomeIconConstants, IconTextLine, FormattedAddress, GUIConstants, Fonts, SeedSignerIconConstants, TextArea,
     calc_bezier_curve, linear_interp)
 
 
@@ -136,11 +136,11 @@ class PSBTOverviewScreen(ButtonListScreen):
                     destination_column.append(truncate_destination_addr("self-transfer"))
             else:
                 # destination_column.append(f"{len(self.destination_addresses)} recipients")
-                destination_column.append(f"recipient 1")
-                destination_column.append(f"[ ... ]")
+                destination_column.append("recipient 1")
+                destination_column.append("[ ... ]")
                 destination_column.append(f"recipient {len(self.destination_addresses) + self.num_self_transfer_outputs}")
 
-            destination_column.append(f"fee")
+            destination_column.append("fee")
 
             if self.num_change_outputs > 0:
                 for i in range(0, self.num_change_outputs):
@@ -551,7 +551,7 @@ class PSBTMathScreen(ButtonListScreen):
         render_amount(
             cur_y,
             f"-{self.fee_amount}",
-            info_text=f""" fee""",
+            info_text=""" fee""",
         )
 
         cur_y += int(digits_height * 1.2) + 4 * ssf

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -9,8 +9,8 @@ from seedsigner.hardware.camera import Camera
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
 from seedsigner.models.threads import BaseThread
 
-from .screen import BaseScreen, ButtonListScreen
-from ..components import GUIConstants, Fonts, TextArea
+from .screen import BaseScreen
+from ..components import GUIConstants, Fonts
 
 
 
@@ -85,7 +85,6 @@ class ScanScreen(BaseScreen):
 
 
         def run(self):
-            from timeit import default_timer as timer
 
             instructions_font = Fonts.get_font(GUIConstants.BODY_FONT_NAME, GUIConstants.BUTTON_FONT_SIZE)
 

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -10,6 +10,7 @@ from seedsigner.gui.components import (GUIConstants,
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.renderer import Renderer
 from seedsigner.hardware.buttons import HardwareButtonsConstants, HardwareButtons
+from seedsigner.models.encode_qr import EncodeQR
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 
@@ -343,7 +344,6 @@ class ButtonListScreen(BaseTopNavScreen):
             self.down_arrow_img = Image.new("RGBA", size=(2 * self.arrow_half_width, 8), color="black")
             self.down_arrow_img_y = self.canvas_height - 16 + 2
             arrow_draw = ImageDraw.Draw(self.down_arrow_img)
-            center_x = int(self.canvas_width / 2)
             arrow_draw.line((self.arrow_half_width, 7, 0, 1), fill=GUIConstants.BUTTON_FONT_COLOR)
             arrow_draw.line((self.arrow_half_width, 7, 2 * self.arrow_half_width, 1), fill=GUIConstants.BUTTON_FONT_COLOR)
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -175,7 +175,6 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
 
         highlighted_row = 3
         num_possible_rows = 11
-        y = self.highlighted_row_y - GUIConstants.LIST_ITEM_PADDING - 3 * self.matches_list_row_height
 
         if not highlight_word:
             list_starting_index = self.selected_possible_words_index - highlighted_row
@@ -1185,8 +1184,8 @@ class SeedTranscribeSeedQRZoomedInScreen(BaseScreen):
         msg = "click to exit"
         font = Fonts.get_font(GUIConstants.BODY_FONT_NAME, GUIConstants.BODY_FONT_SIZE)
         (left, top, right, bottom) = font.getbbox(msg, anchor="ls")
-        msg_height = -1 * top
-        msg_width = right
+        # msg_height = -1 * top
+        # msg_width = right
         # draw.rectangle(
         #     (
         #         int((self.canvas_width - msg_width)/2 - GUIConstants.COMPONENT_PADDING),

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -3,10 +3,9 @@ import time
 from dataclasses import dataclass
 from PIL.ImageOps import autocontrast
 from typing import List
-from seedsigner.gui.components import Button, CheckboxButton, CheckedSelectionButton, FontAwesomeIconConstants, Fonts, GUIConstants, Icon, IconButton, IconTextLine, TextArea
-from seedsigner.gui.screens.scan_screens import ScanScreen
+from seedsigner.gui.components import Button, CheckboxButton, CheckedSelectionButton, FontAwesomeIconConstants, Fonts, GUIConstants, Icon, IconButton, TextArea
 
-from seedsigner.gui.screens.screen import BaseScreen, BaseTopNavScreen, ButtonListScreen
+from seedsigner.gui.screens.screen import BaseTopNavScreen, ButtonListScreen
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 from seedsigner.hardware.camera import Camera
 from seedsigner.models.settings import SettingsConstants

--- a/src/seedsigner/hardware/pivideostream.py
+++ b/src/seedsigner/hardware/pivideostream.py
@@ -2,7 +2,6 @@
 from picamera.array import PiRGBArray
 from picamera import PiCamera
 from threading import Thread
-import time
 
 
 # Modified from: https://github.com/jrosebr1/imutils

--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -2,7 +2,6 @@ import hashlib
 import unicodedata
 
 from embit import bip39
-from embit.bip39 import mnemonic_to_bytes, mnemonic_from_bytes
 from typing import List
 
 

--- a/src/seedsigner/helpers/ur2/bytewords.py
+++ b/src/seedsigner/helpers/ur2/bytewords.py
@@ -105,8 +105,8 @@ def decode(s, separator, word_len):
 
     # Validate checksum
     body = buf[0:-4]
-    body_checksum = buf[-4:]
-    checksum = crc32_bytes(body)
+    # body_checksum = buf[-4:]
+    # checksum = crc32_bytes(body)
     # if checksum != body_checksum:
     #     raise ValueError('Invalid Bytewords.')
 

--- a/src/seedsigner/helpers/ur2/fountain_decoder.py
+++ b/src/seedsigner/helpers/ur2/fountain_decoder.py
@@ -6,7 +6,7 @@
 #
 
 from .fountain_utils import choose_fragments, contains, is_strict_subset, set_difference
-from .utils import join_lists, join_bytes, crc32_int, xor_with, take_first
+from .utils import join_bytes, crc32_int, xor_with, take_first
 
 class InvalidPart(Exception):
     pass

--- a/src/seedsigner/helpers/ur2/fountain_encoder.py
+++ b/src/seedsigner/helpers/ur2/fountain_encoder.py
@@ -50,7 +50,7 @@ class Part:
             (data, _) = decoder.decodeBytes()
 
             return Part(seq_num, seq_len, message_len, checksum, data)
-        except Exception as err:
+        except Exception:
             raise InvalidHeader()
 
     def cbor(self):

--- a/src/seedsigner/helpers/ur2/ur_decoder.py
+++ b/src/seedsigner/helpers/ur2/ur_decoder.py
@@ -6,9 +6,9 @@
 #
 
 from .ur import UR
-from .fountain_encoder import FountainEncoder, Part as FountainEncoderPart
+from .fountain_encoder import Part as FountainEncoderPart
 from .fountain_decoder import FountainDecoder
-from .bytewords import *
+from .bytewords import Bytewords, Bytewords_Style_minimal
 from .utils import drop_first, is_ur_type
 
 class InvalidScheme(Exception):
@@ -135,7 +135,7 @@ class URDecoder:
                 self.result = self.fountain_decoder.result_error()
 
             return True
-        except Exception as err:
+        except Exception:
             return False
 
     def expected_type(self):

--- a/src/seedsigner/helpers/ur2/ur_encoder.py
+++ b/src/seedsigner/helpers/ur2/ur_encoder.py
@@ -6,7 +6,7 @@
 #
 
 from .fountain_encoder import FountainEncoder
-from .bytewords import *
+from .bytewords import Bytewords, Bytewords_Style_minimal
 
 class UREncoder:
     # Start encoding a (possibly) multi-part UR.

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -282,9 +282,10 @@ class DecodeQR:
         return self.qr_type == QRType.BITCOIN_ADDRESS
         
 
-    @property
-    def is_sign_message(self):
-        return self.qr_type == QRType.SIGN_MESSAGE
+    # not reachable as overwitten by the `is_sign_message` static method below
+    # @property
+    # def is_sign_message(self):
+    #    return self.qr_type == QRType.SIGN_MESSAGE
         
 
     @property
@@ -419,7 +420,7 @@ class DecodeQR:
                 # print(bitstream)
 
                 return QRType.SEED__COMPACTSEEDQR
-            except Exception as e:
+            except Exception:
                 # Couldn't extract byte data; assume it's not a byte format
                 pass
 
@@ -556,7 +557,7 @@ class DecodeQR:
                     m = int(match.group(1))
                     n = int(match.group(2))
                 except:
-                    raise Exception(f"Policy line not supported")
+                    raise Exception("Policy line not supported")
             elif label == 'derivation':
                 derivation = value
             elif label == 'format':
@@ -570,16 +571,16 @@ class DecodeQR:
                 x += 1
         
         if None in xpubs or len(xpubs) != n:
-            raise Exception(f"bad or missing xpub")
+            raise Exception("bad or missing xpub")
         
         if m <= 0 or m > 9 or n <= 0 or n > 9:
-            raise Exception(f"bad or missing policy")
+            raise Exception("bad or missing policy")
         
         if len(derivation) == 0:
-            raise Exception(f"bad or missing derivation path")
+            raise Exception("bad or missing derivation path")
         
         if script_type not in ['p2wsh', 'p2sh-p2wsh', 'p2wsh-p2sh']:
-            raise Exception(f"bad or missing script format")
+            raise Exception("bad or missing script format")
         
         # create descriptor string
         
@@ -787,7 +788,7 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
                     return DecodeQRStatus.COMPLETE
                 else:
                     return DecodeQRStatus.INVALID
-            except Exception as e:
+            except Exception:
                 return DecodeQRStatus.INVALID
 
         if qr_type == QRType.SEED__COMPACTSEEDQR:
@@ -815,7 +816,7 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
                 self.complete = True
                 self.collected_segments = 1
                 return DecodeQRStatus.COMPLETE
-            except Exception as e:
+            except Exception:
                 return DecodeQRStatus.INVALID
 
         elif qr_type == QRType.SEED__FOUR_LETTER_MNEMONIC:
@@ -838,7 +839,7 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
                 self.complete = True
                 self.collected_segments = 1
                 return DecodeQRStatus.COMPLETE
-            except Exception as e:
+            except Exception:
                 return DecodeQRStatus.INVALID
 
         else:

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -1,11 +1,9 @@
 import math
 
 from embit import bip32
-from embit.networks import NETWORKS
 from binascii import b2a_base64, hexlify
 from dataclasses import dataclass
 from typing import List
-from embit import bip32
 from embit.networks import NETWORKS
 from embit.psbt import PSBT
 from seedsigner.helpers.ur2.ur_encoder import UREncoder

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -62,7 +62,7 @@ class PSBTParser():
 
     def parse(self):
         if self.psbt is None:
-            print(f"self.psbt is None!!")
+            print("self.psbt is None!!")
             return False
 
         if not self.seed:

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -37,7 +37,7 @@ class SeedStorage:
     def validate_mnemonic(self, mnemonic: List[str]) -> bool:
         try:
             Seed(mnemonic=mnemonic)
-        except InvalidSeedException as e:
+        except InvalidSeedException:
             return False
         
         return True

--- a/src/seedsigner/views/__init__.py
+++ b/src/seedsigner/views/__init__.py
@@ -1,1 +1,1 @@
-from .view import *  # base class has to be first
+from .view import *  # base class has to be first  # noqa

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -2,12 +2,11 @@ import re
 
 from embit.descriptor import Descriptor
 
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.settings_views import SettingsIngestSettingsQRView
-from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, OptionDisabledView, View, Destination
+from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
 
 
 
@@ -178,7 +177,7 @@ class ScanPSBTView(ScanView):
 
 class ScanSeedQRView(ScanView):
     instructions_text = "Scan SeedQR"
-    invalid_qr_type_message = f"Expected a SeedQR"
+    invalid_qr_type_message = "Expected a SeedQR"
 
     @property
     def is_valid_qr_type(self):

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -134,8 +134,6 @@ class ScreensaverScreen(LogoScreen):
         # Store the current screen in order to restore it later
         self.last_screen = self.renderer.canvas.copy()
 
-        screensaver_start = int(time.time() * 1000)
-
         # Screensaver must block any attempts to use the Renderer in another thread so it
         # never gives up the lock until it returns.
         with self.renderer.lock:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -14,7 +14,6 @@ from seedsigner.helpers import embit_utils
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens)
 from seedsigner.gui.screens.screen import LargeIconStatusScreen, QRDisplayScreen
-from seedsigner.helpers import embit_utils
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.encode_qr import EncodeQR
 from seedsigner.models.psbt_parser import PSBTParser
@@ -272,7 +271,7 @@ class SeedMnemonicInvalidView(View):
             WarningScreen,
             title="Invalid Mnemonic!",
             status_headline=None,
-            text=f"Checksum failure; not a valid seed phrase.",
+            text="Checksum failure; not a valid seed phrase.",
             show_back_button=False,
             button_data=button_data,
         )
@@ -1092,7 +1091,7 @@ class SeedBIP85InvalidChildIndexView(View):
         DireWarningScreen(
             title="BIP-85 Index Error",
             show_back_button=False,
-            status_headline=f"Invalid Child Index",
+            status_headline="Invalid Child Index",
             text=f"BIP-85 Child Index must be between 0 and {2**31-1}.",
             button_data=["Try Again"]
         ).display()
@@ -1232,7 +1231,7 @@ class SeedWordsBackupTestMistakeView(View):
         selected_menu_num = DireWarningScreen(
             title="Verification Error",
             show_back_button=False,
-            status_headline=f"Wrong Word!",
+            status_headline="Wrong Word!",
             text=f"Word #{self.cur_index + 1} is not \"{self.wrong_word}\"!",
             button_data=button_data,
         ).display()

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 import hashlib
 import os
 import time
@@ -280,7 +279,7 @@ class ToolsCalcFinalWordFinalizePromptView(View):
             num_entropy_bits = 3
 
         COIN_FLIPS = "Coin flip entropy"
-        SELECT_WORD = f"Word selection entropy"
+        SELECT_WORD = "Word selection entropy"
         ZEROS = "Finalize with zeros"
 
         button_data = [COIN_FLIPS, SELECT_WORD, ZEROS]

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -2,10 +2,9 @@ import embit
 import os
 import sys
 import time
-from mock import Mock, patch, MagicMock
+from mock import Mock, MagicMock
 from seedsigner.helpers import embit_utils
 
-from seedsigner.models.settings import Settings
 
 
 # Prevent importing modules w/Raspi hardware dependencies.
@@ -22,8 +21,6 @@ sys.modules['seedsigner.hardware.microsd'] = MagicMock()
 from seedsigner.controller import Controller
 from seedsigner.gui.renderer import Renderer
 from seedsigner.gui.toast import BaseToastOverlayManagerThread, RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
-from seedsigner.hardware.buttons import HardwareButtons
-from seedsigner.hardware.camera import Camera
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.qr_type import QRType
@@ -235,7 +232,7 @@ def test_generate_screenshots(target_locale):
         ]
     }
 
-    readme = f"""# SeedSigner Screenshots\n"""
+    readme = """# SeedSigner Screenshots\n"""
 
     def screencap_view(view_cls: View, view_name: str, view_args: dict={}, toast_thread: BaseToastOverlayManagerThread = None):
         screenshot_renderer.set_screenshot_filename(f"{view_name}.png")
@@ -269,7 +266,7 @@ def test_generate_screenshots(target_locale):
         readme += "\n\n---\n\n"
         readme += f"## {section_name}\n\n"
         readme += """<table style="border: 0;">"""
-        readme += f"""<tr><td align="center">\n"""
+        readme += """<tr><td align="center">\n"""
         for screenshot in screenshot_list:
             if type(screenshot) == tuple:
                 if len(screenshot) == 2:

--- a/tests/test_bip85.py
+++ b/tests/test_bip85.py
@@ -1,9 +1,5 @@
-import pytest
-from mock import MagicMock
 from seedsigner.models.seed import Seed
-from embit import bip39
 
-from seedsigner.models.settings import SettingsConstants
 
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -22,7 +22,7 @@ class TestController(BaseTest):
     def test_singleton_init_fails(self):
         """ The Controller should not allow any code to instantiate it via Controller() """
         with pytest.raises(Exception):
-            c = Controller()
+            Controller()
 
 
     def test_handle_exception(reset_controller):

--- a/tests/test_decodepsbtqr.py
+++ b/tests/test_decodepsbtqr.py
@@ -283,8 +283,6 @@ def test_short_4_letter_mnemonic_qr():
 
 def test_bitcoin_address():    
     bad1 = "loremipsum"
-    bad2 = "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"
-    bad3 = "121802020768124106400009195602431595117715840445"
     
     legacy_address1 = "1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY"
     legacy_address2 = "16ftSEQ4ctQFDtVZiUBusQUjRrGhM3JYwe"
@@ -296,7 +294,6 @@ def test_bitcoin_address():
     test_nested_segwit_address = "2N6JbrvPMMwbBhu2KxqXyyHUQz3XKspvyfm"
     
     main_bech32_address2 = "bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?amount=12000"
-    main_bech32_address3 = "BITCOIN:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?junk"
     
     d = DecodeQR()
     d.add_data(bad1)

--- a/tests/test_decodepsbtqr.py
+++ b/tests/test_decodepsbtqr.py
@@ -283,6 +283,9 @@ def test_short_4_letter_mnemonic_qr():
 
 def test_bitcoin_address():    
     bad1 = "loremipsum"
+    # TODO: use for negative test cases
+    # bad2 = "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"
+    # bad3 = "121802020768124106400009195602431595117715840445"
     
     legacy_address1 = "1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY"
     legacy_address2 = "16ftSEQ4ctQFDtVZiUBusQUjRrGhM3JYwe"

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -373,7 +373,6 @@ def test_parse_derivation_path():
         (None, SC.CUSTOM_DERIVATION, False, 5): "m/123'/9083270/9083270/9083270/9083270/0/5",
 
         # non-standard change and/or index
-        (None, SC.CUSTOM_DERIVATION, None, 5): "m/9'/78/5",
         (None, SC.CUSTOM_DERIVATION, None, 5): "m/9'/78'/5",
         (None, SC.CUSTOM_DERIVATION, None, None): "m/9'/78'/5'",
         (None, SC.CUSTOM_DERIVATION, False, None): "m/9'/0/5'",

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -373,6 +373,7 @@ def test_parse_derivation_path():
         (None, SC.CUSTOM_DERIVATION, False, 5): "m/123'/9083270/9083270/9083270/9083270/0/5",
 
         # non-standard change and/or index
+        # (None, SC.CUSTOM_DERIVATION, None, 5): "m/9'/78/5", # TODO
         (None, SC.CUSTOM_DERIVATION, None, 5): "m/9'/78'/5",
         (None, SC.CUSTOM_DERIVATION, None, None): "m/9'/78'/5'",
         (None, SC.CUSTOM_DERIVATION, False, None): "m/9'/0/5'",

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -17,7 +17,7 @@ def test_ur_qr_encode():
     cnt = 0
     while cnt <= 10:
         fragment = e.next_part()
-        img = e.part_to_image(fragment)
+        e.part_to_image(fragment)
         cnt += 1
 
 
@@ -55,7 +55,7 @@ def test_specter_qr_encode():
         elif (cnt+1) == 11:
             assert fragment == "p11of117 REKtbWkqONAvETqIlMPWJ/f1uBvSCGFm+zzDYnnEBtuAYjZiQrzj9mFLQz4JUwAAC"
         
-        img = e.part_to_image(fragment)
+        e.part_to_image(fragment)
         cnt += 1
 
 

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -1,6 +1,5 @@
 from base import FlowTest, FlowStep
 
-from seedsigner.controller import Controller
 from seedsigner.views.view import MainMenuView
 from seedsigner.views import scan_views, seed_views, psbt_views
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -8,8 +8,8 @@ from base import FlowTestRunScreenNotExecutedException, FlowTestInvalidButtonDat
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import Seed
-from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView
-from seedsigner.views import seed_views, scan_views, settings_views, tools_views
+from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
+from seedsigner.views import seed_views, scan_views, settings_views
 
 
 def load_seed_into_decoder(view: scan_views.ScanView):
@@ -172,7 +172,7 @@ class TestSeedFlows(FlowTest):
         self.settings.set_value(SettingsConstants.SETTING__COORDINATORS, [x for x,y in coordinators if x!=disabled_coord])
 
         # test that multisig is not an option via exception raised when redirected to next step instead of having a choice
-        with pytest.raises(FlowTestRunScreenNotExecutedException) as e:
+        with pytest.raises(FlowTestRunScreenNotExecutedException):
             self.run_sequence(
                 initial_destination_view_args=dict(seed_num=0),
                 sequence=[
@@ -182,7 +182,7 @@ class TestSeedFlows(FlowTest):
             )
 
         # test that taproot is not an option via exception raised when choice is taproot
-        with pytest.raises(FlowTestInvalidButtonDataSelectionException) as e:
+        with pytest.raises(FlowTestInvalidButtonDataSelectionException):
             self.run_sequence(
                 initial_destination_view_args=dict(seed_num=0),
                 sequence=[
@@ -193,7 +193,7 @@ class TestSeedFlows(FlowTest):
             )
 
         # test that nunchuk is not an option via exception raised when choice is nunchuk
-        with pytest.raises(FlowTestInvalidButtonDataSelectionException) as e:
+        with pytest.raises(FlowTestInvalidButtonDataSelectionException):
             self.run_sequence(
                 initial_destination_view_args=dict(seed_num=0),
                 sequence=[

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,6 +1,5 @@
 from seedsigner.models.seed import Seed
 
-from seedsigner.models.settings import SettingsConstants
 
 
 

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -1,12 +1,9 @@
 import os
-import pyzbar
 from embit import bip39
 from seedsigner.helpers.qr import QR
-from seedsigner.helpers.ur2.bytewords import decode
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
 from seedsigner.models.encode_qr import EncodeQR
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.settings import SettingsConstants
 
 
 


### PR DESCRIPTION
## Description

pre-commit: The pre-commit framework became pretty widely use in recent years, especially in the Python world, where it originates from. There are many hooks for different routine checks like linting and code formatting, see also https://pre-commit.com/hooks.html. The hooks are configured in a file called `.pre-commit-config.yaml` and so don't pollute the `requirements*.txt` files. pre-commit locally installed via pip and can be added as git pre-commit hook via running `pre-commit install` or just be executed on cli (or IDE on very file change) via `pre-commit run --all`. Added this as comments to the config file. With clever selections of hooks a runtime of <5 seconds can be achieved for a good developer experience, when running on every change. The config contains some standard hooks and ruff as Python code linter.

ruff: https://github.com/astral-sh/ruff is proposed as Python linter as it is super fast (due to implemented in Rust) and implements lots of lints/tests from flake8/bandit/pyupgrade/pylint and more and more big projects are starting to adopt it.

This PR introduces pre-commit as concept and ruff with only the test category "F" enabled to keep the amount of fixes reviewable. An added GH workflow runs it on every PR to check that there no findings introduced.

The category "F" already finds lots of things, that are fixed by this PR, like duplicated imports, un-used return-values, un-reachable code, un-used variables etc, see bellow for a full list. One exception are the type annotations in the controller.py, which are non-standard: Decided to add `# noqa` so that ruff ignores those and resolving those can be tried in a followup PR.

This PR should contain no real functional changes, though it still requires very careful reviews.

Further PRs can add more hooks and/or enable more ruff test categories, if sensible.

<details>
  <summary>Click me to see what is fixed</summary>
  
  ```
src/seedsigner/controller.py:55:13: F841 [*] Local variable `last` is assigned to but never used
src/seedsigner/controller.py:100:16: F821 Undefined name `SeedStorage`
src/seedsigner/controller.py:105:12: F821 Undefined name `embit`
src/seedsigner/controller.py:106:17: F821 Undefined name `Seed`
src/seedsigner/controller.py:107:19: F821 Undefined name `PSBTParser`
src/seedsigner/controller.py:111:34: F821 Undefined name `embit`
src/seedsigner/controller.py:132:19: F821 Undefined name `ScreensaverScreen`
src/seedsigner/controller.py:133:33: F821 Undefined name `BaseToastOverlayManagerThread`
src/seedsigner/controller.py:208:43: F821 Undefined name `Seed`
src/seedsigner/controller.py:397:53: F821 Undefined name `BaseToastOverlayManagerThread`
src/seedsigner/gui/__init__.py:1:23: F401 [*] `.renderer.Renderer` imported but unused
src/seedsigner/gui/components.py:342:70: F541 [*] f-string without any placeholders
src/seedsigner/gui/components.py:1349:5: F841 [*] Local variable `start` is assigned to but never used
src/seedsigner/gui/keyboard.py:2:35: F401 [*] `PIL.ImageFont` imported but unused
src/seedsigner/gui/keyboard.py:321:9: F841 [*] Local variable `key` is assigned to but never used
src/seedsigner/gui/keyboard.py:555:13: F841 [*] Local variable `cursor_block_height` is assigned to but never used
src/seedsigner/gui/renderer.py:4:39: F401 [*] `seedsigner.gui.components.Fonts` imported but unused
src/seedsigner/gui/renderer.py:4:46: F401 [*] `seedsigner.gui.components.GUIConstants` imported but unused
src/seedsigner/gui/screens/__init__.py:1:1: F403 `from .screen import *` used; unable to detect undefined names
src/seedsigner/gui/screens/psbt_screens.py:9:39: F401 [*] `.screen.WarningScreen` imported but unused
src/seedsigner/gui/screens/psbt_screens.py:10:38: F401 [*] `..components.Button` imported but unused
src/seedsigner/gui/screens/psbt_screens.py:139:43: F541 [*] f-string without any placeholders
src/seedsigner/gui/screens/psbt_screens.py:140:43: F541 [*] f-string without any placeholders
src/seedsigner/gui/screens/psbt_screens.py:143:39: F541 [*] f-string without any placeholders
src/seedsigner/gui/screens/psbt_screens.py:554:23: F541 [*] f-string without any placeholders
src/seedsigner/gui/screens/scan_screens.py:12:33: F401 [*] `.screen.ButtonListScreen` imported but unused
src/seedsigner/gui/screens/scan_screens.py:13:47: F401 [*] `..components.TextArea` imported but unused
src/seedsigner/gui/screens/scan_screens.py:88:49: F401 [*] `timeit.default_timer` imported but unused
src/seedsigner/gui/screens/screen.py:346:13: F841 [*] Local variable `center_x` is assigned to but never used
src/seedsigner/gui/screens/screen.py:660:18: F821 Undefined name `EncodeQR`
src/seedsigner/gui/screens/screen.py:663:41: F821 Undefined name `EncodeQR`
src/seedsigner/gui/screens/seed_screens.py:178:9: F841 [*] Local variable `y` is assigned to but never used
src/seedsigner/gui/screens/seed_screens.py:1188:9: F841 [*] Local variable `msg_height` is assigned to but never used
src/seedsigner/gui/screens/seed_screens.py:1189:9: F841 [*] Local variable `msg_width` is assigned to but never used
src/seedsigner/gui/screens/settings_screens.py:6:152: F401 [*] `seedsigner.gui.components.IconTextLine` imported but unused
src/seedsigner/gui/screens/settings_screens.py:7:49: F401 [*] `seedsigner.gui.screens.scan_screens.ScanScreen` imported but unused
src/seedsigner/gui/screens/settings_screens.py:9:43: F401 [*] `seedsigner.gui.screens.screen.BaseScreen` imported but unused
src/seedsigner/hardware/pivideostream.py:5:8: F401 [*] `time` imported but unused
src/seedsigner/helpers/mnemonic_generation.py:5:25: F401 [*] `embit.bip39.mnemonic_to_bytes` imported but unused
src/seedsigner/helpers/mnemonic_generation.py:5:44: F401 [*] `embit.bip39.mnemonic_from_bytes` imported but unused
src/seedsigner/helpers/ur2/bytewords.py:108:5: F841 [*] Local variable `body_checksum` is assigned to but never used
src/seedsigner/helpers/ur2/bytewords.py:109:5: F841 [*] Local variable `checksum` is assigned to but never used
src/seedsigner/helpers/ur2/fountain_decoder.py:9:20: F401 [*] `.utils.join_lists` imported but unused
src/seedsigner/helpers/ur2/fountain_encoder.py:53:29: F841 [*] Local variable `err` is assigned to but never used
src/seedsigner/helpers/ur2/ur_decoder.py:9:31: F401 [*] `.fountain_encoder.FountainEncoder` imported but unused
src/seedsigner/helpers/ur2/ur_decoder.py:11:1: F403 `from .bytewords import *` used; unable to detect undefined names
src/seedsigner/helpers/ur2/ur_decoder.py:46:16: F405 `Bytewords` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_decoder.py:46:33: F405 `Bytewords_Style_minimal` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_decoder.py:123:20: F405 `Bytewords` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_decoder.py:123:37: F405 `Bytewords_Style_minimal` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_decoder.py:138:29: F841 [*] Local variable `err` is assigned to but never used
src/seedsigner/helpers/ur2/ur_encoder.py:9:1: F403 `from .bytewords import *` used; unable to detect undefined names
src/seedsigner/helpers/ur2/ur_encoder.py:20:16: F405 `Bytewords` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_encoder.py:20:33: F405 `Bytewords_Style_minimal` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_encoder.py:47:16: F405 `Bytewords` may be undefined, or defined from star imports
src/seedsigner/helpers/ur2/ur_encoder.py:47:33: F405 `Bytewords_Style_minimal` may be undefined, or defined from star imports
src/seedsigner/models/decode_qr.py:422:33: F841 [*] Local variable `e` is assigned to but never used
src/seedsigner/models/decode_qr.py:506:9: F811 Redefinition of unused `is_sign_message` from line 286
src/seedsigner/models/decode_qr.py:559:37: F541 [*] f-string without any placeholders
src/seedsigner/models/decode_qr.py:573:29: F541 [*] f-string without any placeholders
src/seedsigner/models/decode_qr.py:576:29: F541 [*] f-string without any placeholders
src/seedsigner/models/decode_qr.py:579:29: F541 [*] f-string without any placeholders
src/seedsigner/models/decode_qr.py:582:29: F541 [*] f-string without any placeholders
src/seedsigner/models/decode_qr.py:790:33: F841 [*] Local variable `e` is assigned to but never used
src/seedsigner/models/decode_qr.py:818:33: F841 [*] Local variable `e` is assigned to but never used
src/seedsigner/models/decode_qr.py:841:33: F841 [*] Local variable `e` is assigned to but never used
src/seedsigner/models/encode_qr.py:8:19: F811 Redefinition of unused `bip32` from line 3
src/seedsigner/models/encode_qr.py:9:28: F811 Redefinition of unused `NETWORKS` from line 4
src/seedsigner/models/psbt_parser.py:65:19: F541 [*] f-string without any placeholders
src/seedsigner/models/seed_storage.py:40:40: F841 [*] Local variable `e` is assigned to but never used
src/seedsigner/views/__init__.py:1:1: F403 `from .view import *` used; unable to detect undefined names
src/seedsigner/views/scan_views.py:5:43: F401 [*] `seedsigner.gui.screens.screen.RET_CODE__BACK_BUTTON` imported but unused
src/seedsigner/views/scan_views.py:10:98: F401 [*] `seedsigner.views.view.OptionDisabledView` imported but unused
src/seedsigner/views/scan_views.py:181:31: F541 [*] f-string without any placeholders
src/seedsigner/views/screensaver.py:137:9: F841 [*] Local variable `screensaver_start` is assigned to but never used
src/seedsigner/views/seed_views.py:17:32: F811 Redefinition of unused `embit_utils` from line 13
src/seedsigner/views/seed_views.py:275:18: F541 [*] f-string without any placeholders
src/seedsigner/views/seed_views.py:1095:29: F541 [*] f-string without any placeholders
src/seedsigner/views/seed_views.py:1235:29: F541 [*] f-string without any placeholders
src/seedsigner/views/tools_views.py:1:25: F401 [*] `dataclasses.dataclass` imported but unused
src/seedsigner/views/tools_views.py:283:23: F541 [*] f-string without any placeholders
tests/screenshot_generator/generator.py:5:24: F401 [*] `mock.patch` imported but unused
tests/screenshot_generator/generator.py:8:40: F401 [*] `seedsigner.models.settings.Settings` imported but unused
tests/screenshot_generator/generator.py:25:41: F401 [*] `seedsigner.hardware.buttons.HardwareButtons` imported but unused
tests/screenshot_generator/generator.py:26:40: F401 [*] `seedsigner.hardware.camera.Camera` imported but unused
tests/screenshot_generator/generator.py:238:14: F541 [*] f-string without any placeholders
tests/screenshot_generator/generator.py:272:19: F541 [*] f-string without any placeholders
tests/test_bip85.py:1:8: F401 [*] `pytest` imported but unused
tests/test_bip85.py:2:18: F401 [*] `mock.MagicMock` imported but unused
tests/test_bip85.py:4:19: F401 [*] `embit.bip39` imported but unused
tests/test_bip85.py:6:40: F401 [*] `seedsigner.models.settings.SettingsConstants` imported but unused
tests/test_controller.py:25:13: F841 [*] Local variable `c` is assigned to but never used
tests/test_decodepsbtqr.py:286:5: F841 [*] Local variable `bad2` is assigned to but never used
tests/test_decodepsbtqr.py:287:5: F841 [*] Local variable `bad3` is assigned to but never used
tests/test_decodepsbtqr.py:299:5: F841 [*] Local variable `main_bech32_address3` is assigned to but never used
tests/test_embit_utils.py:377:9: F601 Dictionary key literal `(None, SC.CUSTOM_DERIVATION, None, 5)` repeated
tests/test_encodepsbtqr.py:20:9: F841 [*] Local variable `img` is assigned to but never used
tests/test_encodepsbtqr.py:58:9: F841 [*] Local variable `img` is assigned to but never used
tests/test_flows_psbt.py:3:35: F401 [*] `seedsigner.controller.Controller` imported but unused
tests/test_flows_seed.py:11:80: F401 [*] `seedsigner.views.view.RemoveMicroSDWarningView` imported but unused
tests/test_flows_seed.py:12:70: F401 [*] `seedsigner.views.tools_views` imported but unused
tests/test_flows_seed.py:196:76: F841 [*] Local variable `e` is assigned to but never used
tests/test_seed.py:3:40: F401 [*] `seedsigner.models.settings.SettingsConstants` imported but unused
tests/test_seedqr.py:2:8: F401 [*] `pyzbar` imported but unused
tests/test_seedqr.py:5:46: F401 [*] `seedsigner.helpers.ur2.bytewords.decode` imported but unused
tests/test_seedqr.py:9:40: F401 [*] `seedsigner.models.settings.SettingsConstants` imported but unused
  ```
</details>

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
