### PR TITLE
Fix unhandled exception when attempting to sign message for custom derivation address

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1928,7 +1928,9 @@ class SeedSignMessageStartView(View):
         # calculate the actual receive address
         addr_format = embit_utils.parse_derivation_path(derivation_path)
         if not addr_format["clean_match"]:
-            raise NotYetImplementedView("Signing messages for custom derivation paths not supported")
+            self.set_redirect(Destination(NotYetImplementedView, view_args=dict(text=f"Signing messages for custom derivation paths not supported")))
+            self.controller.resume_main_flow = None
+            return
 
         # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
         if self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -287,7 +287,9 @@ class PowerOffView(View):
 
 
 
+@dataclass
 class NotYetImplementedView(View):
+    text: str = "This is still on our to-do list!"
     """
         Temporary View to use during dev.
     """
@@ -296,7 +298,7 @@ class NotYetImplementedView(View):
             WarningScreen,
             title="Work In Progress",
             status_headline="Not Yet Implemented",
-            text="This is still on our to-do list!",
+            text=self.text,
             button_data=["Back to Main Menu"],
         )
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -8,7 +8,7 @@ from base import FlowTestRunScreenNotExecutedException, FlowTestInvalidButtonDat
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import Seed
-from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView
+from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView, NotYetImplementedView
 from seedsigner.views import seed_views, scan_views, settings_views, tools_views
 
 
@@ -299,6 +299,7 @@ class TestSeedFlows(FlowTest):
 class TestMessageSigningFlows(FlowTest):
     MAINNET_DERIVATION_PATH = "m/84h/0h/0h/0/0"
     TESTNET_DERIVATION_PATH = "m/84h/1h/0h/0/0"
+    CUSTOM_DERIVATION_PATH = "m/99h/0/0"
     SHORT_MESSAGE = "I attest that I control this bitcoin address blah blah blah"
     MULTIPAGE_MESSAGE = """Chancellor on brink of second bailout for banks
 
@@ -327,6 +328,10 @@ class TestMessageSigningFlows(FlowTest):
 
     def load_multipage_message_into_decoder(self, view: View):
         self.load_signmessage_into_decoder(view, self.MAINNET_DERIVATION_PATH, self.MULTIPAGE_MESSAGE)
+
+
+    def load_custom_derivation_into_decoder(self, view: View):
+        self.load_signmessage_into_decoder(view, self.CUSTOM_DERIVATION_PATH, self.SHORT_MESSAGE)
 
 
     def inject_mesage_as_paged_message(self, view: View):
@@ -503,3 +508,27 @@ class TestMessageSigningFlows(FlowTest):
         ])
 
         assert self.controller.resume_main_flow is None
+
+
+    def test_sign_message_unsupported_derivation_flow(self):
+        """
+        Should redirect to NotYetImplementedView if a message's derivation path isn't yet supported
+        """
+        # Ensure message signing is enabled
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        def expect_unsupported_derivation(load_message: Callable):
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+                FlowStep(scan_views.ScanView, before_run=load_message),  # simulate read message QR; ret val is ignored
+                FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+                FlowStep(seed_views.NotYetImplementedView),
+                FlowStep(MainMenuView),
+            ])
+
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
+        expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
+


### PR DESCRIPTION
## Description

This PR fixes the unhandled exception when trying to sign a message from a custom derivation path.  The intention in the original code was to show a NotYetImplementedView with a custom text message describing the unsupported feature, however it was implemented as a raise of the view instead of a redirect, as well as a bad initialization of the view (bad parameters).

![Screenshot from 2024-01-08 10-49-11](https://github.com/SeedSigner/seedsigner/assets/86847733/21332425-ff26-4a0c-ad22-722d7e97750a)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other  seedsigner-emulator

