### PR TITLE
[Refactor / bugfix] Simplify `HardwareButtons`

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 from dataclasses import dataclass, field
@@ -14,6 +15,8 @@ from seedsigner.hardware.buttons import HardwareButtonsConstants, HardwareButton
 from seedsigner.models.encode_qr import BaseQrEncoder
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
+
+logger = logging.getLogger(__name__)
 
 
 # Must be huge numbers to avoid conflicting with the selected_button returned by the
@@ -450,7 +453,7 @@ class ButtonListScreen(BaseTopNavScreen):
         while True:
             ret = self._run_callback()
             if ret is not None:
-                print("Exiting ButtonListScreen due to _run_callback")
+                logging.info("Exiting ButtonListScreen due to _run_callback")
                 return ret
 
             user_input = self.hw_inputs.wait_for(

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -71,6 +71,13 @@ class BaseScreen(BaseComponent):
             for t in self.get_threads():
                 t.stop()
 
+            for t in self.get_threads():
+                # Wait for each thread to stop; equivalent to `join()` but gracefully
+                # handles threads that were never run (necessary for screenshot generator
+                # compatibility, perhaps other edge cases).
+                while t.is_alive():
+                    time.sleep(0.01)
+
 
     def clear_screen(self):
         # Clear the whole canvas
@@ -226,11 +233,7 @@ class BaseTopNavScreen(BaseScreen):
                 time.sleep(0.1)
                 continue
 
-            user_input = self.hw_inputs.wait_for(
-                HardwareButtonsConstants.ALL_KEYS,
-                check_release=True,
-                release_keys=HardwareButtonsConstants.KEYS__ANYCLICK
-            )
+            user_input = self.hw_inputs.wait_for(HardwareButtonsConstants.ALL_KEYS)
 
             with self.renderer.lock:
                 if not self.top_nav.is_selected and user_input in [
@@ -447,6 +450,7 @@ class ButtonListScreen(BaseTopNavScreen):
         while True:
             ret = self._run_callback()
             if ret is not None:
+                print("Exiting ButtonListScreen due to _run_callback")
                 return ret
 
             user_input = self.hw_inputs.wait_for(
@@ -455,9 +459,7 @@ class ButtonListScreen(BaseTopNavScreen):
                     HardwareButtonsConstants.KEY_DOWN,
                     HardwareButtonsConstants.KEY_LEFT,
                     HardwareButtonsConstants.KEY_RIGHT,
-                ] + HardwareButtonsConstants.KEYS__ANYCLICK,
-                check_release=True,
-                release_keys=HardwareButtonsConstants.KEYS__ANYCLICK
+                ] + HardwareButtonsConstants.KEYS__ANYCLICK
             )
 
             with self.renderer.lock:
@@ -641,9 +643,7 @@ class LargeButtonScreen(BaseTopNavScreen):
                     HardwareButtonsConstants.KEY_DOWN,
                     HardwareButtonsConstants.KEY_LEFT,
                     HardwareButtonsConstants.KEY_RIGHT
-                ] + HardwareButtonsConstants.KEYS__ANYCLICK,
-                check_release=True,
-                release_keys=HardwareButtonsConstants.KEYS__ANYCLICK
+                ] + HardwareButtonsConstants.KEYS__ANYCLICK
             )
 
             with self.renderer.lock:
@@ -858,9 +858,7 @@ class QRDisplayScreen(BaseScreen):
                     HardwareButtonsConstants.KEY_DOWN,
                     HardwareButtonsConstants.KEY_LEFT,
                     HardwareButtonsConstants.KEY_RIGHT,
-                ] + HardwareButtonsConstants.KEYS__ANYCLICK,
-                check_release=True,
-                release_keys=HardwareButtonsConstants.KEYS__ANYCLICK
+                ] + HardwareButtonsConstants.KEYS__ANYCLICK
             )
             if user_input == HardwareButtonsConstants.KEY_DOWN:
                 # Reduce QR code background brightness
@@ -1191,9 +1189,7 @@ class KeyboardScreen(BaseTopNavScreen):
         # Start the interactive update loop
         while True:
             input = self.hw_inputs.wait_for(
-                HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN + [HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3],
-                check_release=True,
-                release_keys=[HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3]
+                HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN + [HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3]
             )
 
             with self.renderer.lock:

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -243,11 +243,7 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
 
     def _run(self):
         while True:
-            input = self.hw_inputs.wait_for(
-                HardwareButtonsConstants.ALL_KEYS,
-                check_release=True,
-                release_keys=[HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY2]
-            )
+            input = self.hw_inputs.wait_for(HardwareButtonsConstants.ALL_KEYS)
 
             with self.renderer.lock:
                 if self.is_input_in_top_nav:
@@ -885,11 +881,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
 
         # Start the interactive update loop
         while True:
