### PR TITLE
new url for libzbar; altered config for seedsigner service

### DIFF
--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -122,7 +122,7 @@ SeedSigner requires `zbar` at 0.23.x or higher.
 
 Download the binary:
 ```bash
-curl -L http://raspbian.raspberrypi.org/raspbian/pool/main/z/zbar/libzbar0_0.23.90-1_armhf.deb --output libzbar0_0.23.90-1_armhf.deb
+curl -L http://raspbian.raspberrypi.org/raspbian/pool/main/z/zbar/libzbar0_0.23.90-1+deb11u1_armhf.deb --output libzbar0_0.23.90-1_armhf.deb
 ```
 
 And then install it:
@@ -211,7 +211,9 @@ Description=Seedsigner
 [Service]
 User=pi
 WorkingDirectory=/home/pi/seedsigner/src/
-ExecStart=/usr/bin/python3 main.py > /dev/null 2>&1
+ExecStart=/usr/bin/python3 main.py
+StandardOutput=null
+ErrorOutput=null
 Restart=always
 
 [Install]
@@ -220,7 +222,7 @@ WantedBy=multi-user.target
 
 _Note: For local dev you'll want to edit the `Restart=always` line to `Restart=no`. This way when your dev code crashes it won't keep trying to restart itself. Note that the UI "Reset" will no longer work when auto-restarts are disabled._
 
-_Note: Debugging output is completely wiped via routing the output to `/dev/null 2>&1`. When working in local dev, you'll `kill` the `systemd` SeedSigner service and just directly run the code on demand so you can see all the debugging output live._
+_Note: Debugging output is completely wiped via routing the stdout and stderr to `/dev/null`. When working in local dev, you'll `kill` the `systemd` SeedSigner service and just directly run the code on demand so you can see all the debugging output live._
 
 Use `CTRL-X` and `y` to exit and save changes.
 


### PR DESCRIPTION
## Description

While recently rebuilding my manual-build development raspi-os sdcard image, I ran into two problems:
* The expected libzbar file was no longer available, as mentioned/solved in #551
* The seedsigner service failed to restart, complaining about syntax with traditional redirection to /dev/null

This pull request is categorized as:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [X] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms/os:

- [X] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.

