### PR TITLE
[Enhancement] improve FlowTest + Exception handling interactions

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -157,6 +157,10 @@ class FlowTestUnexpectedRedirectException(FlowBasedTestException):
     pass
 
 
+class FlowTestMissingRedirectException(FlowBasedTestException):
+    """ The Controller's current View did NOT trigger a redirect when one was expected by the current FlowStep in the sequence """
+    pass
+
 
 class FlowTest(BaseTest):
     """ Base class for any tests that do flow-based testing """
@@ -224,6 +228,11 @@ class FlowTest(BaseTest):
                             # The current View redirected without calling run_screen()
                             # but we weren't expecting it.
                             raise FlowTestUnexpectedRedirectException(f"Unexpected redirect to {destination.View_cls}")
+
+                        elif mock_run_screen.call_count > prev_mock_run_screen_call_count and cur_flow_step.is_redirect:
+                            # The View ran its Screen, but the current FlowStep was expecting it
+                            # to redirect (is_redirect=True) *instead of* running its Screen.
+                            raise FlowTestMissingRedirectException(f"FlowStep expected redirect but {cur_flow_step.expected_view} did not redirect")
 
                     finally:
                         # Regardless of the outcome, we always move our FlowTest

--- a/tests/base.py
+++ b/tests/base.py
@@ -152,6 +152,12 @@ class FlowTestUnexpectedViewException(FlowBasedTestException):
 
 
 
+class FlowTestUnexpectedRedirectException(FlowBasedTestException):
+    """ The Controller's current View triggered a redirect that was not expected by the current FlowStep in the sequence """
+    pass
+
+
+
 class FlowTest(BaseTest):
     """ Base class for any tests that do flow-based testing """
 
@@ -209,7 +215,7 @@ class FlowTest(BaseTest):
                         if mock_run_screen.call_count == prev_mock_run_screen_call_count and cur_flow_step.is_redirect is not True:
                             # The current View redirected without calling run_screen()
                             # but we weren't expecting it.
-                            raise FlowTestUnexpectedViewException(f"Unexpected redirect to {destination.View_cls}")
+                            raise FlowTestUnexpectedRedirectException(f"Unexpected redirect to {destination.View_cls}")
 
                     finally:
                         # Regardless of the outcome, we always move our FlowTest

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,7 +16,7 @@ from seedsigner.controller import Controller, FlowBasedTestException, StopFlowBa
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.settings import Settings
-from seedsigner.views.view import Destination, MainMenuView, View
+from seedsigner.views.view import Destination, MainMenuView, UnhandledExceptionView, View
 
 import logging
 logger = logging.getLogger(__name__)
@@ -152,12 +152,6 @@ class FlowTestUnexpectedViewException(FlowBasedTestException):
 
 
 
-class FlowTestRunScreenNotExecutedException(FlowBasedTestException):
-    """ The View's run_screen() method was not called but the FlowStep expected it to need user input """
-    pass
-
-
-
 class FlowTest(BaseTest):
     """ Base class for any tests that do flow-based testing """
 
@@ -177,7 +171,7 @@ class FlowTest(BaseTest):
                     """ Replaces Destination._run_view() """
                     if len(sequence) == 0:
                         self.stop_test()
-                    
+
                     cur_flow_step = sequence[0]
 
                     # Verify that the View class specified in the test sequence matches the
@@ -185,17 +179,11 @@ class FlowTest(BaseTest):
                     if destination.View_cls != cur_flow_step.expected_view:
                         raise FlowTestUnexpectedViewException(f"Expected {cur_flow_step.expected_view}, got {destination.View_cls}")
 
-                    # Run the optional pre-run function to modify the View.
-                    if cur_flow_step.before_run:
-                        cur_flow_step.before_run(destination.view)
+                    try:
+                        if cur_flow_step.is_redirect and destination.view.has_redirect:
+                            # Right upon instantiation, the View set its own redirect without
+                            # needing to wait for its run() method to be called.
 
-                    if cur_flow_step.is_redirect:
-                        # The current View is going to auto-redirect without calling run_screen(),
-                        # so we need to remove the current step from the sequence before the
-                        # View.run() call below.
-                        sequence.pop(0)
-
-                        if destination.view.has_redirect:
                             # TODO: Migrate all View redirects to use `View.set_redirect()`
                             # in their `__init__()` rather than `run()` and then refactor
                             # here to explicitly require `has_redirect` to be True.
@@ -204,44 +192,57 @@ class FlowTest(BaseTest):
                             # below.
                             return destination.view.get_redirect()
 