-            input = self.hw_inputs.wait_for(
-                HardwareButtonsConstants.ALL_KEYS,
-                check_release=True,
-                release_keys=[HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY1, HardwareButtonsConstants.KEY2, HardwareButtonsConstants.KEY3]
-            )
+            input = self.hw_inputs.wait_for(HardwareButtonsConstants.ALL_KEYS)
 
             keyboard_swap = False
 
@@ -1467,13 +1459,13 @@ class SeedAddressVerificationScreen(ButtonListScreen):
     
 
     def _run_callback(self):
-        # Exit the screen on success via a non-None value
-        logger.info(f"verified_index: {self.verified_index.cur_count}")
+        # Exit the screen on success via a non-None value.
+        # see: ButtonListScreen._run()
         if self.verified_index.cur_count is not None:
-            logger.info("Screen callback returning success!")
-            self.threads[-1].stop()
-            while self.threads[-1].is_alive():
-                time.sleep(0.01)
+            # Note that the ProgressThread will have already exited on its own.
+
+            # Return a success value (anything other than None) to end the 
+            # ButtonListScreen._run() loop.
             return 1
 
 
@@ -1490,10 +1482,13 @@ class SeedAddressVerificationScreen(ButtonListScreen):
             while self.keep_running:
                 if self.verified_index.cur_count is not None:
                     # This thread will detect the success state while its parent Screen
-                    # holds in its `wait_for`. Have to trigger a hw_input event to break
-                    # the Screen._run out of the `wait_for` state. The Screen will then
-                    # call its `_run_callback` and detect the success state and exit.
-                    HardwareButtons.get_instance().trigger_override(force_release=True)
+                    # blocks in its `wait_for`. Have to trigger a hw_input override event
+                    # to break the Screen._run out of the `wait_for` state. The Screen
+                    # will then call its `_run_callback` and detect the success state and
+                    # exit.
+                    HardwareButtons.get_instance().trigger_override()
+
+                    # Exit the loop and thereby end this thread
                     return
 
                 textarea = TextArea(

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -183,7 +183,7 @@ class IOTestScreen(BaseTopNavScreen):
             screen_y=int((self.canvas_height - msg_height)/ 2),
         )
         while True:
-            input = self.hw_inputs.wait_for(keys=HardwareButtonsConstants.ALL_KEYS, check_release=False)
+            input = self.hw_inputs.wait_for(keys=HardwareButtonsConstants.ALL_KEYS)
 
             if input == HardwareButtonsConstants.KEY1:
                 # Note that there are three distinct screen updates that happen at

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -173,8 +173,6 @@ class HardwareButtons(Singleton):
 
 
 # class used as short hand for static button/channel lookup values
-# TODO: Implement `release_lock` functionality as a global somewhere. Mixes up design
-#   patterns to have a static constants class plus a settable global value.
 class HardwareButtonsConstants:
     if GPIO.RPI_INFO['P1_REVISION'] == 3: #This indicates that we have revision 3 GPIO
         KEY_UP = 31

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -33,6 +33,7 @@ class HardwareButtons(Singleton):
         KEY2_PIN = 12
         KEY3_PIN = 8
 
+
     @classmethod
     def get_instance(cls):
         # This is the only way to access the one and only instance
@@ -53,7 +54,7 @@ class HardwareButtons(Singleton):
             cls._instance.GPIO = GPIO
             cls._instance.override_ind = False
 
-            cls._instance.add_events([HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN, HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT, HardwareButtonsConstants.KEY1, HardwareButtonsConstants.KEY2, HardwareButtonsConstants.KEY3])
+            # cls._instance.add_events([HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN, HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT, HardwareButtonsConstants.KEY1, HardwareButtonsConstants.KEY2, HardwareButtonsConstants.KEY3])
 
             # Track state over time so we can apply input delays/ignores as needed
             cls._instance.cur_input = None           # Track which direction or button was last pressed
@@ -65,7 +66,6 @@ class HardwareButtons(Singleton):
         return cls._instance
 
 
-
     @classmethod
     def get_instance_no_hardware(cls):
         # This is the only way to access the one and only instance
@@ -73,17 +73,23 @@ class HardwareButtons(Singleton):
             cls._instance = cls.__new__(cls)
 
 
+    def wait_for(self, keys=[]) -> int:
+        """
+        Block execution until one of the target keys is pressed.
 
-    def wait_for(self, keys=[], check_release=True, release_keys=[]) -> int:
+        Optionally override the wait by calling `trigger_override()`.
+        """
         # TODO: Refactor to keep control in the Controller and not here
         from seedsigner.controller import Controller
         controller = Controller.get_instance()
-
-        if not release_keys:
-            release_keys = keys
         self.override_ind = False
 
         while True:
