### PR TITLE
[Screen Redesign] Light rearrangement of SeedAddressVerificationSuccess

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: seedsigner 0.8.5\n"
+"Project-Id-Version: seedsigner 0.8.5-rc1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-11-03 14:15-0600\n"
+"POT-Creation-Date: 2024-12-30 13:43-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -121,9 +121,8 @@ msgid "OP_RETURN"
 msgstr ""
 
 #. Label for a change output in the PSBT Overview flow diagram
-#. Used in a sentence describing the address type (change or receive)
 #: src/seedsigner/gui/screens/psbt_screens.py
-#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/psbt_views.py
 msgid "change"
 msgstr ""
 
@@ -204,11 +203,15 @@ msgstr ""
 msgid "Darker"
 msgstr ""
 
-#: src/seedsigner/gui/screens/screen.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/gui/screens/screen.py
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
 msgid "Success!"
 msgstr ""
 
-#: src/seedsigner/gui/screens/screen.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/gui/screens/screen.py
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
 msgid "OK"
 msgstr ""
 
@@ -389,6 +392,25 @@ msgstr ""
 #. Inserts the nth address number (e.g. "Checking address 7")
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Checking address {}"
+msgstr ""
+
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Address Verified"
+msgstr ""
+
+#. Describes the address type (change or receive)
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "change address"
+msgstr ""
+
+#. Describes the address type (change or receive)
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "receive address"
+msgstr ""
+
+#. Describes the address index (e.g. "index 7")
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "index {}"
 msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
@@ -1260,30 +1282,6 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Can't validate a single sig addr without specifying a seed"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "multisig"
-msgstr ""
-
-#. Inserts the seed fingerprint
-#: src/seedsigner/views/seed_views.py
-msgid "seed {}"
-msgstr ""
-
-#. Used in a sentence describing the address type (change or receive)
-#: src/seedsigner/views/seed_views.py
-msgid "receive"
-msgstr ""
-
-#. Address verification success message (e.g. "bc1qabc = seed 12345678's
-#. receive address #0.")
-#: src/seedsigner/views/seed_views.py
-msgid "{} = {}'s {} address #{}."
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Address Verified"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -332,7 +332,7 @@ class ButtonListScreen(BaseTopNavScreen):
                 active_button_label = button_option.active_button_label
             
             else:
