### PR TITLE
[bugfix] `DecodeQR`: handle Compact SeedQR byte data that can be decoded to `str`

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -417,6 +417,9 @@ class DecodeQR:
         # 32 bytes for 24-word CompactSeedQR; 16 bytes for 12-word CompactSeedQR
         if len(s) == 32 or len(s) == 16:
             try:
+                if not isinstance(s, bytes):
+                    # TODO: remove this check & conversion once above cast to str is removed
+                    s = s.encode()
                 bitstream = ""
                 for b in s:
                     bitstream += bin(b).lstrip('0b').zfill(8)

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -414,12 +414,17 @@ class DecodeQR:
             pass
 
         # Is it byte data?
+        if not isinstance(s, bytes):
+            try:
+                # TODO: remove this check & conversion once above cast to str is removed
+                s = s.encode()
+            except UnicodeError:
+                # Couldn't convert back to bytes; shouldn't happen
+                raise Exception("Conversion to bytes failed")
+
         # 32 bytes for 24-word CompactSeedQR; 16 bytes for 12-word CompactSeedQR
         if len(s) == 32 or len(s) == 16:
             try:
-                if not isinstance(s, bytes):
-                    # TODO: remove this check & conversion once above cast to str is removed
-                    s = s.encode()
                 bitstream = ""
                 for b in s:
                     bitstream += bin(b).lstrip('0b').zfill(8)


### PR DESCRIPTION
## Description

Fixes #656 

### The bug
The QR decoder (decode_qr.py) starts by interpreting QR data as `str` as it tries to figure out the QR format that was just scanned (e.g. animated psbt, address to verify, SeedQR, etc). In most cases, Compact SeedQR byte data will fail the conversion to `str` (raises `UnicodeDecodeError`; all good, we expect that) and the code will carry on to its next step where it assumes the data is still in `bytes` format.

But in the edge cases where the Compact SeedQR byte data CAN be converted to `str` (e.g. "abandon" x11 + "about" as reported in #656), the successful conversion to `str` then runs into errors in the Compact SeedQR decoding: the data isn't `bytes`, it's `str` at this point, and so the byte manipulation code errors out. The error is caught and the decoder reports the Compact SeedQR as invalid (even though it IS actually valid).


### The fix
This PR simply checks and ensures that the data is in `bytes` format before the Compact SeedQR processing begins.

TODO: Longer term, the conversion to `str` should be eliminated altogether. But that approach was NOT taken in this PR in order to minimize the impact of this PR and minimize the amount of testing needed.

---

* Additional test case added with the #656 byte data as well as randomly generated 12- and 24-word entropy byte data that are able to pass the conversion to `str`.

---

### Testing
12-word Compact SeedQR that will fail with `dev` but succeed with this PR:

![pr657_12_word](https://github.com/user-attachments/assets/86bcdb23-4748-4368-83ac-4d2d6c57d45e)

And a 24-word Compact SeedQR:

![pr657_24_word](https://github.com/user-attachments/assets/bd65a6c3-3cf2-413e-8191-b51c77f42420)





---

This pull request is categorized as a:
- [x] Bug fix

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] Yes

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other