### PR TITLE
[Enhancement] MicroSD toast timer settings

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -248,7 +248,7 @@ class Controller(Singleton):
             * initial_destination: The first View to run. If None, the MainMenuView is
             used. Only used by the test suite.
         """
-        from seedsigner.views import MainMenuView, BackStackView
+        from seedsigner.views import MainMenuView, BackStackView, RemoveMicroSDWarningView
         from seedsigner.views.screensaver import OpeningSplashScreen
         from seedsigner.gui.toast import RemoveSDCardToastManagerThread
 
@@ -289,7 +289,7 @@ class Controller(Singleton):
             if self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS:
                 self.activate_toast(RemoveSDCardToastManagerThread())
             elif self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FOREVER:
-                self.activate_toast(RemoveSDCardToastManagerThread(duration=1e6, hw_input_lock=True))
+                next_destination = Destination(RemoveMicroSDWarningView)
 
             while True:
                 # Destination(None) is a special case; render the Home screen

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -11,6 +11,7 @@ from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.seed import Seed
 from seedsigner.models.seed_storage import SeedStorage
 from seedsigner.models.settings import Settings
+from seedsigner.models.settings import SettingsConstants
 from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
 from seedsigner.views.screensaver import ScreensaverScreen
@@ -285,7 +286,10 @@ class Controller(Singleton):
                 next_destination = Destination(MainMenuView)
             
             # Set up our one-time toast notification tip to remove the SD card
-            self.activate_toast(RemoveSDCardToastManagerThread())
+            if self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS:
+                self.activate_toast(RemoveSDCardToastManagerThread())
+            elif self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FOREVER:
+                self.activate_toast(RemoveSDCardToastManagerThread(duration=1e6, hw_input_lock=True))
 
             while True:
                 # Destination(None) is a special case; render the Home screen

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -88,6 +88,7 @@ class BaseToastOverlayManagerThread(BaseThread):
     def __init__(self,
                  activation_delay: int = 0,  # seconds before toast is displayed
                  duration: int = 3,          # seconds toast is displayed
+                 hw_input_lock: bool = False,
                  ):
         from seedsigner.controller import Controller
         from seedsigner.gui.renderer import Renderer
@@ -95,6 +96,7 @@ class BaseToastOverlayManagerThread(BaseThread):
         super().__init__()
         self.activation_delay: int = activation_delay
         self.duration: int = duration
+        self.hw_input_lock: bool = hw_input_lock
         self._toggle_renderer_lock: bool = False
 
         self.renderer = Renderer.get_instance()
@@ -124,7 +126,7 @@ class BaseToastOverlayManagerThread(BaseThread):
         logger.info(f"{self.__class__.__name__}: started")
         start = time.time()
         while time.time() - start < self.activation_delay:
-            if self.hw_inputs.has_any_input():
+            if self.hw_inputs.has_any_input() and not self.hw_input_lock:
                 # User has pressed a button, cancel the toast
                 logger.info(f"{self.__class__.__name__}: Canceling toast due to user input")
                 return
@@ -140,7 +142,7 @@ class BaseToastOverlayManagerThread(BaseThread):
             has_rendered = False
             previous_screen_state = None
             while self.keep_running and self.should_keep_running():
-                if self.hw_inputs.has_any_input():
+                if self.hw_inputs.has_any_input() and not self.hw_input_lock:
                     # User has pressed a button, hide the toast
                     logger.info(f"{self.__class__.__name__}: Exiting due to user input")
                     break
@@ -187,21 +189,29 @@ class BaseToastOverlayManagerThread(BaseThread):
 
 
 class RemoveSDCardToastManagerThread(BaseToastOverlayManagerThread):
-    def __init__(self, activation_delay=3):
+    def __init__(self, activation_delay=3, duration=5, hw_input_lock=False):
         # Note: activation_delay is configurable so the screenshot generator can get the
         # toast to immediately render.
         super().__init__(
             activation_delay=activation_delay,  # seconds
-            duration=1e6,                       # seconds ("forever")
+            duration=duration,                  # seconds
+            hw_input_lock=hw_input_lock,
         )
 
 
     def instantiate_toast(self) -> ToastOverlay:
+        if self.hw_input_lock:
+            self.height=self.renderer.canvas_height # Fullscreen toast
+            label_text="You must remove\nthe SD card now"
+        else:
+            self.height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING
+            label_text="You can remove\nthe SD card now"
+
         return ToastOverlay(
             icon_name=SeedSignerIconConstants.MICROSD,
-            label_text="You can remove\nthe SD card now",
+            label_text=label_text,
             font_size=GUIConstants.BODY_FONT_SIZE,
-            height=GUIConstants.BODY_FONT_SIZE * 2 + GUIConstants.BODY_LINE_SPACING + GUIConstants.EDGE_PADDING,
+            height=self.height
         )
 
 

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -124,6 +124,15 @@ class SettingsConstants:
         (CUSTOM_DERIVATION, "Custom Derivation"),
     ]
 
+    MICROSD_TOAST_TIMER_DISABLED = "D"
+    MICROSD_TOAST_TIMER_FIVE_SECONDS = "E"
+    MICROSD_TOAST_TIMER_FOREVER = "inf"
+    ALL_MICROSD_TOAST_TIMERS = [
+        (MICROSD_TOAST_TIMER_DISABLED, "Disabled"),
+        (MICROSD_TOAST_TIMER_FIVE_SECONDS, "5 seconds"),
+        (MICROSD_TOAST_TIMER_FOREVER, "Until SD removed")
+    ]
+
     WORDLIST_LANGUAGE__ENGLISH = "en"
     WORDLIST_LANGUAGE__CHINESE_SIMPLIFIED = "zh_Hans_CN"
     WORDLIST_LANGUAGE__CHINESE_TRADITIONAL = "zh_Hant_TW"
@@ -167,6 +176,7 @@ class SettingsConstants:
     SETTING__DIRE_WARNINGS = "dire_warnings"
     SETTING__QR_BRIGHTNESS_TIPS = "qr_brightness_tips"
     SETTING__PARTNER_LOGOS = "partner_logos"
+    SETTING__MICROSD_TOAST_TIMER = "microsd_toast_timer"
 
     SETTING__DEBUG = "debug"
 
@@ -478,6 +488,14 @@ class SettingsDefinition:
                       help_text="Native Segwit only",
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
+        
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__MICROSD_TOAST_TIMER,
+                      display_name="MicroSD toast timer",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_MICROSD_TOAST_TIMERS,
+                      default_value=SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__MESSAGE_SIGNING,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -423,8 +423,6 @@ class RemoveMicroSDWarningView(View):
 
         from seedsigner.hardware.microsd import MicroSD
         if button_data[selected_menu_num] == self.CONTINUE and MicroSD.get_instance().is_inserted:
-            return Destination(MainMenuView, clear_history=True)
-        elif button_data[selected_menu_num] == self.DISMISS:
-            return Destination(MainMenuView, clear_history=True)
-        else:
             return Destination(RemoveMicroSDWarningView, clear_history=True)
+        else:
+            return Destination(MainMenuView, clear_history=True)

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -416,7 +416,7 @@ class RemoveMicroSDWarningView(View):
             title="Action Required",
             status_icon_name=SeedSignerIconConstants.MICROSD,
             status_headline="",
-            text="You must remove the,\nMicroSD card to continue.",
+            text="You must remove the\nMicroSD card to continue.",
             show_back_button=False,
             button_data=button_data,
         )

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Type
 
-from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
+from seedsigner.gui.components import SeedSignerIconConstants
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON, RET_CODE__BACK_BUTTON
 from seedsigner.gui.screens.screen import BaseScreen, DireWarningScreen, LargeButtonScreen, PowerOffScreen, PowerOffNotRequiredScreen, ResetScreen, WarningScreen
 from seedsigner.models.settings import Settings, SettingsConstants
@@ -405,19 +405,26 @@ class RemoveMicroSDWarningView(View):
     """
         Warning to remove the microsd
     """
-    def __init__(self, next_view: View):
-        super().__init__()
-        self.next_view = next_view
+    CONTINUE = "Continue"
+    DISMISS = "Dismiss"
+
 
     def run(self):
-        self.run_screen(
+        button_data = [self.CONTINUE, self.DISMISS]
+        selected_menu_num = self.run_screen(
             WarningScreen,
-            title="Security Tip",
-            status_icon_name=FontAwesomeIconConstants.SDCARD,
+            title="Action Required",
+            status_icon_name=SeedSignerIconConstants.MICROSD,
             status_headline="",
-            text="For maximum security,\nremove the MicroSD card\nbefore continuing.",
+            text="You must remove the,\nMicroSD card to continue.",
             show_back_button=False,
-            button_data=["Continue"],
+            button_data=button_data,
         )
 
-        return Destination(self.next_view, clear_history=True)
+        from seedsigner.hardware.microsd import MicroSD
+        if button_data[selected_menu_num] == self.CONTINUE and MicroSD.get_instance().is_inserted:
+            return Destination(MainMenuView, clear_history=True)
+        elif button_data[selected_menu_num] == self.DISMISS:
+            return Destination(MainMenuView, clear_history=True)
+        else:
+            return Destination(RemoveMicroSDWarningView, clear_history=True)

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -165,7 +165,6 @@ def test_generate_screenshots(target_locale):
             (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_removed', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__REMOVED)),
             (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_inserted', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__INSERTED)),
             (MainMenuView, {}, 'MainMenuView_RemoveSDCardToast', RemoveSDCardToastManagerThread(activation_delay=0)),
-            (MainMenuView, {}, 'MainMenuView_RemoveSDCardToast_Forever', RemoveSDCardToastManagerThread(activation_delay=0, fullscreen=True, hw_input_lock=True)),
             PowerOptionsView,
             RestartView,
             PowerOffView,

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -33,7 +33,7 @@ from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
-from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
+from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, RemoveMicroSDWarningView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views)
 from seedsigner.views.view import ErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView, View
 
@@ -165,6 +165,7 @@ def test_generate_screenshots(target_locale):
             (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_removed', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__REMOVED)),
             (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_inserted', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__INSERTED)),
             (MainMenuView, {}, 'MainMenuView_RemoveSDCardToast', RemoveSDCardToastManagerThread(activation_delay=0)),
+            RemoveMicroSDWarningView,
             PowerOptionsView,
             RestartView,
             PowerOffView,

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -165,6 +165,7 @@ def test_generate_screenshots(target_locale):
             (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_removed', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__REMOVED)),
             (MainMenuView, {}, 'MainMenuView_SDCardStateChangeToast_inserted', SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__INSERTED)),
             (MainMenuView, {}, 'MainMenuView_RemoveSDCardToast', RemoveSDCardToastManagerThread(activation_delay=0)),
+            (MainMenuView, {}, 'MainMenuView_RemoveSDCardToast_Forever', RemoveSDCardToastManagerThread(activation_delay=0, fullscreen=True, hw_input_lock=True)),
             PowerOptionsView,
             RestartView,
             PowerOffView,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -110,6 +110,7 @@ class TestController(BaseTest):
         assert controller.settings.get_value(SettingsConstants.SETTING__DIRE_WARNINGS) == SettingsConstants.OPTION__ENABLED
         assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS_TIPS) == SettingsConstants.OPTION__ENABLED
         assert controller.settings.get_value(SettingsConstants.SETTING__PARTNER_LOGOS) == SettingsConstants.OPTION__ENABLED
+        assert controller.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS
 
         # Hidden Settings defaults
         assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS) == 62


### PR DESCRIPTION
## Description

Proposed solution for issue #546 

Provides 3 microSD options:

-   Toast disabled
-   5-sec toast (default)
-   SD card removal required* (fullscreen dialog, cannot proceed unless microSD is removed)

![SettingsEntryUpdateSelectionView_microsd_toast_timer](https://github.com/user-attachments/assets/1add75f6-9558-408b-ac24-0eb6b05c85a6)

For the third option, the new warning dialog UI (re-used and old View class that was unused) looks as follows:

![RemoveMicroSDWarningView](https://github.com/user-attachments/assets/91a4804e-7274-4cb7-b82e-e396e83bb0eb)

So the user can choose between:

- Remove MicroSD and then press "Continue"
- Press "Dismiss" to modify persistent settings before removing the MicroSD

This behaviour has the possibility to be different. In previous commit https://github.com/SeedSigner/seedsigner/commit/255464783009dd5caae1077d2486acc3e8267c14, a fullscreen toast with no dialog options is shown instead of the warning dialog. Here, user **must** remove MicroSD to continue. However, as persistent settings must be written to the MicroSD to continue, user should have to insert it again if they wanted to hange the settings. 

That behaviour was a bit more confusing for the user but is still an option if most devs agree on it.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other

