### PR TITLE
README note: don't mount .img before signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Once the files have all finished downloading, follow the steps below to verify t
 You can quickly verify that the software you just downloaded is both authentic and unaltered, by following these instructions.
 We assume you are running the commands from a computer where both [GPG](https://gnupg.org/download/index.html) and [shasum](https://command-not-found.com/shasum) are already installed, and that you also know [how to navigate on a terminal](https://terminalcheatsheet.com/guides/navigate-terminal). 
 
+> You must run the following verification before opening or mounting the .img file.
+> Some operating systems modify the file on mount causing verification to fail.
 
 ### Step 1. Verify that the signature (.sig) file is genuine:
 


### PR DESCRIPTION
## Description

Clarify instructions for new users. If you happen to double click the .img before running the verification code on a Mac
then verification fails and it looks scary for no reason.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

> So I did run `pytest` and two tests are failing, which I'm glad to fix but have nothing to do with my PR.
> See comments for more.

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Mac OS, Apple M1, Python 3.10.14


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