+            if self.override_ind:
+                # Break out of the wait_for without waiting for user input
+                self.override_ind = False
+                return HardwareButtonsConstants.OVERRIDE
+
             cur_time = int(time.time() * 1000)
             if cur_time - self.last_input_time > controller.screensaver_activation_ms and not controller.is_screensaver_running:
                 # Start the screensaver. Will block execution until input detected.
@@ -99,48 +105,42 @@ class HardwareButtons(Singleton):
                 # Resume from a fresh loop
                 continue
 
+            # Check each candidate key to see if it was pressed
             for key in keys:
-                if not check_release or ((check_release and key in release_keys and HardwareButtonsConstants.release_lock) or check_release and key not in release_keys):
-                    # when check release is False or the release lock is released (True)
-                    if self.GPIO.input(key) == GPIO.LOW or self.override_ind:
-                        HardwareButtonsConstants.release_lock = False
-                        if self.override_ind:
-                            self.override_ind = False
-                            return HardwareButtonsConstants.OVERRIDE
+                if self.GPIO.input(key) == GPIO.LOW:
+                    if self.cur_input != key:
+                        self.cur_input = key
+                        self.cur_input_started = int(time.time() * 1000)  # in milliseconds
+                        self.last_input_time = self.cur_input_started
+                        return key
 
-                        if self.cur_input != key:
-                            self.cur_input = key
-                            self.cur_input_started = int(time.time() * 1000)  # in milliseconds
-                            self.last_input_time = self.cur_input_started
+                    else:
+                        # Still pressing the same input
+                        if cur_time - self.last_input_time > self.next_repeat_threshold:
+                            # Too much time has elapsed to consider this the same
+                            #   continuous input. Treat as a new separate press.
+                            self.cur_input_started = cur_time
+                            self.last_input_time = cur_time
+                            return key
+
+                        elif cur_time - self.cur_input_started > self.first_repeat_threshold:
+                            # We're good to relay this immediately as continuous
+                            #   input.
+                            self.last_input_time = cur_time
                             return key
 
                         else:
-                            # Still pressing the same input
-                            if cur_time - self.last_input_time > self.next_repeat_threshold:
-                                # Too much time has elapsed to consider this the same
-                                #   continuous input. Treat as a new separate press.
-                                self.cur_input_started = cur_time
-                                self.last_input_time = cur_time
-                                return key
-
-                            elif cur_time - self.cur_input_started > self.first_repeat_threshold:
-                                # We're good to relay this immediately as continuous
-                                #   input.
-                                self.last_input_time = cur_time
-                                return key
-
-                            else:
-                                # We're not yet at the first repeat threshold; triggering
-                                #   a key now would be too soon and yields a bad user
-                                #   experience when only a single click was intended but
-                                #   a second input is processed because of race condition
-                                #   against human response time to release the button.
-                                # So there has to be a delay before we allow the first
-                                #   continuous repeat to register. So we'll ignore this
-                                #   round's input and **won't update any of our
-                                #   timekeeping vars**. But once we cross the threshold,
-                                #   we let the repeats fly.
-                                pass
+                            # We're not yet at the first repeat threshold; triggering
+                            #   a key now would be too soon and yields a bad user
+                            #   experience when only a single click was intended but
+                            #   a second input is processed because of race condition
+                            #   against human response time to release the button.
+                            # So there has to be a delay before we allow the first
+                            #   continuous repeat to register. So we'll ignore this
+                            #   round's input and **won't update any of our
+                            #   timekeeping vars**. But once we cross the threshold,
+                            #   we let the repeats fly.
+                            pass
 
             time.sleep(0.01) # wait 10 ms to give CPU chance to do other things
 
@@ -149,29 +149,13 @@ class HardwareButtons(Singleton):
         self.last_input_time = int(time.time() * 1000)
 
 
-    def add_events(self, keys=[]):
-        for key in keys:
-            GPIO.add_event_detect(key, self.GPIO.RISING, callback=HardwareButtons.rising_callback)
+    def trigger_override(self) -> bool:
+        """ Set the override flag to break out of the current `wait_for` loop """
+        self.override_ind = True
 
-
-    def rising_callback(channel):
-        HardwareButtonsConstants.release_lock = True
-
-
-    def trigger_override(self, force_release = False) -> bool:
-        if force_release:
-            HardwareButtonsConstants.release_lock = True
-
-        if not self.override_ind:
-            self.override_ind = True
-            return True
-        return False
-
-    def force_release(self) -> bool:
-        HardwareButtonsConstants.release_lock = True
-        return True
 
     def check_for_low(self, key: int = None, keys: List[int] = None) -> bool:
+        """ Returns True if one of the target keys/key is pressed """
         if key:
             keys = [key]
         for key in keys:
