### PR TITLE
Lock translations submodule to 0.8.5-rc1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src/seedsigner/resources/seedsigner-translations"]
 	path = src/seedsigner/resources/seedsigner-translations
 	url = https://github.com/SeedSigner/seedsigner-translations.git
-	branch = dev
+	branch = 0.8.5-rc1
 [submodule "seedsigner-screenshots"]
 	path = seedsigner-screenshots
 	url = https://github.com/SeedSigner/seedsigner-screenshots.git


### PR DESCRIPTION
## Description

Points the `seedsigner-translations` submodule to its `0.8.5-rc1` release tag.

This will enable reproducible builds by locking the translations for this release tag.

---

This pull request is categorized as a:
- [x] Other

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other