### PR TITLE
Resolve 547

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 class SeedsMenuView(View):
     LOAD = "Load a seed"
+    CREATE = "Create a seed"
 
     def __init__(self):
         super().__init__()
@@ -49,7 +50,7 @@ class SeedsMenuView(View):
         button_data = []
         for seed in self.seeds:
             button_data.append((seed["fingerprint"], SeedSignerIconConstants.FINGERPRINT))
-        button_data.append("Load a seed")
+        button_data.extend([self.LOAD, self.CREATE])
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -61,8 +62,13 @@ class SeedsMenuView(View):
         if len(self.seeds) > 0 and selected_menu_num < len(self.seeds):
             return Destination(SeedOptionsView, view_args={"seed_num": selected_menu_num})
 
+        # accessed relative to len(self.seeds) which may have changed
         elif selected_menu_num == len(self.seeds):
             return Destination(LoadSeedView)
+
+        elif selected_menu_num == len(self.seeds) + 1:
+            from .tools_views import ToolsMenuView
+            return Destination(ToolsMenuView, view_args={"new_seeds_only": True})
 
         elif selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
@@ -213,8 +219,7 @@ class LoadSeedView(View):
 
         elif button_data[selected_menu_num] == self.CREATE:
             from .tools_views import ToolsMenuView
-            return Destination(ToolsMenuView)
-
+            return Destination(ToolsMenuView, view_args={"new_seeds_only": True})
 
 
 class SeedMnemonicEntryView(View):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -32,12 +32,18 @@ class ToolsMenuView(View):
     ADDRESS_EXPLORER = "Address Explorer"
     VERIFY_ADDRESS = "Verify address"
 
+    def __init__(self, new_seeds_only: bool = False):
+        super().__init__()
+        self.new_seeds_only = new_seeds_only
+
     def run(self):
-        button_data = [self.IMAGE, self.DICE, self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS]
+        button_data = [self.IMAGE, self.DICE, self.KEYBOARD]
+        if not self.new_seeds_only:
+            button_data.extend([self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS])
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
-            title="Tools",
+            title="Tools" if not self.new_seeds_only else "Create A Seed",
             is_button_text_centered=False,
             button_data=button_data
         )
@@ -54,10 +60,10 @@ class ToolsMenuView(View):
         elif button_data[selected_menu_num] == self.KEYBOARD:
             return Destination(ToolsCalcFinalWordNumWordsView)
 
-        elif button_data[selected_menu_num] == self.ADDRESS_EXPLORER:
+        elif not self.new_seeds_only and button_data[selected_menu_num] == self.ADDRESS_EXPLORER:
             return Destination(ToolsAddressExplorerSelectSourceView)
 
-        elif button_data[selected_menu_num] == self.VERIFY_ADDRESS:
+        elif not self.new_seeds_only and button_data[selected_menu_num] == self.VERIFY_ADDRESS:
             from seedsigner.views.scan_views import ScanAddressView
             return Destination(ScanAddressView)
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -9,7 +9,7 @@ from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
 from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
-from seedsigner.views import seed_views, scan_views, settings_views
+from seedsigner.views import seed_views, scan_views, settings_views, tools_views
 
 
 def load_seed_into_decoder(view: scan_views.ScanView):
@@ -643,3 +643,11 @@ class TestMessageSigningFlows(FlowTest):
         self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
         expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
 
+
+    def test_create_seed_via_seeds_while_none_loaded(self):
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.CREATE),
+            FlowStep(tools_views.ToolsMenuView),
+        ])


### PR DESCRIPTION
## Description

resolves #547

Can now "Create a new seed" from:
* Seeds menu with seed(s) loaded instead of going thru "Load a seed", but title is "Create a Seed" and no Address Explorer/Verification offered

Can still do so via Seeds menu when no seed is loaded, but won't be offered the Explorer/Verification tools.
Can still do so via Tools menu.

Im late to get this submitted, and it still deserves more tests that prove can:
* flow to it immediately in Seeds menu w/ seeds loaded... and that other tools are not available.
* flow to it from "Load a seed" screen... and that other tools are not available.
* flow to it from Tools menu, and the other tools ARE available.


_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