-                    # Some Views reach into their Screen's variables directly (e.g. 
-                    # Screen.buttons to preserve the scroll position), so we need to mock out the
-                    # Screen instance that is created by the View.
-                    destination.view.screen = MagicMock()
+                        # Run the optional pre-run function to modify the View.
+                        if cur_flow_step.before_run:
+                            cur_flow_step.before_run(destination.view)
 
-                    prev_mock_run_screen_call_count = mock_run_screen.call_count
+                        # Some Views reach into their Screen's variables directly (e.g. 
+                        # Screen.buttons to preserve the scroll position), so we need to mock out the
+                        # Screen instance that is created by the View.
+                        destination.view.screen = MagicMock()
 
-                    # Run the View (with our mocked run_screen) and get the next Destination that results
-                    destination = destination.view.run()
+                        prev_mock_run_screen_call_count = mock_run_screen.call_count
 
-                    if (cur_flow_step.button_data_selection or cur_flow_step.screen_return_value is not None) and mock_run_screen.call_count == prev_mock_run_screen_call_count:
-                        # The FlowStep was expecting some kind of user interaction, but the View
-                        # never called run_screen().
-                        raise FlowTestRunScreenNotExecutedException(f"View.run_screen() was not run for {destination.View_cls.__name__}")
+                        # Run the View (with our mocked run_screen) and get the next Destination that results
+                        destination = destination.view.run()
+
+                        if mock_run_screen.call_count == prev_mock_run_screen_call_count and cur_flow_step.is_redirect is not True:
+                            # The current View redirected without calling run_screen()
+                            # but we weren't expecting it.
+                            raise FlowTestUnexpectedViewException(f"Unexpected redirect to {destination.View_cls}")
+
+                    finally:
+                        # Regardless of the outcome, we always move our FlowTest
+                        # sequence forward.
+                        sequence.pop(0)
 
                     return destination
 
-                def run_screen(view: View, *args, **kwargs):
-                    """ Replaces View.run_screen() """
-                    # Return the return value specified in the test sequence and
-                    # remove the completed test step from the sequence.
-                    flow_step = sequence.pop(0)
 
-                    if flow_step.button_data_selection:
+                def run_screen(view: View, *args, **kwargs):
+                    """
+                    Replaces View.run_screen().
+
+                    Just returns the return value specified in the test sequence.
+                    """
+                    cur_flow_step = sequence[0]
+
+                    if cur_flow_step.button_data_selection:
                         # We're mocking out the View.run_screen() method, so we'll get all of the
                         # input args that are normally passed into the Screen.run() method,
                         # including the button_data kwarg.
                         if "button_data" in kwargs:
-                            if flow_step.button_data_selection not in kwargs.get("button_data") and flow_step.button_data_selection not in [RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON]:
-                                raise FlowTestInvalidButtonDataSelectionException(f"'{flow_step.button_data_selection}' not found in button_data: {kwargs.get('button_data')}")
-                            return kwargs.get("button_data").index(flow_step.button_data_selection)
+                            if cur_flow_step.button_data_selection not in kwargs.get("button_data") and cur_flow_step.button_data_selection not in [RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON]:
+                                raise FlowTestInvalidButtonDataSelectionException(f"'{cur_flow_step.button_data_selection}' not found in button_data: {kwargs.get('button_data')}")
+                            return kwargs.get("button_data").index(cur_flow_step.button_data_selection)
                         else:
                             raise Exception(f"Can't specify `FlowStep.button_data_selection` if `button_data` isn't a kwarg in {view.__class__.__name__}'s run_screen()")
 
-                    elif type(flow_step.screen_return_value) in [StopFlowBasedTest, FlowBasedTestException]:
-                        raise flow_step.screen_return_value
+                    elif type(cur_flow_step.screen_return_value) in [StopFlowBasedTest, FlowBasedTestException]:
+                        raise cur_flow_step.screen_return_value
 
-                    return flow_step.screen_return_value
+                    return cur_flow_step.screen_return_value
+
 
                 # Mock out the Destination._run_view() method so we can verify the View class
                 # that is specified in the test sequence and then run the View.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,13 +1,13 @@
 import pytest
 
 # Must import test base before the Controller
-from base import FlowTest, FlowStep, FlowTestUnexpectedViewException, FlowTestInvalidButtonDataSelectionException, FlowTestRunScreenNotExecutedException
+from base import FlowTest, FlowStep, FlowTestUnexpectedViewException, FlowTestInvalidButtonDataSelectionException
 
 from seedsigner.controller import Controller
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON
 from seedsigner.models.seed import Seed
