### PR TITLE
[Enhancement] Improved animated QR scanning percentage display

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -407,7 +407,6 @@ class Controller(Singleton):
         """
         from seedsigner.hardware.buttons import HardwareButtons
         HardwareButtons.get_instance().update_last_input_time()
-        print("reset_screensaver_timeout")
 
 
     def activate_toast(self, toast_manager_thread: BaseToastOverlayManagerThread):

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -398,6 +398,16 @@ class Controller(Singleton):
         # Start the screensaver, but it will block until it can acquire the Renderer.lock.
         self.screensaver.start()
         print("Controller: Screensaver started")
+    
+
+    def reset_screensaver_timeout(self):
+        """
+        Reset the screensaver's timeout starting point to right now (i.e. make it think
+        that zero time has elapsed since the last user interaction).
+        """
+        from seedsigner.hardware.buttons import HardwareButtons
+        HardwareButtons.get_instance().update_last_input_time()
+        print("reset_screensaver_timeout")
 
 
     def activate_toast(self, toast_manager_thread: BaseToastOverlayManagerThread):

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -29,6 +29,8 @@ class GUIConstants:
     BITCOIN_ORANGE = "#FF9416"
     TESTNET_COLOR = "#00F100"
     REGTEST_COLOR = "#00CAF1"
+    GREEN_INDICATOR_COLOR = "#00FF00"
+    INACTIVE_COLOR = "#414141"
 
     ICON_FONT_NAME__FONT_AWESOME = "Font_Awesome_6_Free-Solid-900"
     ICON_FONT_NAME__SEEDSIGNER = "seedsigner-icons"

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -104,7 +104,7 @@ class ScanScreen(BaseScreen):
 
             start_time = time.time()
             num_frames = 0
-            debug = True
+            debug = False
             show_framerate = False  # enable for debugging / testing
             while self.keep_running:
                 frame = self.camera.read_video_stream(as_image=True)
@@ -112,8 +112,7 @@ class ScanScreen(BaseScreen):
                     num_frames += 1
                     cur_time = time.time()
                     cur_fps = num_frames / (cur_time - start_time)
-                    print(f"{cur_fps=}")
-
+                    
                     scan_text = None
                     progress_percentage = self.decoder.get_percent_complete()
                     if progress_percentage == 0:

--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -38,7 +38,7 @@ class Camera(Singleton):
             return frame
         else:
             if frame is not None:
-                return Image.fromarray(frame.astype('uint8'), 'RGB').rotate(90 + self._camera_rotation)
+                return Image.fromarray(frame.astype('uint8'), 'RGB').convert('RGBA').rotate(90 + self._camera_rotation)
         return None
 
 

--- a/src/seedsigner/helpers/ur2/fountain_decoder.py
+++ b/src/seedsigner/helpers/ur2/fountain_decoder.py
@@ -4,7 +4,7 @@
 # Copyright © 2020 Foundation Devices, Inc.
 # Licensed under the "BSD-2-Clause Plus Patent License"
 #
-
+import time
 from .fountain_utils import choose_fragments, contains, is_strict_subset, set_difference
 from .utils import join_lists, join_bytes, crc32_int, xor_with, take_first
 
@@ -71,13 +71,50 @@ class FountainDecoder:
     def result_error(self):
          return self.result
 
-    def estimated_percent_complete(self):
+
+    def estimated_percent_complete(self, weight_mixed_frames: bool = False):
         if self.is_complete():
             return 1
         if self.expected_part_indexes == None:
             return 0
-        estimated_input_parts = self.expected_part_count() * 1.75
-        return min(0.99, self.processed_parts_count / estimated_input_parts)
+        
+        if not weight_mixed_frames:
+            # Original estimation method
+            estimated_input_parts = self.expected_part_count() * 1.75
+            return min(0.99, self.processed_parts_count / estimated_input_parts)
+        else:
+            # Weighted mixed frame method:
+            # * counts completed frames
+            # * counts each additional frame that is currently XORed in a mixed frame;
+            #   its score is weighted by the number of frames mixed together
+            #   (1/num frames mixed).
+            parts = self.expected_part_count() if self.expected_part_indexes != None else 'None'
+            mixed = []
+            mixed_index_scoring = {}
+            mixed_set = set()
+            for indexes, p in self.mixed_parts.items():
+                if not indexes:
+                    continue
+                mixed.append(self.indexes_to_string(indexes))
+                mixed_set.update(indexes)
+                score = 1.0 / float(len(indexes))
+                for index in indexes:
+                    if index not in mixed_index_scoring:
+                        mixed_index_scoring[index] = 0.0
+                    mixed_index_scoring[index] += score
+
+            mixed_score = 0.0
+            for index, score in mixed_index_scoring.items():
+                # set a ceiling; don't let an index in a mixed/XOR frame
+                # achieve equal weight as a fully decoded frame. Also if
+                # the ceiling is too high, can potentially see your
+                # reported progress percentage DECREASE during a decode.
+                mixed_score += min(score, 0.80)
+            
+            num_complete = len(self.received_part_indexes)
+            weighted_estimate = (num_complete + mixed_score) / float(parts)
+            return weighted_estimate
+ 
 
     def receive_part(self, encoder_part):
         # Don't process the part if we're already done
@@ -93,6 +130,9 @@ class FountainDecoder:
         self.last_part_indexes = p.indexes
         self.enqueue(p)
 
+        num_complete = len(self.received_part_indexes)
+        num_mixed_frames = len(self.mixed_parts)
+
         # Process the queue until we're done or the queue is empty
         while not self.is_complete() and len(self.queued_parts) != 0:
             self.process_queue_item()
@@ -101,6 +141,12 @@ class FountainDecoder:
         self.processed_parts_count += 1
 
         # self.print_part_end()
+        self.print_state()
+
+        if num_complete == len(self.received_part_indexes) and num_mixed_frames == len(self.mixed_parts):
+            # This part didn't add any new info
+            print("No new data")
+            return False
 
         return True
 
@@ -114,6 +160,7 @@ class FountainDecoder:
         self.queued_parts.append(p)
 
     def process_queue_item(self):
+        start = time.time()
         part = self.queued_parts.pop(0)
         # self.print_part(part)
 
@@ -121,6 +168,8 @@ class FountainDecoder:
             self.process_simple_part(part)
         else:
             self.process_mixed_part(part)
+        
+        print(f"Queue processing: {int((time.time() - start)*1000.0)}ms")
         # self.print_state()
 
     def reduce_mixed_by(self, p):
@@ -141,6 +190,7 @@ class FountainDecoder:
                 new_mixed[reduced_part.indexes] = reduced_part
 
         self.mixed_parts = new_mixed
+        # print(self.mixed_parts.keys())
 
     def reduce_part_by_part(self, a, b):
         # If the fragments mixed into `b` are a strict (proper) subset of those in `a`...
@@ -268,11 +318,27 @@ class FountainDecoder:
     def print_state(self):
         parts = self.expected_part_count() if self.expected_part_indexes != None else 'None'
         received = self.indexes_to_string(self.received_part_indexes)
+
+        guesstimate = self.estimated_percent_complete(weight_mixed_frames=True)
+        original_metric = self.estimated_percent_complete()
         mixed = []
-        for indexes, p in self.mixed_parts.items():
-            mixed.append(self.indexes_to_string(indexes))
-        
-        mixed_s = "[{}]".format(', '.join(mixed))
-        queued = len(self.queued_parts)
-        res = self.result_description()
-        print('parts: {}, received: {}, mixed: {}, queued: {}, result: {}'.format(parts, received, mixed_s, queued, res))
+        mixed_set = set()
+        try:
+            for indexes, p in self.mixed_parts.items():
+                if not indexes or len(indexes) == 0:
+                    continue
+                mixed.append(self.indexes_to_string(indexes))
+                mixed_set.update(indexes)
+            
+            num_complete = len(self.received_part_indexes)
+
+            mixed_s = "[{}]".format(', '.join(mixed))
+            queued = len(self.queued_parts)
+            res = self.result_description()
+            # print(f"{self.estimated_percent_complete()*100.0:3.1f}%" + 'parts: {}, received: {}, mixed: {}, queued: {}, result: {}'.format(parts, received, mixed_s, queued, res))
+            print(f"{original_metric*100.0:5.1f}% | {guesstimate*100.0:5.1f}% | done: {num_complete:2d}, mixed: {len(mixed_set):2d}, queued: {queued}, frames: {self.processed_parts_count:2d} | {mixed_s}")
+            # print(f"{original_metric*100.0:5.1f}% | {guesstimate*100.0:5.1f}% | {mixed_s}")
+
+        except Exception as e:
+            import traceback
+            traceback.print_exc()

--- a/src/seedsigner/helpers/ur2/fountain_decoder.py
+++ b/src/seedsigner/helpers/ur2/fountain_decoder.py
@@ -78,7 +78,6 @@ class FountainDecoder:
             * counts completed frames
             * counts each additional frame that is currently XORed in a mixed frame; its
                 score is weighted by the number of frames mixed together (1/num frames mixed).
-            TODO: try just using the largest fraction of the XOR total
         """
         if self.is_complete():
             return 1
