### PR TITLE
Hold QR animation on brightness tips and reset animated QR sequence

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -670,7 +670,7 @@ class QRDisplayScreen(BaseScreen):
             self.tips_start_time = tips_start_time
 
 
-        def add_brightness_tips(self, image: Image.Image) -> None:
+        def render_brightness_tip(self, image: Image.Image) -> None:
             # TODO: Refactor ToastOverlay to support two lines of icon + text and use
             # that instead of this more manual approach.
 
@@ -745,19 +745,29 @@ class QRDisplayScreen(BaseScreen):
             from seedsigner.models.settings import Settings
             settings = Settings.get_instance()
             cur_brightness_setting = settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS_TIPS)
-            show_brightness_tips = cur_brightness_setting == SettingsConstants.OPTION__ENABLED
+            is_brightness_tip_enabled = cur_brightness_setting == SettingsConstants.OPTION__ENABLED
+            pending_encoder_restart = False
 
             # Loop whether the QR is a single frame or animated; each loop might adjust
             # brightness setting.
             while self.keep_running:
                 # convert the self.qr_brightness integer (31-255) into hex triplets
                 hex_color = (hex(self.qr_brightness.cur_count).split('x')[1]) * 3
-                image = self.qr_encoder.next_part_image(240, 240, border=2, background_color=hex_color)
 
                 # Display the brightness tips toast
                 duration = 10 ** 9 * 1.2  # 1.2 seconds
-                if show_brightness_tips and time.time_ns() - self.tips_start_time.cur_count < duration:
-                    self.add_brightness_tips(image)
+                if is_brightness_tip_enabled and time.time_ns() - self.tips_start_time.cur_count < duration:
+                    image = self.qr_encoder.part_to_image(self.qr_encoder.cur_part(), 240, 240, border=2, background_color=hex_color)
+                    self.render_brightness_tip(image)
+                    pending_encoder_restart = True
+                else:
+                    # Only advance the QR animation when the brightness tip is not displayed
+                    if pending_encoder_restart:
+                        # Animated QRs should restart their frame sequence after the
+                        # brightness tip is stowed.
+                        self.qr_encoder.restart()
+                        pending_encoder_restart = False
+                    image = self.qr_encoder.next_part_image(240, 240, border=2, background_color=hex_color)
 
                 with self.renderer.lock:
                     self.renderer.show_image(image)


### PR DESCRIPTION
Depends on #494

This PR actually only has minimal changes; to get a proper diff you need to compare against https://github.com/kdmukai/seedsigner/tree/qr_encoding_refactor

## Description

For fountain encoders, the first `n` frames are extremely valuable. But since we start the animated QR sequence with the brightness tip overlaid, many of the early frames will be wasted and/or unreadable.

This change pauses the current frame whenever the brightness tip is visible and then restarts the animated QR sequence (per @jdlcdl's suggestion) when the brightness tip deactivates.

Fountain encoders: should be beneficial
"Simple" animated encoders (Specter xpub): doesn't really matter
Static encoders: no effect

This pull request is categorized as a:

- [x] New feature (really a behavior change)

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

If this evolves to support more elaborate changes to the fountain encoder sequence, then dedicated tests will be added.

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
