### PR TITLE
Fix issue caused by having is_sign_message method and property of same name

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -382,7 +382,7 @@ class DecodeQR:
                 return QRType.BITCOIN_ADDRESS
 
             # message signing
-            elif DecodeQR.is_sign_message(s):
+            elif s.startswith("signmessage"):
                 return QRType.SIGN_MESSAGE
 
             # config data
@@ -504,11 +504,6 @@ class DecodeQR:
             return True
         else:
             return False
-
-
-    @staticmethod
-    def is_sign_message(s):
-        return type(s) == str and s.startswith("signmessage")
 
 
     @staticmethod


### PR DESCRIPTION
## Description

Small fix of an issue caused by having a method and property of the same name.  In scan_views.py, the check:
`         elif self.decoder.is_sign_message: `
always passes the check because self.decoder.is_sign_message is of type method, evaluates to True because it's not None.  It doesn't seem to be causing any issues currently because it's the final elif check for the QR type, however when adding new QR types below that elif, it will never flow to them.  I experienced this when prototyping a new QR functionality.  The following example code demonstrates the issue:
```
class TestClass:
    @property
    def test_it(self):
        return False

    def test_it(variable : str):
        return False

t = TestClass()
if not t.test_it:
    print ("Everything fine, got False for type " + str(type(t.test_it)))
else:
    print ("Not fine, wanted the property function but rather is of type " + str(type(t.test_it)))
```
Which yields:
`Not fine, wanted the property function but rather is of type <class 'method'>`

This pull request is categorized as a:

- [x] Bug fix


## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other seedsigner-emulator


