### PR TITLE
[Enhancement] Update seed_phrase_to_qr.py; warnings, add Compact SeedQR

### DIFF
--- a/tools/seed_phrase_to_qr.py
+++ b/tools/seed_phrase_to_qr.py
@@ -1,4 +1,5 @@
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, SeedQrEncoder
+from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
 
 """
@@ -27,7 +28,7 @@ if __name__ == "__main__":
         print("Invalid option")
         sys.exit(1)
 
-    seed_phrase = input("Enter 12- or 24-word test seed phrase: ").strip().split(" ")
+    seed_phrase = input("\nEnter 12- or 24-word test seed phrase: ").strip().split(" ")
 
     if format == COMPACT:
         encoder = CompactSeedQrEncoder(seed_phrase=seed_phrase, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
@@ -38,3 +39,6 @@ if __name__ == "__main__":
     qr.add_data(encoder.next_part())
     qr.make(fit=True)
     qr.make_image(fill_color="black", back_color="white").resize((240,240)).convert('RGB').show()
+
+    seed = Seed(seed_phrase)
+    print(f"\nfingerprint: {seed.get_fingerprint()}\n")

--- a/tools/seed_phrase_to_qr.py
+++ b/tools/seed_phrase_to_qr.py
@@ -1,19 +1,40 @@
+from seedsigner.models.encode_qr import CompactSeedQrEncoder, SeedQrEncoder
+from seedsigner.models.settings_definition import SettingsConstants
+
+"""
+This is a utility for testing / dev purposes only. 
+"""
 
 if __name__ == "__main__":
     import qrcode
     import sys
-    from embit import bip39
 
-    print(sys.argv)
-    seed_phrase = sys.argv[1:]
-    print(seed_phrase)
+    print("""
+*******************************************************************************
 
-    data = ""
-    for word in seed_phrase:
-        index = bip39.WORDLIST.index(word)
-        data += str("%04d" % index)
+    This is a utility for testing / dev purposes ONLY.
+
+    A SeedQR for a real seed holding actual value should never be created
+    this way.
+
+*******************************************************************************
+""")
+
+    COMPACT = 1
+    STANDARD = 2
+    format = int(input("1. Compact SeedQR\n2. Standard SeedQR\nEnter 1 or 2: ").strip())
+    if format not in [COMPACT, STANDARD]:
+        print("Invalid option")
+        sys.exit(1)
+
+    seed_phrase = input("Enter 12- or 24-word test seed phrase: ").strip().split(" ")
+
+    if format == COMPACT:
+        encoder = CompactSeedQrEncoder(seed_phrase=seed_phrase, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    else:
+        encoder = SeedQrEncoder(seed_phrase=seed_phrase, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
 
     qr = qrcode.QRCode( version=1, error_correction=qrcode.constants.ERROR_CORRECT_L, box_size=5, border=3)
-    qr.add_data(data)
+    qr.add_data(encoder.next_part())
     qr.make(fit=True)
     qr.make_image(fill_color="black", back_color="white").resize((240,240)).convert('RGB').show()


### PR DESCRIPTION
## Description

The tools/seed_phrase_to_qr.py utility script converts a mnemonic to a digital SeedQR in png format. The tool is only meant for dev testing purposes and should announce itself as such if someone tries to run it.

Also adds support for generating Compact SeedQR format.

Changes mnemonic input to use interactive input steps rather than including the mnemonic when executing from the command line (minor improvement to not have mnemonics in your bash history, though, again, only disposable test seeds should be used here).

This pull request is categorized as a:

- [x] New feature
- [x] Code refactor
- [x] Documentation

## Checklist

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Other

Meant to run in local dev environment, not on Raspi.