### PR TITLE
[UI tweak] Minor adjustment to `PSBTChangeDetailsScreen`

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -656,15 +656,12 @@ class PSBTChangeDetailsScreen(ButtonListScreen):
         ))
 
         self.components.append(FormattedAddress(
-            screen_y=self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING,
+            screen_y=self.components[-1].screen_y + self.components[-1].height,
             address=self.address,
             max_lines=1,
         ))
 
         screen_y = self.components[-1].screen_y + self.components[-1].height + 2*GUIConstants.COMPONENT_PADDING
-        if self.is_multisig and not self.is_change_addr_verified:
-            # Adjust the vertical spacing
-            screen_y -= GUIConstants.COMPONENT_PADDING
         self.components.append(IconTextLine(
             icon_name=SeedSignerIconConstants.FINGERPRINT,
             icon_color=GUIConstants.INFO_COLOR,


### PR DESCRIPTION
## Description

The vertical alignment of the abbreviated address is just slightly off.

BEFORE / AFTER:
<img src="https://github.com/user-attachments/assets/89da5051-ad43-40dd-8b3b-eb4fedd44eef" width="240"> <img src="https://github.com/user-attachments/assets/fa6bab30-1384-46e3-b1bd-9815eef519da" width="240">

BEFORE / AFTER:
<img src="https://github.com/user-attachments/assets/d5c03387-5a59-4b99-be66-43615cf5e133" width="240"> <img src="https://github.com/user-attachments/assets/c0f16fdb-2982-49cb-9051-c707459c9555" width="240">


This pull request is categorized as a:

- [x] UI tweak

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other (only via screenshot generator since @bitcoinprecept currently has my dev SeedSigner!) 