-from seedsigner.models.settings_definition import SettingsConstants
-from seedsigner.views.seed_views import SeedBackupView, SeedMnemonicEntryView, SeedOptionsView, SeedWordsWarningView
+from seedsigner.views.psbt_views import PSBTSelectSeedView
+from seedsigner.views.seed_views import SeedBackupView, SeedMnemonicEntryView, SeedOptionsView, SeedSelectSeedView, SeedsMenuView
 from seedsigner.views.view import MainMenuView, PowerOptionsView, UnhandledExceptionView
 from seedsigner.views.tools_views import ToolsMenuView, ToolsCalcFinalWordNumWordsView
 
@@ -38,6 +38,23 @@ class TestFlowTest(FlowTest):
                 FlowStep(MainMenuView, button_data_selection=RET_CODE__POWER_BUTTON),
                 FlowStep(ToolsMenuView),  # <-- Wrong target View! Should raise an AssertionError.
             ])
+    
+
+    def test_UnhandledExceptionView(self):
+        """
+        Ensure that the FlowTest will raise a FlowTestUnexpectedViewException if an
+        UnhandledExceptionView is encountered.
+        """
+        with pytest.raises(FlowTestUnexpectedViewException):
+            self.run_sequence([
+                FlowStep(SeedOptionsView),  # <-- There is no seed loaded nor a seed_num specified. Should raise an UnhandledException.
+            ])
+
+        # If we don't trap the exception, we should end up at the UnhandledExceptionView.
+        self.run_sequence([
+            FlowStep(PSBTSelectSeedView),  # <-- There's no PSBT loaded.
+            FlowStep(UnhandledExceptionView),
+        ])
 
 
     def test_FlowTestInvalidButtonDataSelectionException(self):
@@ -47,29 +64,23 @@ class TestFlowTest(FlowTest):
         """
         with pytest.raises(FlowTestInvalidButtonDataSelectionException):
             self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection="this is not a real button option!"),
+                FlowStep(MainMenuView, button_data_selection="this is not a real button option!"),
             ])
 
 
-    def test_FlowTestRunScreenNotExecutedException(self):
+    def test_unexpected_redirect_flow(self):
         """
-        Ensure that the FlowTest will raise a FlowTestRunScreenNotExecutedException if the next
-        View in the sequence doesn't call its View.run_screen().
+        If the FlowStep doesn't specify is_redirect when the View redirects, raise an exception.
         """
-        # Disable dire warnings so that the SeedWordsWarningView won't execute its run_screen()
-        self.settings.set_value(SettingsConstants.SETTING__DIRE_WARNINGS, SettingsConstants.OPTION__DISABLED)
-        self.controller.storage.set_pending_seed(Seed(mnemonic=["bacon"] * 24))
-        self.controller.storage.finalize_pending_seed()
+        with pytest.raises(FlowTestUnexpectedViewException) as e:
+            self.run_sequence([
+                FlowStep(SeedsMenuView, screen_return_value=0),  # <-- No seeds loaded, so it'll redirect elsewhere
+            ])
 
-        with pytest.raises(FlowTestRunScreenNotExecutedException):
-            self.run_sequence(
-                initial_destination_view_args=dict(seed_num=0),
-                sequence=[
-                    FlowStep(SeedOptionsView, button_data_selection=SeedOptionsView.BACKUP),
-                    FlowStep(SeedBackupView, button_data_selection=SeedBackupView.VIEW_WORDS),
-                    FlowStep(SeedWordsWarningView, screen_return_value=0),
-                ],
-            )
+        # This time we'll show that we know it should redirect
+        self.run_sequence([
+            FlowStep(SeedsMenuView, is_redirect=True),
+        ])
 
 
     def test_before_run_executes(self):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -7,7 +7,7 @@ from seedsigner.controller import Controller
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON
 from seedsigner.models.seed import Seed
 from seedsigner.views.psbt_views import PSBTSelectSeedView
-from seedsigner.views.seed_views import SeedBackupView, SeedMnemonicEntryView, SeedOptionsView, SeedSelectSeedView, SeedsMenuView
+from seedsigner.views.seed_views import SeedBackupView, SeedMnemonicEntryView, SeedOptionsView, SeedsMenuView
 from seedsigner.views.view import MainMenuView, PowerOptionsView, UnhandledExceptionView
 from seedsigner.views.tools_views import ToolsMenuView, ToolsCalcFinalWordNumWordsView
 
@@ -36,7 +36,7 @@ class TestFlowTest(FlowTest):
         with pytest.raises(FlowTestUnexpectedViewException):
             self.run_sequence([
                 FlowStep(MainMenuView, button_data_selection=RET_CODE__POWER_BUTTON),
-                FlowStep(ToolsMenuView),  # <-- Wrong target View! Should raise an AssertionError.
+                FlowStep(ToolsMenuView),  # <-- Wrong target View!
             ])
     
 
@@ -74,7 +74,7 @@ class TestFlowTest(FlowTest):
         """
         with pytest.raises(FlowTestUnexpectedRedirectException) as e:
             self.run_sequence([
-                FlowStep(SeedsMenuView, screen_return_value=0),  # <-- No seeds loaded, so it'll redirect elsewhere
+                FlowStep(SeedsMenuView, button_data_selection=SeedsMenuView.LOAD),  # <-- No seeds loaded, so it'll redirect elsewhere
             ])
 
         # This time we'll show that we know it should redirect

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,7 +1,7 @@
 import pytest
 
 # Must import test base before the Controller
