### PR TITLE
Remove unused dependencies from requirements.txt

### DIFF
--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -111,7 +111,7 @@ sudo apt install python3-apt -y
 Copy this entire box and run it as one command (~15 minutes on a Pi Zero 1.3):
 ```bash
 sudo apt update && sudo apt install -y wiringpi python3-pip \
-   python3-numpy python-pil libjpeg-dev zlib1g-dev libopenjp2-7 \
+   python-pil libjpeg-dev zlib1g-dev libopenjp2-7 \
    git python3-opencv python3-picamera libatlas-base-dev qrencode
 ```
 

--- a/requirements-raspi.txt
+++ b/requirements-raspi.txt
@@ -1,3 +1,5 @@
 picamera==1.13
+# numpy = transitive picamera dependency
+numpy==1.25.2
 RPi.GPIO==0.7.0
 spidev==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 embit==0.7.0
-numpy==1.25.2
 Pillow==9.4.0
 pyzbar @ git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03
 qrcode==7.3.1
-six==1.16.0
 urtypes @ git+https://github.com/selfcustody/urtypes.git@7fb280eab3b3563dfc57d2733b0bf5cbc0a96a6a


### PR DESCRIPTION
This removes numpy and six from requirements.txt as there are no left references in the code and moves numpy to the requirements-raspi.txt file as it is a transitive picamera dependency.

## Description

_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
