### PR TITLE
[Test] Add missing flow-based test for bip39 passphrase entry

### DIFF
--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -32,6 +32,23 @@ class TestSeedFlows(FlowTest):
         ])
 
 
+    def test_passphrase_entry_flow(self):
+        """
+        Opting to add a bip39 passphrase on the Finalize Seed screen should enter the
+        passphrase entry / review flow and end at the SeedOptionsView. 
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value="muhpassphrase"),
+            FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value="muhpassphrase2"),
+            FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
+            FlowStep(seed_views.SeedOptionsView),
+        ])
+
+
     def test_mnemonic_entry_flow(self):
         """
             Manually entering a mnemonic should land at the Finalize Seed flow and end at


### PR DESCRIPTION
## Description

Adds a missing flow-based test for the process of entering an optional bip39 passphrase, reviewing the resulting fingerprint, editing the passphrase, once again reviewing the results, and then finalizing the seed.

This pull request is categorized as a:

- [x] Test case

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Other