@@ -104,11 +103,8 @@ class FountainDecoder:
                     if index not in mixed_index_scoring:
                         mixed_index_scoring[index] = 0.0
                     
-                    # metric 1: sum up partial scores
+                    # sum up partial scores
                     mixed_index_scoring[index] += score
-
-                    # metric 2: just keep the max
-                    # mixed_index_scoring[index] = max(score, mixed_index_scoring[index])
 
             mixed_score = 0.0
             for index, score in mixed_index_scoring.items():
@@ -117,11 +113,11 @@ class FountainDecoder:
                 # the ceiling is too high, can potentially see your
                 # reported progress percentage DECREASE during a decode.
                 mixed_score += min(score, 0.75)
-            
+
             num_complete = len(self.received_part_indexes)
             weighted_estimate = (num_complete + mixed_score) / float(parts)
             return weighted_estimate
- 
+
 
     def receive_part(self, encoder_part):
         # Don't process the part if we're already done
@@ -148,11 +144,11 @@ class FountainDecoder:
         self.processed_parts_count += 1
 
         # self.print_part_end()
-        self.print_state()
+        # self.print_state()
 
         if num_complete == len(self.received_part_indexes) and num_mixed_frames == len(self.mixed_parts):
             # This part didn't add any new info
-            print("No new data")
+            # print("No new data")
             return False
 
         return True
