### PR TITLE
Support exotic sighashes

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -524,7 +524,7 @@ class PSBTFinalizeView(View):
         else:
             # Sign PSBT
             sig_cnt = PSBTParser.sig_count(psbt)
-            psbt.sign_with(psbt_parser.root)
+            psbt.sign_with(psbt_parser.root, None)
             trimmed_psbt = PSBTParser.trim(psbt)
 
             if sig_cnt == PSBTParser.sig_count(trimmed_psbt):


### PR DESCRIPTION
## Description

Solves issue #545

Before this change, attempting to sign a psbt specifying any sighash other than SIGHASH_ALL would show an error on the Seedsigner.

The gist of the issue is that if the sighash argument of `psbt.sign_with()` is not explitictly set to [None](https://github.com/diybitcoinhardware/embit/blob/v0.8.0/src/embit/psbt.py#L926), embit doesn't take the sighash in the psbt into account. With sighash=None, embit signs each input in the manner that the psbt data specifies.

This has been tested in native segwit and taproot. However, taproot transactions with an exotic sighash are not signed correctly. I suspect this could be an issue with embit, not seedsigner.

I'm not sure how to write a test for this change, feedback appreciated.


### Testing approach

1. Set up the Seedsigner [emulator](https://github.com/enteropositivo/seedsigner-emulator) and configured it in testnet mode.
2. Loaded a dummy seed into the seedsigner (e.g. aim 12 times).
3. Created a cold wallet in Sparrow by exporting the xpub of that seed.
4. Sent some testnet sats to this new wallet.
5. Created a transaction from Sparrow. In the next menu, a non-standard sighash such as SINGLE|ACP was chosen.
6. Scanned the unsigned transaction QR with seedsigner and signed it.
7. Scanned the signed transaction QR from Sparrow and broadcasted it.

This pull request is categorized as a:

- [X] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [X] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [X] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [X] Other: Enteropositivo's Seedsigner Emulator


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
