### PR TITLE
Add Python 3.12 to test matrix as upper bound and fix findings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        # 3.10: currently used by Seedsigner
+        # 3.12: latest stable Python as upper test bound
+        python-version: ["3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +36,7 @@ jobs:
           sudo apt-get install libzbar0
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r tests/requirements.txt
-          python setup.py install
+          pip install .
       - name: Test with pytest
         run: |
           mkdir artifacts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 embit==0.7.0
-Pillow==9.4.0
+Pillow==10.0.1
 pyzbar @ git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03
 qrcode==7.3.1
 urtypes @ git+https://github.com/selfcustody/urtypes.git@7fb280eab3b3563dfc57d2733b0bf5cbc0a96a6a

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Type
 
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
@@ -313,7 +313,7 @@ class ErrorView(View):
     status_headline: str = None
     text: str = None
     button_text: str = None
-    next_destination: Destination = Destination(MainMenuView, clear_history=True)
+    next_destination: Destination = field(default_factory=lambda: Destination(MainMenuView, clear_history=True))
 
 
     def run(self):


### PR DESCRIPTION
This is done in advance to open the door for upgrading to newer Python versions on seeedsigner-os at any time.

Fixes / required changes:
* Fix `E   ValueError: mutable default <class 'seedsigner.views.view.Destination'> for field next_destination is not allowed: use default_factory`
* Install package during CI with pip instead of calling the setup.py (which got deprecated a while a ago and breaks with Python 3.11/3.12)
* Update Pillow version to 10.0.1 = first version with Python 3.12 support

## Description

_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
