### PR TITLE
[Bugfix] Message Signing TextDoesNotFitException on long no whitespace messages

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1522,6 +1522,7 @@ class SeedSignMessageConfirmMessageScreen(ButtonListScreen):
                 text=self.sign_message_data["message"],
                 width=renderer.canvas_width - 2*GUIConstants.EDGE_PADDING,
                 height=message_height,
+                allow_text_overflow=True,
             )
             self.sign_message_data["paged_message"] = paged
 


### PR DESCRIPTION
## Description

Closes issue #550

Current message signing feature requires entire message to be made visible in the SeedSigner GUI without exception. This PR changes this behavior and would allow messages without whitespace and that do not fit in a single line to still be signed.

An alternative solution to this PR would be to improve handling text without whitespace and allow the text to wrap (virtual line breaks). This solution would require larger development effort over allowing text overflow.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
