### PR TITLE
[Bugfix] Restore log access in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ branch = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-p no:logging"
+log_level = "DEBUG"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,20 @@ Run a specific test:
 pytest tests/test_this_file.py::test_this_specific_test
 ```
 
+Force pytest to show logging output:
+```bash
+pytest tests/test_this_file.py::test_this_specific_test -o log_cli=1
+
+# or (same result)
+
+pytest tests/test_this_file.py::test_this_specific_test --log-cli-level=DEBUG
+```
+
+Annoying complications:
+* If you want to see `print()` statements that are in a test file, add `-s`
+* Better idea: use a proper logger in the test file and use one of the above options to display logs
+
+
 ### Test Coverage
 Run tests and generate test coverage
 ```

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,8 @@ from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.settings import Settings
 from seedsigner.views.view import Destination, MainMenuView, View
 
+import logging
+logger = logging.getLogger(__name__)
 
 
 
@@ -90,6 +92,28 @@ class BaseTest:
 
     def teardown_method(self):
         BaseTest.remove_settings()
+
+
+
+class TestBaseTest(BaseTest):
+    def test_howto_log_from_test(self):
+        """
+            Not actually a test, just a demonstration of how to use/access logs while
+            testing.
+
+            Enable log visibility by running with:
+                --log-cli-level=NOTSET (or the level of your choice)
+                -o log_cli=1
+            
+            Enable print() visibility by running with:
+                -s or --capture=no
+        """
+        print("This is a test print message")
+        logger.info("This is a test log message")
+        logger.debug("This is a test debug message")
+        logger.warning("This is a test warning message")
+        logger.error("This is a test error message")
+        logger.critical("This is a test critical message")
 
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,40 +1,50 @@
 import logging
+import pytest
 import sys
 from unittest.mock import patch, call
 
-import pytest
+# Must import from base.py before any other SeedSigner dependency to mock out certain imports
+from base import BaseTest
 
 sys.path.insert(0,'src')
 from main import main
 
 
-@patch("main.Controller")
-def test_main__argparse__default(patched_controller):
-    main([])
-    assert logging.root.level == logging.INFO
-    assert logging.getLogger().getEffectiveLevel() == logging.INFO
-    patched_controller.assert_has_calls(
-        [call.get_instance(), call.get_instance().start()]
-    )
+class TestMain(BaseTest):
+    """
+    The `main.Controller` has to be patched / mocked out otherwise the virtual SeedSigner
+    will just keep running and cause the test to hang.
+    """
+    @patch("main.Controller")
+    def test_main__argparse__default(self, patched_controller):
+        main([])
+        assert logging.root.level == logging.INFO
+        assert logging.getLogger().getEffectiveLevel() == logging.INFO
+        patched_controller.assert_has_calls(
+            [call.get_instance(), call.get_instance().start()]
+        )
 
 
-@patch("main.Controller")
-def test_main__argparse__enable_debug_logging(patched_controller):
-    main(["--loglevel", "DEBUG"])
-    assert logging.root.level == logging.DEBUG
-    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
-    patched_controller.assert_has_calls(
-        [call.get_instance(), call.get_instance().start()]
-    )
+    @patch("main.Controller")
+    def test_main__argparse__enable_debug_logging(self, patched_controller):
+        main(["--loglevel", "DEBUG"])
+        assert logging.root.level == logging.DEBUG
+        assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+        patched_controller.assert_has_calls(
+            [call.get_instance(), call.get_instance().start()]
+        )
 
 
-def test_main__argparse__invalid_arg():
-    with pytest.raises(SystemExit):
-        main(["--invalid"])
+    def test_main__argparse__invalid_arg(self):
+        with pytest.raises(SystemExit):
+            main(["--invalid"])
 
 
-@patch("main.Controller")
-def test_main__logging__writes_to_stderr(patched_controller, capsys):
-    main([])
-    _, err = capsys.readouterr()
-    assert "Starting SeedSigner" in err and "INFO" in err
+    @patch("main.Controller")
+    def test_main__logging__writes_to_stderr(self, patched_controller, capsys):
+        main([])
+        _, err = capsys.readouterr()
+        assert "Starting SeedSigner" in err and "INFO" in err
+        patched_controller.assert_has_calls(
+            [call.get_instance(), call.get_instance().start()]
+        )


### PR DESCRIPTION
## Description

Current `dev` branch won't show any logs from SeedSigner code when running pytest, regardless of `-s`, `-o log_cli=1`, nor `--log-cli-level=DEBUG`.

Even on a failed test, our logging cannot be surfaced.

This PR:
* Alters `pyproject.toml` to restore the option to review the logs when running pytest AND to insure that the logs are presented when a test fails.

* Adds info in tests/README.md

* Adds a trivial demonstration test in tests/base.py


Misc:
* Bugfix on tests/test_main.py: This test file could not be run individually (`pytest tests/test_main.py`) because it was not importing tests/base.py which mocks out the problematic dependencies. Wrapping the tests in their own `BaseTest` class is just cosmetic but also ensures that the important import (`from base import BaseTest`) gets referenced so an IDE won't consider it an unnecessary import.

---

This pull request is categorized as a:

- [x] Bug fix
- [x] Code refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] Yes

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
