### PR TITLE
[Docs update] Manual installation steps minor edits

### DIFF
--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -148,31 +148,6 @@ rm bcm2835-1.60.tar.gz
 sudo rm -rf bcm2835-1.60
 ```
 
-### Set up `virtualenv`
-```bash
-python -m pip install virtualenvwrapper
-```
-
-Edit your bash profile with the command `nano ~/.profile` and add the following to the end:
-```bash
-export WORKON_HOME=$HOME/.envs
-export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
-source $HOME/.local/bin/virtualenvwrapper.sh
-```
-Then `CTRL-X` and `y` to exit and save changes.
-
-Now create the virtualenv for SeedSigner:
-```bash
-source ~/.profile
-mkvirtualenv seedsigner-env
-```
-
-For convenience you can configure your `.profile` to auto-activate the SeedSigner virtualenv when you ssh in. Once again `nano ~/.profile` and add at the end:
-```bash
-workon seedsigner-env
-```
-
-
 ### Download the SeedSigner code:
 ```bash
 git clone https://github.com/SeedSigner/seedsigner
@@ -196,9 +171,11 @@ sudo swapon /swapfile
 
 ### Install Python `pip` dependencies:
 ```bash
-# Takes 1hr 45min on a Pi Zero 1.3
-pip install -r requirements.txt
-pip install -r requirements-raspi.txt
+# Takes 1hr 15min on a Pi Zero 1.3
+python3 -m pip install -r requirements.txt
+
+# Only takes ~100 seconds
+python3 -m pip install -r requirements-raspi.txt
 ```
 
 #### `pyzbar`
@@ -208,28 +185,6 @@ The fork is required because the main `pyzbar` repo has been abandoned. This [gi
 * [PR 76](https://github.com/NaturalHistoryMuseum/pyzbar/pull/76/files): enables scanning to continue even when a null byte (`x\00`) is found.
 * [PR 82](https://github.com/NaturalHistoryMuseum/pyzbar/pull/82): enable `zbar`'s new binary mode. Note that this PR has a trivial bug that was fixed in our fork.
 
-
-### Finish configuring the virtualenv
-Set the SeedSigner `src/` directory as the project directory for the virtualenv (this is where the virtualenv will take you when you activate it):
-```bash
-cd src
-setvirtualenvproject
-```
-
-Test it out:
-```bash
-# exit the virtualenv
-deactivate
-
-# change dirs to somewhere else
-cd ~
-
-# activate the virtualenv
-workon seedsigner-env
-
-# you should now be back in the SeedSigner src/ directory
-pwd
-```
 
 ### Optional: increase spidev buffer size
 This allows `ST7789.py` to update the LCD without performing multiple write operations because the default buffer size is 4096 bytes. The default can be changed via the  `/boot/cmdline.txt` file. You will need to add `spidev.bufsiz=131072` to the end of this single lined file command.
@@ -254,7 +209,7 @@ Description=Seedsigner
 [Service]
 User=pi
 WorkingDirectory=/home/pi/seedsigner/src/
-ExecStart=/home/pi/.envs/seedsigner-env/bin/python3 main.py > /dev/null 2>&1
+ExecStart=/usr/bin/python3 main.py > /dev/null 2>&1
 Restart=always
 
 [Install]
@@ -303,13 +258,9 @@ sudo rm /var/swap
 
 ## Manually start the SeedSigner code
 ```bash
-# activate the virtualenv if you haven't already
-workon seedsigner-env
+cd ~/seedsigner/src
 
-# You should now be in the SeedSigner src/ directory. List its contents:
-ls
-
-# You should see the main.py file. Run it:
+# You'll find the main.py file in that directory. Run it:
 python main.py
 
 # To kill the process, use CTRL-C

--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -106,7 +106,7 @@ sudo apt install python3-apt -y
 
 
 ### Install dependencies
-Copy this entire box and run it as one command (will take a while to complete):
+Copy this entire box and run it as one command (~15 minutes on a Pi Zero 1.3):
 ```bash
 sudo apt update && sudo apt install -y wiringpi python3-pip \
    python3-numpy python-pil libjpeg-dev zlib1g-dev libopenjp2-7 \


### PR DESCRIPTION
## Description

* Adds additional time guidance for long-running setup tasks.
* Removes the virtualenv

Rationale: virtualenvs are only useful when multiple python projects run on the same machine. Instead we just directly install pip dependencies into the installed python3.

This pull request is categorized as a:

- [x] Documentation

## Checklist
If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A