@@ -176,7 +172,7 @@ class FountainDecoder:
         else:
             self.process_mixed_part(part)
         
-        print(f"Queue processing: {int((time.time() - start)*1000.0)}ms")
+        # print(f"Queue processing: {int((time.time() - start)*1000.0)}ms")
         # self.print_state()
 
     def reduce_mixed_by(self, p):
@@ -323,9 +319,6 @@ class FountainDecoder:
         print("processed: {}, expected: {}, received: {}, percent: {}%".format(self.processed_parts_count, expected, len(self.received_part_indexes), percent))
 
     def print_state(self):
-        parts = self.expected_part_count() if self.expected_part_indexes != None else 'None'
-        received = self.indexes_to_string(self.received_part_indexes)
-
         guesstimate = self.estimated_percent_complete(weight_mixed_frames=True)
         original_metric = self.estimated_percent_complete()
         mixed = []
@@ -341,10 +334,7 @@ class FountainDecoder:
 
             mixed_s = "[{}]".format(', '.join(mixed))
             queued = len(self.queued_parts)
-            res = self.result_description()
-            # print(f"{self.estimated_percent_complete()*100.0:3.1f}%" + 'parts: {}, received: {}, mixed: {}, queued: {}, result: {}'.format(parts, received, mixed_s, queued, res))
             print(f"{original_metric*100.0:5.1f}% | {guesstimate*100.0:5.1f}% | done: {num_complete:2d}, mixed: {len(mixed_set):2d}, queued: {queued}, frames: {self.processed_parts_count:2d} | {mixed_s}")
-            # print(f"{original_metric*100.0:5.1f}% | {guesstimate*100.0:5.1f}% | {mixed_s}")
 
         except Exception as e:
             import traceback

--- a/src/seedsigner/helpers/ur2/ur_decoder.py
+++ b/src/seedsigner/helpers/ur2/ur_decoder.py
@@ -153,8 +153,8 @@ class URDecoder:
     def processed_parts_count(self):
         return self.fountain_decoder.processed_parts_count
 
-    def estimated_percent_complete(self):
-        return self.fountain_decoder.estimated_percent_complete()
+    def estimated_percent_complete(self, weight_mixed_frames: bool = False):
+        return self.fountain_decoder.estimated_percent_complete(weight_mixed_frames=weight_mixed_frames)
         
     def is_success(self):
         result = self.result

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -264,6 +264,7 @@ class DecodeQR:
             QRType.PSBT__BASE43,
         ]
 
