### PR TITLE
[Bugfix] UI BTC Address cutoff in PSBTAddressDetailsScreen screen.

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -625,7 +625,7 @@ class PSBTAddressDetailsScreen(ButtonListScreen):
             0,
             0,
             self.canvas_width,
-            formatted_address.screen_y + formatted_address.height
+            formatted_address.screen_y + formatted_address.height + btc_amount.height
         ))
         body_img_y = self.top_nav.height + int((center_img_height - self.body_img.height - GUIConstants.COMPONENT_PADDING)/2)
 


### PR DESCRIPTION
## Description

"Will Send" (PSBTAddressDetailsScreen) screen in PSBT flow of receive address has the bottom address text cutoff (bug not in 0.7.0). I believe this is resolved by including the amount height in the center image crop.

Bug:
![PSBTAddressDetailsView](https://github.com/user-attachments/assets/71c676bd-f263-4f2e-8161-489b5cfa5f26)

Post PR Fix:
![PSBTAddressDetailsView fixed](https://github.com/user-attachments/assets/d5fa1cf7-e33a-45f9-a4c8-3ed90ebe28c2)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
