### PR TITLE
[Bugfix] Xpub export can select the wrong coordinator

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -718,19 +718,24 @@ class SeedExportXpubCoordinatorView(View):
             args["coordinator"] = self.settings.get_value(SettingsConstants.SETTING__COORDINATORS)[0]
             return Destination(SeedExportXpubWarningView, view_args=args, skip_current_view=True)
 
+        button_data = self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__COORDINATORS)
+
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title="Export Xpub",
             is_button_text_centered=False,
-            button_data=self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__COORDINATORS),
+            button_data=button_data,
         )
 
-        if selected_menu_num < len(self.settings.get_value(SettingsConstants.SETTING__COORDINATORS)):
-            args["coordinator"] = self.settings.get_value(SettingsConstants.SETTING__COORDINATORS)[selected_menu_num]
-            return Destination(SeedExportXpubWarningView, view_args=args)
-
-        elif selected_menu_num == RET_CODE__BACK_BUTTON:
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
+
+        coordinators_settings_entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__COORDINATORS)
+        selected_display_name = button_data[selected_menu_num]
+        args["coordinator"] = coordinators_settings_entry.get_selection_option_value_by_display_name(selected_display_name)
+
+        return Destination(SeedExportXpubWarningView, view_args=args)
+
 
 
 


### PR DESCRIPTION
## Description

### How to reproduce the bug:
* Go to Settings -> Coordinators and enable a few coordinators (end up with at least one enabled) but exclude BlueWallet.
* Do a final update and enable BlueWallet.
* Load a seed and begin the xpub export flow.
* At the coordinator selection screen, choose BlueWallet.
* Note your debugging output on the next screen; "coordinator" will NOT be "bw".
* Alternatively, if the resulting xpub QR is animated, it's obviously targeting a different coordinator (BlueWallet xpub QRs should always be static)

### What is happening?
Multiselect options just pop or append to a list of available options. In this flow, BlueWallet is now at the end of the list.

But the coordinator selection View is assuming that the options are sorted the way they're defined in the SettingsEntry for that attribute (see: `SettingsConstants.ALL_COORDINATORS`).


### The fix
Use the SettingsEntry to retrieve the selected coordinator via `get_selection_option_value_by_display_name` which is completely independent of any ordering.
 

This pull request is categorized as a:

- [x] Bug fix

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A (??)

Though this bug is sequence-dependent, I didn't think it merited a flow-based test since the ultimate problem was just that the View wasn't using the best technique to retrieve its selected value.

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