+
     @property
     def is_seed(self):
         return self.qr_type in [
@@ -308,7 +309,7 @@ class DecodeQR:
 
 
     @staticmethod
-    def extract_qr_data(image, is_binary:bool = False) -> [str|None]:
+    def extract_qr_data(image, is_binary:bool = False) -> str | None:
         if image is None:
             return None
 

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -322,8 +322,6 @@ class DecodeQR:
         for barcode in barcodes:
             # Only pull and return the first barcode
             return barcode.data
-        
-        print("No QR data")
 
 
     @staticmethod
@@ -343,10 +341,10 @@ class DecodeQR:
             # PSBT
             if re.search("^UR:CRYPTO-PSBT/", s, re.IGNORECASE):
                 return QRType.PSBT__UR2
-                
+
             elif re.search("^UR:CRYPTO-OUTPUT/", s, re.IGNORECASE):
                 return QRType.OUTPUT__UR
-                
+
             elif re.search("^UR:CRYPTO-ACCOUNT/", s, re.IGNORECASE):
                 return QRType.ACCOUNT__UR
 
@@ -368,10 +366,10 @@ class DecodeQR:
             elif re.search(r'^\{\"label\".*\"descriptor\"\:.*', desc_str, re.IGNORECASE):
                 # if json starting with label and contains descriptor, assume specter wallet json
                 return QRType.WALLET__SPECTER
-            
+
             elif "multisig setup file" in s.lower():
                 return QRType.WALLET__CONFIGFILE
-            
+
             elif "sortedmulti" in s:
                 return QRType.WALLET__GENERIC
 
@@ -398,7 +396,7 @@ class DecodeQR:
                 _4LETTER_WORDLIST = [word[:4].strip() for word in wordlist]
             except:
                 _4LETTER_WORDLIST = []
-            
+
             if all(x in wordlist for x in s.strip().split(" ")):
                 # checks if all words in list are in bip39 word list
                 return QRType.SEED__MNEMONIC
@@ -414,7 +412,7 @@ class DecodeQR:
             # Probably this isn't meant to be string data; check if it's valid byte data
             # below.
             pass
-        
+
         # Is it byte data?
         # 32 bytes for 24-word CompactSeedQR; 16 bytes for 12-word CompactSeedQR
         if len(s) == 32 or len(s) == 16:

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -47,6 +47,10 @@ class ScanView(View):
             decoder=self.decoder
         )
 
+        # A long scan might have exceeded the screensaver timeout; ensure screensaver
+        # doesn't immediately engage when we leave here.
+        self.controller.reset_screensaver_timeout()
+
         # Handle the results
         if self.decoder.is_complete:
             if not self.is_valid_qr_type:


### PR DESCRIPTION
## Overview

* New animated QR scanning progress display bar.
* Changes how the percent progress is calculated.
* Subtle additional green / gray dot decoder indicator:
  * Green = new information gained by the current animated QR frame
  * Gray = successfully decoded the current animated QR frame, but no new info learned
  * (no dot) = no QR of any kind detected in the current camera frame
* Minor bugfix: Screensaver can kick in as soon as a very long scanning attempt is exited.

---

## In-Depth description
Current progress metric just guesstimates that `1.75 * n` animated frames will be needed for an animated QR that has `n` full frames' worth of data, capped at 99% until all data is read. Unfortunately the metric counts frames that don't add any new data, so for very long animated QRs, useless reads pile up and keep advancing the progress metric until it gets pinned to 99%.

But because of the nature of the mixed / XOR frames in the fountain encoding, there isn't a sensible way to quantify one's current progress. This PR's new metric counts each component in a mixed frame as partial progress, relative to its proportion in each mixed frame, summed across all mixed frames:

e.g.
We need to decode full frames A through Z.

We score a fully decoded frame as 1.0.

Mixed frame `i` is an XOR of full frames G, K, Q, and Z.

So we count 1/4 G, 1/4 K, 1/4 Q, and 1/4 Z towards our total progress.

Then we receive mixed frame `j` which is an XOR of full frames A, F, G, P, Y

So frame G's contribution to our progress is now 1/4 + 1/5.

It's possible to have G XORed in so many mixed frames that its summed fractional score might exceed 1.0, so we need to cap G's scoring value until we fully decode it. The cap selected in this PR -- 0.75 -- started from an arbitrary guess and then was tweaked based on how the progress percentage was reported in real-world use (oddly, larger values could result in the progress percentage occasionally decreasing(!!), though I wonder if that might have been more due to some threading artifact?).

This metric accelerates the reported progress in the early stages of decoding a long animated QR vs the original metric. But this metric predictably slows down toward the end as we receive less and less new information and instead are stuck waiting for just the right XOR frame to start being able to unlock the big collection of mixed frames we're holding in memory. So while we don't pin the reported progress at 99% for what could feel like (or actually be) forever, we do still experience a fair bit of agony at, say, 85% as progress begins to crawl.

---

Design by @easyuxd:

![F6UGYaIWsAAew0g (1)](https://github.com/SeedSigner/seedsigner/assets/934746/d32488bb-1d35-40a8-89b1-cf126782bd64)

Note: no new screenshots added in this PR because the screenshot generator can't produce screenshots for live camera preview screens.

---

## Very large animated QR for testing

https://github.com/SeedSigner/seedsigner/assets/934746/96f3f99c-d720-4607-bfd9-60dca9a6fc27

---

This pull request is categorized as a:

- [x] Enhacement


## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR


If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

Test suite cannot simulate animated QR scanning.

---

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
