### PR TITLE
[README] Fix internal link to Verification section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * [Project Summary](#project-summary)
 * [Shopping List](#shopping-list)
 * [Software Installation](#software-installation)
-  * [Verifying the Software](#verifying-the-software)
+  * [Verifying your download](#verifying-your-download)
 * [Enclosure Designs](#enclosure-designs)
 * [SeedQR Printable Templates](#seedqr-printable-templates)
 * [Build from Source](#build-from-source)
@@ -119,13 +119,13 @@ Once the files have all finished downloading, follow the steps below to verify t
 [Our previous software versions are available here](https://github.com/SeedSigner/seedsigner/releases). Choose a specific version and then expand the *Assets* sub-heading to display the .img file binary and also the 2 associated signature files. **Note:** The prior version files will have lower numbers than the scripts and examples provided in this document, but the naming format will be the same, so you can edit them as required for signature verification etc.   
 
 
-## Verifying that the downloaded files are authentic (optional but highly recommended!)
+## Verifying your download
 
-You can quickly verify that the software you just downloaded is both authentic and unaltered, by following these instructions.
-We assume you are running the commands from a computer where both [GPG](https://gnupg.org/download/index.html) and [shasum](https://command-not-found.com/shasum) are already installed, and that you also know [how to navigate on a terminal](https://terminalcheatsheet.com/guides/navigate-terminal). 
+You can quickly verify that the software you just downloaded is both authentic and unaltered by following these instructions.
+We assume you are running the commands from a computer where both [GPG](https://gnupg.org/download/index.html) and [shasum](https://command-not-found.com/shasum) are already installed and that you also know [how to navigate on a terminal](https://terminalcheatsheet.com/guides/navigate-terminal). 
 
 > You must run the following verification before opening or mounting the .img file.
-> Some operating systems modify the file on mount causing verification to fail.
+> Some operating systems modify the file on mount, causing verification to fail.
 
 ### Step 1. Verify that the signature (.sig) file is genuine:
 


### PR DESCRIPTION
## Description

The internal link at the table of contents to the verification section was broken; Markdown references only work when the "#" anchor matches the subhead text it's referring to.

This simplified section title also makes it easy to link to this section from elsewhere (e.g. the release notes).

Also minor comma usage edits that my eye happened to catch. A follow-up round of light edits and simplifications is probably overdue.

---

I think this whole README could use some trimming down. The verification instructions could easily be pulled out into their own doc.

---

This pull request is categorized as a:

- [x] Bug fix
- [x] Documentation

## Checklist

I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR
- [x] N/A

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] N/A
