### PR TITLE
Use mock from Python stdlib and upgrade test requirements versions

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass
-from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from typing import Callable
 
 # Prevent importing modules w/Raspi hardware dependencies.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-coverage==7.2.1
-mock==4.0.3
-pytest==6.2.4
+coverage==7.3.1
+pytest==7.4.2
 pytest-cov==4.1.0

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -2,7 +2,7 @@ import embit
 import os
 import sys
 import time
-from mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock
 from seedsigner.helpers import embit_utils
 
 from seedsigner.models.settings import Settings

--- a/tests/test_bip85.py
+++ b/tests/test_bip85.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 from seedsigner.models.seed import Seed
 from embit import bip39
 

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -1,7 +1,7 @@
 import os
 from typing import Callable
 
-from mock import PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
 # Must import test base before the Controller
 from base import FlowTest, FlowStep

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 # Must import test base before the Controller
 from base import FlowTest, FlowStep


### PR DESCRIPTION
## Description

mock is part of the Python standard lib since Python 3.3, see also https://docs.python.org/3/library/unittest.mock.html. Switching to that allows to remove it from `test/requirements.txt`.

While at it, also updating the package versions in `test/requirements.txt`.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
