### PR TITLE
Enable image builds with badge and add os-ref param for manual builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,22 @@
 name: Build
 
 on:
+  schedule:
+    # Build daily at 5:30 UTC
+    - cron:  '30 5 * * *'
   workflow_dispatch:
+    inputs:
+      os-ref:
+        description: The seedsigner-os ref (tag/branch/sha1) to use
+        default: main
+        required: true
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    # Prevent resource consuming cron triggered runs in forks
+    if: (!github.event.repository.fork || github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:
@@ -16,25 +26,41 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "seedsigner/seedsigner-os"
+          # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.os-ref || 'main' }}
           submodules: true
           path: "seedsigner-os"
-
-      - name: get seedsigner-os latest commit hash
-        id: get-seedsigner-os-hash
-        run: |
-          cd seedsigner-os
-          echo "builder_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          # get full history + tags for "git describe"
+          fetch-depth: 0
 
       - name: checkout source
         uses: actions/checkout@v3
         with:
+          # ref defaults to repo default-branch=dev (cron) or SHA of event (workflow_dispatch)
           path: "seedsigner-os/opt/rootfs-overlay/opt"
+          # get full history + tags for "git describe"
+          fetch-depth: 0
 
-      - name: get seedsigner latest commit hash
-        id: get-seedsigner-hash
+      - name: Get and set meta data
         run: |
-          git init
-          echo "source_hash=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+          # The builder_hash (seedsigner-os hash) for the cache action step key
+          echo "builder_hash=$(git -C seedsigner-os rev-parse --short HEAD)"| tee -a $GITHUB_ENV
+
+          # Derive tag based versions, like 0.7.0-40-g0424967 (=$tag-$number-of-commits-since-tag-$short-sha1),
+          # or just e.g. 0.7.0, if we are exactly on a 0.7.0 tagged commit.
+          # --always to fall back to commit sha, if no tag present like in partial forks of the repo
+          os_version="$(git -C seedsigner-os describe --tags --always)"
+          source_version="$(git -C seedsigner-os/opt/rootfs-overlay/opt describe --tags --always)"
+
+          # Combine seedsigner and seedsigner-os version into one version string and squash the versions, if
+          # they are identical: So os_version=0.7.0 + source_version=0.7.0 combine to just only "0.7.0",
+          # whereas os_version=0.6.0-61-g9fafebe + source_version=0.7.0-40-g0424967 combine to "os0.6.0-61-g9fafebe_sw0.7.0-40-g0424967"
+          if [ "${os_version}" = "${source_version}" ]; then
+            # seedsigner + seedsigner_os have the same tag
+            echo "img_version=${source_version}"| tee -a $GITHUB_ENV
+          else
+            echo "img_version=os${os_version}_sw${source_version}"| tee -a $GITHUB_ENV
+          fi
 
       - name: delete unnecessary files
         run: |
@@ -44,11 +70,9 @@ jobs:
           ls -la src
 
       - name: restore build cache
-        id: build-cache-restore
-        uses: actions/cache/restore@v3
-        # Caching seedsigner-os/buildroot_dl is optional.
-        # Caching it can save a small amount of build time,
-        # but it will occupy a larger amount of storage space.
+        uses: actions/cache@v3
+        # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
+        # while consuming ~850 MB storage space).
         with:
           path: |
             ~/.buildroot-ccache/
@@ -62,16 +86,6 @@ jobs:
           cd seedsigner-os/opt
           ./build.sh --${{ matrix.target }} --skip-repo --no-clean
 
-      - name: save build cache
-        id: build-cache-save
-        if: steps.build-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ~/.buildroot-ccache/
-            seedsigner-os/buildroot_dl
-          key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
-
       - name: list image (before rename)
         run: |
           ls -la seedsigner-os/images
@@ -79,7 +93,7 @@ jobs:
       - name: rename image
         run: |
           cd seedsigner-os/images
-          mv seedsigner_os*.img seedsigner_os.${{ env.source_hash }}.${{ matrix.target }}.img
+          mv seedsigner_os*.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
 
       - name: print sha256sum
         run: |
@@ -96,6 +110,7 @@ jobs:
           name: seedsigner_os_images
           path: "seedsigner-os/images/*.img"
           if-no-files-found: error
+          retention-days: 7
 
   sha256sum:
     name: calculate sha256sum
@@ -129,3 +144,4 @@ jobs:
           name: seedsigner_os_images
           path: "images/*.sha256"
           if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
 on:
+  pull_request:
+    # Build on changes to this workflow files in PRs to test proposed changes
+    paths:
+      - '.github/workflows/build.yml'
   schedule:
     # Build daily at 5:30 UTC
     - cron:  '30 5 * * *'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,15 +5,19 @@ on:
     # Build on changes to this workflow files in PRs to test proposed changes
     paths:
       - '.github/workflows/build.yml'
-  schedule:
-    # Build daily at 5:30 UTC
-    - cron:  '30 5 * * *'
+  push:
+    branches:
+      - main
+      - dev
   workflow_dispatch:
     inputs:
       os-ref:
         description: The seedsigner-os ref (tag/branch/sha1) to use
         default: main
         required: true
+
+# Increment this number as part of a PR to trigger an image build for the PR
+# trigger = 0
 
 jobs:
   build:
@@ -114,7 +118,8 @@ jobs:
           name: seedsigner_os_images
           path: "seedsigner-os/images/*.img"
           if-no-files-found: error
-          retention-days: 7
+          # maximum 90 days retention
+          retention-days: 90
 
   sha256sum:
     name: calculate sha256sum
@@ -148,4 +153,5 @@ jobs:
           name: seedsigner_os_images
           path: "images/*.sha256"
           if-no-files-found: error
-          retention-days: 7
+          # maximum 90 days retention
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 # Project Summary
 
 [![CI](https://github.com/SeedSigner/seedsigner/actions/workflows/tests.yml/badge.svg)](https://github.com/SeedSigner/seedsigner/actions/workflows/tests.yml)
+[![Build](https://github.com/SeedSigner/seedsigner/actions/workflows/build.yml/badge.svg)](https://github.com/SeedSigner/seedsigner/actions/workflows/build.yml)
 
 The goal of SeedSigner is to lower the cost and complexity of Bitcoin multi-signature wallet use. To accomplish this goal, SeedSigner offers anyone the opportunity to build a verifiably air-gapped, stateless Bitcoin signing device using inexpensive, publicly available hardware components (usually < $50). SeedSigner helps users save with Bitcoin by assisting with trustless private key generation and multisignature (aka "multisig") wallet setup, and helps users transact with Bitcoin via a secure, air-gapped QR-exchange signing model.
 


### PR DESCRIPTION
This updates the existing build action to:
* add an os-ref input parameter to be able to do manual workflow_dispatch builds where any seedsigner branch can be combined with any seedsigner-os ref (tag, branch, sha1). (default = the default branch of both repos)
* produce unique (git describe based)image file names that have the seedsigner and seedsigner-os version encoded, e.g. seedsigner_os.os0.6.0-61-g9fafebe_sw0.7.0-40-g4b7c895.pi0.img to know exactly what version an image is based on.
* simplify the cache action step: restore + save is automatically done by the plain action and its included post-action step. Some testing shows that the cache action reduces the build time to 50% (~30mins).
* ~~enable daily builds = daily PoW that everything works, sources exist, and builds fine together. And it also enables easily testing of merged PRs of the last days for everybody without locally building anything or waiting for a manual workflow_dispatch run. (this also keeps the cache warm, so succeeding triggered builds are a lot faster).~~ one build per merge
* ~~lower the retention-days to 7 (default 90 days), to not consume to much artifact space with the daily builds enabled.~~ newer builds overwrite older builds in case the artifact cache is full

For more details see inline comments.

Succeeding PRs can also enable builds for every merge to the dev/main branch or for triggering builds when a tag is added.

some links: 
* A full run of the build workflow triggered via manual workflow_dispatch from the branch of the PR can be seen here https://github.com/dbast/seedsigner/actions/runs/6259494273 
* this one p0 run finished in 22 mins due to caching https://github.com/dbast/seedsigner/actions/runs/6259494273/job/16995636719 
* this is a cron triggered run with disabled fork protection, reduced build matrix and caching https://github.com/dbast/seedsigner/actions/runs/6218622125/job/16875333434

## Description

_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