-from base import FlowTest, FlowStep, FlowTestUnexpectedViewException, FlowTestInvalidButtonDataSelectionException
+from base import FlowTest, FlowStep, FlowTestUnexpectedRedirectException, FlowTestUnexpectedViewException, FlowTestInvalidButtonDataSelectionException
 
 from seedsigner.controller import Controller
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON
@@ -68,11 +68,11 @@ class TestFlowTest(FlowTest):
             ])
 
 
-    def test_unexpected_redirect_flow(self):
+    def test_FlowTestUnexpectedRedirectException(self):
         """
-        If the FlowStep doesn't specify is_redirect when the View redirects, raise an exception.
+        If the FlowStep doesn't specify is_redirect when the View redirects, raise FlowTestUnexpectedRedirectException
         """
-        with pytest.raises(FlowTestUnexpectedViewException) as e:
+        with pytest.raises(FlowTestUnexpectedRedirectException) as e:
             self.run_sequence([
                 FlowStep(SeedsMenuView, screen_return_value=0),  # <-- No seeds loaded, so it'll redirect elsewhere
             ])

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -8,8 +8,8 @@ from base import FlowTestInvalidButtonDataSelectionException
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
-from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, RemoveMicroSDWarningView, View, NetworkMismatchErrorView, NotYetImplementedView
-from seedsigner.views import seed_views, scan_views, settings_views, tools_views
+from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
+from seedsigner.views import seed_views, scan_views, settings_views
 
 
 def load_seed_into_decoder(view: scan_views.ScanView):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -561,8 +561,6 @@ class TestMessageSigningFlows(FlowTest):
         expect_network_mismatch_error(self.load_short_message_into_decoder)
 
 
-
-
     def test_sign_message_option_disabled(self):
         """
         Should redirect to OptionDisabledView if a `signmessage` QR is scanned with
@@ -583,7 +581,7 @@ class TestMessageSigningFlows(FlowTest):
         # First test routing to update the setting
         self.run_sequence(
             sequence + [
-                FlowStep(OptionDisabledView, button_data_selection=OptionDisabledView.UPDATE_SETTING, is_redirect=True),
+                FlowStep(OptionDisabledView, button_data_selection=OptionDisabledView.UPDATE_SETTING),
                 FlowStep(settings_views.SettingsEntryUpdateSelectionView),
             ]
         )
@@ -591,7 +589,7 @@ class TestMessageSigningFlows(FlowTest):
         # Now test exiting to Main Menu
         self.run_sequence(
             sequence + [
-                FlowStep(OptionDisabledView, button_data_selection=OptionDisabledView.DONE, is_redirect=True),
+                FlowStep(OptionDisabledView, button_data_selection=OptionDisabledView.DONE),
                 FlowStep(MainMenuView),
             ]
         )

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -22,7 +22,7 @@ class TestViewFlows(FlowTest):
                 FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.RESET),
                 FlowStep(RestartView),
             ])
-        
+
 
     def test_power_off_flow(self):
         """
@@ -34,7 +34,7 @@ class TestViewFlows(FlowTest):
                 FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
                 FlowStep(PowerOffView),
             ])
-        
+
         # And again, but this time as if we were in the SeedSigner OS
         Settings.HOSTNAME = Settings.SEEDSIGNER_OS
         self.run_sequence([
@@ -43,7 +43,7 @@ class TestViewFlows(FlowTest):
             FlowStep(PowerOffView),  # returns BackStackView
             FlowStep(PowerOptionsView),
         ])
