### PR TITLE
Pin+update Github Actions, add dependabot config for action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# See also:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         target: [ "pi0", "pi2", "pi02w", "pi4" ]
     steps:
       - name: checkout seedsigner-os
-        uses: actions/checkout@v3
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           repository: "seedsigner/seedsigner-os"
           # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           # ref defaults to repo default-branch=dev (cron) or SHA of event (workflow_dispatch)
           path: "seedsigner-os/opt/rootfs-overlay/opt"
@@ -78,7 +78,7 @@ jobs:
           ls -la src
 
       - name: restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
         # while consuming ~850 MB storage space).
         with:
@@ -113,7 +113,7 @@ jobs:
           ls -la seedsigner-os/images
 
       - name: upload images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: seedsigner_os_images
           path: "seedsigner-os/images/*.img"
@@ -127,7 +127,7 @@ jobs:
     needs: build
     steps:
       - name: download images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: seedsigner_os_images
           path: images
@@ -148,7 +148,7 @@ jobs:
           sha256sum *.img > seedsigner_os.${{ env.source_hash }}.sha256
 
       - name: upload checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: seedsigner_os_images
           path: "images/*.sha256"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,12 +144,12 @@ jobs:
       - name: write sha256sum
         run: |
           cd images
-          sha256sum *.img > seedsigner_os.${{ env.source_hash }}.sha256
+          find . -name "*.img" -print0 | xargs -0 cat | sha256sum | tee seedsigner_os.${{ env.source_hash }}.sha256
 
       - name: upload checksums
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_images_sha256
           path: "images/*.sha256"
           if-no-files-found: error
           # maximum 90 days retention

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: upload images
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_images_${{ matrix.target }}
           path: "seedsigner-os/images/*.img"
           if-no-files-found: error
           # maximum 90 days retention
@@ -129,7 +129,6 @@ jobs:
       - name: download images
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: seedsigner_os_images
           path: images
 
       - name: list images

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -56,7 +56,7 @@ jobs:
           python -m pytest tests/screenshot_generator/generator.py
           cp -r ./seedsigner-screenshots ./artifacts/
       - name: Archive CI Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ci-artifacts
           path: artifacts/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Archive CI Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: ci-artifacts
+          name: ci-artifacts-${{ matrix.python-version }}
           path: artifacts/**
           retention-days: 10
         # Upload also when tests fail. The workflow result (red/green) will


### PR DESCRIPTION
The current Github actions used in the test and build workflow are outdated and cause the following warnings:
* The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3, actions/setup-python@v4, actions/upload-artifact@v3
* The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "ci-artifacts"

see e.g. https://github.com/SeedSigner/seedsigner/actions/runs/9842707509

This PR therefore updates all actions and additionally pins them to their exact git sha1 (with human readable version as comment). This is done for security reasons as plain versions are git tags and thus are mutable = can influence the workflow outcome if manipulated.

see also https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

An added dependabot config helps to keep those actions up-to-date and makes it much easier as no person has to deal with manually updating action sha1s. Merging this PR results in the creation of automatic update PRs by dependebot as can be seen here https://github.com/dbast/seedsigner/pull/8

## Description

_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