@@ -181,11 +165,14 @@ class HardwareButtons(Singleton):
         else:
             return False
 
+
     def has_any_input(self) -> bool:
+        """ Returns True if any of the keys are pressed """
         for key in HardwareButtonsConstants.ALL_KEYS:
             if self.GPIO.input(key) == GPIO.LOW:
                 return True
         return False
+
 
 # class used as short hand for static button/channel lookup values
 # TODO: Implement `release_lock` functionality as a global somewhere. Mixes up design
@@ -227,5 +214,3 @@ class HardwareButtonsConstants:
 
     KEYS__LEFT_RIGHT_UP_DOWN = [KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN]
     KEYS__ANYCLICK = [KEY_PRESS, KEY1, KEY2, KEY3]
-
-    release_lock = True # released when True, locked when False

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -54,8 +54,6 @@ class HardwareButtons(Singleton):
             cls._instance.GPIO = GPIO
             cls._instance.override_ind = False
 
-            # cls._instance.add_events([HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN, HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT, HardwareButtonsConstants.KEY1, HardwareButtonsConstants.KEY2, HardwareButtonsConstants.KEY3])
-
             # Track state over time so we can apply input delays/ignores as needed
             cls._instance.cur_input = None           # Track which direction or button was last pressed
             cls._instance.cur_input_started = None   # Track when that input began


### PR DESCRIPTION
## Description

Two main issues are addressed:
* Eliminates lots of unnecessary complexity in `HardwareButtons`.
* Fixes #654 which seems to be some kind of race condition that is buried inside some of the above (now removed) complexity.

---

### Death to `release_lock`
The main change is around eliminating the `release_lock` and related concepts in `HardwareButtons`. It's extremely difficult to reason through in its current (`dev`, i.e. before this PR) state. From what I can discern, it's meant to track the status of a button (or joystick direction) being physically released (press a button down, then release it to let it return to its normal resting position).

So think of it like javascript's onMouseUp event.

However, if you look at how our code reacts to user input, we only react on the PRESS, not on the release.

We only need `HardwareButtons` to react to individual inputs (joystick movement, button press) and be savvy about short-press vs long-press/sustained hold (e.g. holding the joystick to continuously scan across a keyboard). It doesn't care at all if we clicked some super-important OKAY button that we categorized as a `release_key`.

So if we start to unwind the `release_lock` concept, a number of methods can be totally deleted:
* The `check_release` and `release_keys` input params on `wait_for()`
* `force_release()`
* The `rising_callback()` handler
* The `add_events()` initializer to set that handler
* `trigger_override()` now doesn't need any reference to `release_lock`

---

Issue #654: In my testing, this was caused by this line: https://github.com/SeedSigner/seedsigner/blob/9bfb7b289d8366321ab8578e797d75411bbf9c41/src/seedsigner/hardware/buttons.py#L106

If I moved that to after the override is handled, the issue was resolved (sort of -- I had a lot of changes in place by then, but moving that line was the big breakthrough as far as I could tell).

Completely eliminating the `release_lock` (thankfully) also fixed the bug.

---

### Simplify `trigger_override`
The current (`dev`) version of `wait_for()` has an absolutely nightmarish `if` statement AND an incomprehensible follow up comment (that I think I wrote, unfortunately):
```python
if not check_release or ((check_release and key in release_keys and HardwareButtonsConstants.release_lock) or check_release and key not in release_keys):
    # when check release is False or the release lock is released (True)
```

The above `release_lock` changes help us out a ton here. We can eliminate all of the `if` statement mess. The last complication is in how we process the `trigger_override()`. This now becomes simple: We triggered the override to break us out of the `wait_for()` loop. So move that check to the beginning of the loop and keep its logic completely separate.

---

### Remaining changes
* Matching changes elsewhere to the `wait_for()` input params.
* Bit of thread cleanup assurances in `BaseScreen.display()`.
* seed_views.py: the diff looks messy, but it's really just bumping everything in to wrap it in a `try`/`finally` to add guarantees about the `BruteForceAddressVerificationThread` being shut down.

---

### Tips for testing
Any screen that involves user input, especially if there are other threads or atypical input handling:
* Issue #654 Address Verification
* The Address Verification brute force thread (Skip 10, Cancel).
* I/O Test
* Scan (from MainMenu) w/LEFT to cancel.
* Image entropy live preview (all navigation options on: live preview, review final pic)
* Seed word entry keyboard screen (joystick movement, joystick HOLD to scan across or up/down, KEY1/KEY3 press/hold to scroll candidate matches.
* BIP-39 passphrase entry, KEY1/KEY2 keyboard swaps
* Animated QR brightness up/down, exit

---

This pull request is categorized as a:
- [x] Bug fix
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A (currently no way for the test suite to test real-time hardware input interactions)

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board