-                raise Exception("Refactor needed!")
+                raise Exception("Refactor to ButtonOption approach needed!")
 
             button_kwargs = dict(
                 text=_(button_label),  # Wrap here for just-in-time translations
@@ -923,13 +923,14 @@ class LargeIconStatusScreen(ButtonListScreen):
             self.components.append(self.warning_headline_textarea)
             next_y = next_y + self.warning_headline_textarea.height
 
-        self.components.append(TextArea(
-            height=self.buttons[0].screen_y - next_y,
-            text=_(self.text),
-            width=self.canvas_width,
-            edge_padding=self.text_edge_padding,  # Don't render all the way up to the far left/right edges
-            screen_y=next_y,
-        ))
+        if self.text:
+            self.components.append(TextArea(
+                height=self.buttons[0].screen_y - next_y,
+                text=_(self.text),
+                width=self.canvas_width,
+                edge_padding=self.text_edge_padding,  # Don't render all the way up to the far left/right edges
+                screen_y=next_y,
+            ))
 
 
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1524,7 +1524,7 @@ class SeedAddressVerificationSuccessScreen(LargeIconStatusScreen):
         self.status_headline = _("Address Verified")
         self.button_data = [ButtonOption("OK")]
         self.is_bottom_list = True
-        self.show_back_button = False,
+        self.show_back_button = False
         super().__post_init__()
 
         if self.verified_index_is_change:

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1,24 +1,24 @@
-import math
 import logging
+import math
 import time
 
 from dataclasses import dataclass
 from gettext import gettext as _
+from PIL import Image, ImageDraw, ImageFilter
 from typing import List
 
-from PIL import Image, ImageDraw, ImageFilter
-from seedsigner.gui.renderer import Renderer
+from seedsigner.hardware.buttons import HardwareButtons, HardwareButtonsConstants
 from seedsigner.helpers.qr import QR
+from seedsigner.gui.components import (Button, FontAwesomeIconConstants, Fonts, FormattedAddress, IconButton,
+    IconTextLine, SeedSignerIconConstants, TextArea, GUIConstants, reflow_text_into_pages)
+from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
+from seedsigner.gui.renderer import Renderer
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 
-from .screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen, WarningEdgesMixin
-from ..components import (Button, FontAwesomeIconConstants, Fonts, FormattedAddress, IconButton,
-    IconTextLine, SeedSignerIconConstants, TextArea, GUIConstants, reflow_text_into_pages)
-
-from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
-from seedsigner.hardware.buttons import HardwareButtons, HardwareButtonsConstants
+from .screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen, LargeIconStatusScreen, WarningEdgesMixin
 
 logger = logging.getLogger(__name__)
+
 
 
 @dataclass
@@ -1057,7 +1057,6 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                     self.hw_button2.render()
 
                 self.renderer.show_image()
-                
 
 
 
@@ -1509,6 +1508,49 @@ class SeedAddressVerificationScreen(ButtonListScreen):
                     self.renderer.show_image()
 
                 time.sleep(0.1)
+
+
+
+@dataclass
+class SeedAddressVerificationSuccessScreen(LargeIconStatusScreen):
+    address: str = None
+    verified_index: int = None
+    verified_index_is_change: bool = None
+
+
+    def __post_init__(self):
+        # Customize defaults
+        self.title = _("Success!")
+        self.status_headline = _("Address Verified")
+        self.button_data = [ButtonOption("OK")]
+        self.is_bottom_list = True
+        self.show_back_button = False,
+        super().__post_init__()
+
+        if self.verified_index_is_change:
+            # TRANSLATOR_NOTE: Describes the address type (change or receive)
+            address_type = _("change address")
+        else:
+            # TRANSLATOR_NOTE: Describes the address type (change or receive)
+            address_type = _("receive address")
+
+        self.components.append(FormattedAddress(
+            screen_y=self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING,
+            address=self.address,
+            max_lines=1,  # Use abbreviated format w/ellipsis
+        ))
+
+        self.components.append(TextArea(
+            text=address_type,
+            screen_y=self.components[-1].screen_y + self.components[-1].height + 2*GUIConstants.COMPONENT_PADDING,
+        ))
+
+        # TRANSLATOR_NOTE: Describes the address index (e.g. "index 7")
+        index_str = _("index {}").format(self.verified_index)
+        self.components.append(TextArea(
+            text=index_str,
+            screen_y=self.components[-1].screen_y + self.components[-1].height + GUIConstants.COMPONENT_PADDING,
+        ))
 
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1977,36 +1977,12 @@ class SeedAddressVerificationSuccessView(View):
     
 
     def run(self):
-        from seedsigner.gui.screens.screen import LargeIconStatusScreen
-        address = self.controller.unverified_address["address"]
-        sig_type = self.controller.unverified_address["sig_type"]
-        verified_index = self.controller.unverified_address["verified_index"]
-        verified_index_is_change = self.controller.unverified_address["verified_index_is_change"]
-
-        if sig_type == SettingsConstants.MULTISIG:
-            source = _("multisig")
-        else:
-            # TRANSLATOR_NOTE: Inserts the seed fingerprint
-            source = _("seed {}").format(self.seed.get_fingerprint())
-
-        # TRANSLATOR_NOTE: Used in a sentence describing the address type (change or receive)
-        change_text = _("change")
-
-        # TRANSLATOR_NOTE: Used in a sentence describing the address type (change or receive)
-        receive_text = _("receive")
-
-        # TRANSLATOR_NOTE: Address verification success message (e.g. "bc1qabc = seed 12345678's receive address #0.")
-        text = _("{} = {}'s {} address #{}.").format(
-            address[:7],
-            source,
-            change_text if verified_index_is_change else receive_text,
-            verified_index
+        self.run_screen(
+            seed_screens.SeedAddressVerificationSuccessScreen,
+            address = self.controller.unverified_address["address"],
+            verified_index = self.controller.unverified_address["verified_index"],
+            verified_index_is_change = self.controller.unverified_address["verified_index_is_change"],
         )
-        LargeIconStatusScreen(
-            status_headline=_("Address Verified"),
-            text=text,
-            show_back_button=False,
-        ).display()
 
         return Destination(MainMenuView)
 


### PR DESCRIPTION
## Description

Fixes #650

Removes the sentence that had complex variable insertions in favor of simple single line reporting.

Before / After
<img src="https://github.com/user-attachments/assets/7bc0ba90-1508-4b43-b73d-83f2a9308b06"> <img src="https://github.com/user-attachments/assets/0bc65ce5-7243-435c-b1dd-38540ef77e21">

Due to the slight UI changes, the master `messages.pot` translation strings have changed slightly and will need new translations.

Additional light refactors:
* Clarify Exception message in screen.py
* Skip `LargeIconStatusScreen` body text component if no `text` input param is provided. This allows this PR to simply reference `self.components[-1]` to reference the the last VISIBLE display element; in this case, the `LargeIconStatusScreen.status_headline`.
* Light refactor to sort the imports in seed_screens.py.


---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)