### PR TITLE
`Controller` cleanup: lazy imports no longer required

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -3,11 +3,18 @@ import logging
 
 import traceback
 
+from embit.descriptor import Descriptor
+from embit.psbt import PSBT
 from PIL.Image import Image
+from seedsigner.gui.toast import BaseToastOverlayManagerThread
 
+from seedsigner.models.psbt_parser import PSBTParser
+from seedsigner.models.seed import Seed
+from seedsigner.models.seed_storage import SeedStorage
 from seedsigner.models.settings import Settings
 from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
+from seedsigner.views.screensaver import ScreensaverScreen
 from seedsigner.views.view import Destination
 
 
@@ -97,18 +104,18 @@ class Controller(Singleton):
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.
-    _storage: 'SeedStorage' = None   # TODO: Rename "storage" to something more indicative of its temp, in-memory state
+    _storage: SeedStorage = None   # TODO: Rename "storage" to something more indicative of its temp, in-memory state
     settings: Settings = None
 
     # TODO: Refactor these flow-related attrs that survive across multiple Screens.
     # TODO: Should all in-memory flow-related attrs get wiped on MainMenuView?
-    psbt: 'embit.psbt.PSBT' = None
-    psbt_seed: 'Seed' = None
-    psbt_parser: 'PSBTParser' = None
+    psbt: PSBT = None
+    psbt_seed: Seed = None
+    psbt_parser: PSBTParser = None
 
     unverified_address = None
 
-    multisig_wallet_descriptor: 'embit.descriptor.Descriptor' = None
+    multisig_wallet_descriptor: Descriptor = None
 
     image_entropy_preview_frames: list[Image] = None
     image_entropy_final_image: Image = None
@@ -129,8 +136,8 @@ class Controller(Singleton):
     resume_main_flow: str = None
 
     back_stack: BackStack = None
-    screensaver: 'ScreensaverScreen' = None
-    toast_notification_thread: 'BaseToastOverlayManagerThread' = None
+    screensaver: ScreensaverScreen = None
+    toast_notification_thread: BaseToastOverlayManagerThread = None
 
 
     @classmethod
@@ -205,7 +212,7 @@ class Controller(Singleton):
         return self._storage
 
 
-    def get_seed(self, seed_num: int) -> 'Seed':
+    def get_seed(self, seed_num: int) -> Seed:
         if seed_num < len(self.storage.seeds):
             return self.storage.seeds[seed_num]
         else:
@@ -394,7 +401,7 @@ class Controller(Singleton):
         print("Controller: Screensaver started")
 
 
-    def activate_toast(self, toast_manager_thread: 'BaseToastOverlayManagerThread'):
+    def activate_toast(self, toast_manager_thread: BaseToastOverlayManagerThread):
         """
         Ensures that the Controller has explicit control over which processes get to
         claim the Renderer.lock and which need to (potentially) release it.

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -1,13 +1,12 @@
-import time
 import logging
-
+import time
 import traceback
 
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
 from PIL.Image import Image
-from seedsigner.gui.toast import BaseToastOverlayManagerThread
 
+from seedsigner.gui.toast import BaseToastOverlayManagerThread
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.seed import Seed
 from seedsigner.models.seed_storage import SeedStorage


### PR DESCRIPTION
## Description

At an earlier phase of the test suite refactor (a few months back) and before all the mocking had been put in to wall off the hardware-dependent libraries, the `Controller` was updated to use lazy imports (not explicitly importing via standard `from blah import foo`).

But with the test suite in its current form, this workaround is no longer necessary.

This pull request is categorized as a:

- [x] Code refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