-    
+
 
     def test_not_yet_implemented_flow(self):
         """
@@ -59,13 +59,12 @@ class TestViewFlows(FlowTest):
             FlowStep(NotYetImplementedView),
             FlowStep(MainMenuView),
         ])
-    
+
 
     def test_unhandled_exception_flow(self):
         """
         Basic flow from any arbitrary View to the UnhandledExceptionView
         """
-        Settings.HOSTNAME = "NOT seedsigner-os"
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
             FlowStep(ToolsMenuView, button_data_selection=ToolsMenuView.KEYBOARD),


### PR DESCRIPTION
## Description

### Quick Background
A FlowTest sequence normally proceeds from View to View, exactly as if a user was clicking from one screen to the next.

But we also have redirects that are often invisible to the user (e.g. only Native Segwit is enabled, so skip the script type selection View).

There are three types of possible redirects:
* (newest) The View's `__init__` determines that the user should be redirected elsewhere and calls `View.set_redirect()`. In this case the View's `run()` is never called. This method is preferred but is not widely implemented yet.

* (most common) The View's `run()` immediately returns a new Destination without ever calling its `run_screen()`. This was how v0.5.0+ redirects were originally implemented.

* An unhandled exception occurs during any phase (in `__init__()`, in `run()` before or after `run_screen()`, or within the associated `Screen.display()`). The `Controller` catches the exception and redirects the user to the `UnhandledExceptionView`.

### The Problem
A `FlowStep` can specify `is_redirect=True` to indicate that the expected View should execute, but is expected to immediately return a new Destination without ever running its Screen.

But lack of clarity on the above three distinct redirect scenarios made that one single `is_redirect` attr ineffective and confusing in `FlowTest.run_sequence()`. This was wholly my fault, by the way! The original implementation more or less properly handled the middle case (redirect triggered in `View.run()`), maybe handled the first case correctly (triggered via `View.set_redirect()`), and definitely did NOT handle the third case correctly (`UnhandledExceptionView`).

Yes, FlowTests have been passing all this time, but partially due to silent, unnoticed failures. A typical example is that the last or penultimate FlowStep triggers an `UnhandledExceptionView` but the heart of the FlowTest is already over and so there's no next step (next expected View) that would fail.

But if the penultimate FlowStep lands on `UnhandledExceptionView`, shouldn't the FINAL step detect some kind of mismatch? This is where the second aspect of the problem comes in: when do we `sequence.pop(0)` the current FlowStep out of the sequence?

In this example, that final FlowStep was being improperly popped before the FlowTest could verify that we got the expected View. So the FlowTest was totally unaware that our sequence ended on the wrong View.

### The Fix
First, just getting mental clarity on those three possible redirect scenarios was huge.

Second, remove ALL the `sequence.pop(0)` calls that created too many confusing hell scenarios.

Instead, wrap it all in a `try...finally` block to guarantee that `sequence.pop(0)` is always called after each iteration AND that it's only called once.

The explicit handling for each of the redirect scenarios:
* `__init__.set_redirect()` obviously happens before the Screen is run, so put that logic at the front.

* Redirects coming out of `View.run()` are obvious because we can check the `call_count` on `run_screen()`.

* And `UnhandledExceptionView` doesn't actually need any special handling. If the FlowTest was expecting that to be triggered, it would specify `is_redirect=True` and the next FlowStep would be the `UnhandledExceptionView`. If the FlowTest was NOT expecting it, either the `is_redirect=True` would be missing (in which case we raise the new `FlowTestUnexpectedRedirectException`) or the next FlowStep's expected View won't match when we run the next iteration in the sequence (resulting in a `FlowTestUnexpectedViewException`).

Additional:
* `FlowTestRunScreenNotExecutedException` removed as its purpose has been superseded by `FlowTestUnexpectedRedirectException`. Raised when a redirect occurs but the FlowStep did not specify `is_redirect=True`.
* `FlowTestMissingRedirectException` added for the opposite scenario (FlowStep specified `is_redirect=True` but no redirect happened.
* `FlowTest.run_sequence().run_screen()` no longer makes any changes to the `sequence`. Just (simulate) running the f'n Screen.
* Completing the FlowTest sequence is now cleaner. Before, if the last FlowStep's View was, say, `MainMenuView` but with no user input result specified, the FlowTest would execute the View and its Screen, but would actually create a quiet Exception that we just weren't aware of and wouldn't care about anyway (the View runs as if the Screen returned `None`, which then causes an `IndexError` when the View tries to access `None` to see which item in its `button_list` the user ostensibly selected).
  * FlowTest can exit on the last item in the sequence if the FlowStep implies no user interaction.
  * Can still exit as before when the `sequence` list is empty.

---

This pull request is categorized as a:

- [x] Bug fix
- [x] Code refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] Yes

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
