### PR TITLE
Add SPACE, DEL icons to `Keyboard`; various UI consistency tweaks

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.5-rc1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-01-15 10:45-0600\n"
+"POT-Creation-Date: 2025-01-19 10:20-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,16 +34,6 @@ msgstr ""
 #: src/seedsigner/gui/components.py src/seedsigner/gui/screens/psbt_screens.py
 #: src/seedsigner/models/settings_definition.py
 msgid "sats"
-msgstr ""
-
-#. The abbreviated label for the special key <del> on a standard keyboard.
-#: src/seedsigner/gui/keyboard.py
-msgid "del"
-msgstr ""
-
-#. The abbreviated label for the special key <space> on a standard keyboard.
-#: src/seedsigner/gui/keyboard.py
-msgid "space"
 msgstr ""
 
 #: src/seedsigner/gui/toast.py
@@ -215,7 +205,7 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: src/seedsigner/gui/screens/screen.py src/seedsigner/views/psbt_views.py
+#: src/seedsigner/gui/screens/screen.py
 msgid "Caution"
 msgstr ""
 
@@ -901,18 +891,16 @@ msgstr ""
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
-msgid ""
-"PSBT's {} address could not be verified with your multisig wallet "
-"descriptor."
-msgstr ""
-
-#: src/seedsigner/views/psbt_views.py
-msgid "Suspicious PSBT"
+msgid "PSBT's {} address could not be verified from wallet descriptor."
 msgstr ""
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
 msgid "PSBT's {} address could not be generated from your seed."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious PSBT"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
@@ -1459,10 +1447,13 @@ msgstr ""
 msgid "Back to Main Menu"
 msgstr ""
 
+#. The network setting (mainnet/testnet/regtest) doesn't match the provided
+#. derivation path
 #: src/seedsigner/views/view.py
 msgid "Network Mismatch"
 msgstr ""
 
+#. Button option to alter a setting
 #: src/seedsigner/views/view.py
 msgid "Change Setting"
 msgstr ""

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -217,9 +217,9 @@ class SeedSignerIconConstants:
 
     # Messaging icons
     INFO = "\ue912"
-    ERROR = "\ue913"
-    SUCCESS = "\ue914"
-    WARNING = "\ue915"
+    SUCCESS = "\ue913"
+    WARNING = "\ue914"
+    ERROR = "\ue915"
 
     # Informational icons
     ADDRESS = "\ue916"
@@ -241,8 +241,9 @@ class SeedSignerIconConstants:
     DELETE = "\ue922"
     SPACE = "\ue923"
 
+    # Must be updated whenever new icons are added. See usage in `Icon` class below.
     MIN_VALUE = SCAN
-    MAX_VALUE = QRCODE
+    MAX_VALUE = SPACE
 
 
 
@@ -277,17 +278,6 @@ def calc_text_centering(font: ImageFont,
     text_y = int((total_height - (ascent - offset_y)) / 2) - offset_y
 
     return (start_x + text_x, start_y + text_y)
-
-
-
-def load_icon(icon_name: str, load_selected_variant: bool = False):
-    icon_url = os.path.join(pathlib.Path(__file__).parent.resolve(), "..", "resources", "icons", icon_name)
-    icon = Image.open(icon_url + ".png").convert("RGB")
-    if not load_selected_variant:
-        return icon
-    else:
-        icon_selected = Image.open(icon_url + "_selected.png").convert("RGB")
-        return (icon, icon_selected)
 
 
 

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -3,7 +3,7 @@ from PIL import Image, ImageDraw, ImageFont
 from typing import Tuple
 from gettext import gettext as _
 
-from seedsigner.gui.components import Fonts, GUIConstants
+from seedsigner.gui.components import Fonts, GUIConstants, SeedSignerIconConstants
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 
 
@@ -30,46 +30,43 @@ class Keyboard:
     ENTER_RIGHT = "enter_right"
 
     REGULAR_KEY_FONT = "regular"
-    COMPACT_KEY_FONT = "compact"
+    ICON_KEY_FONT = GUIConstants.ICON_FONT_NAME__SEEDSIGNER
 
-    # TRANSLATOR_NOTE: The abbreviated label for the special key <del> on a standard keyboard.
-    del_label = _("del")
     KEY_BACKSPACE = {
         "code": "DEL",
-        "letter": del_label,
-        "font": COMPACT_KEY_FONT,
+        "letter": SeedSignerIconConstants.DELETE,
+        "font": ICON_KEY_FONT,
         "size": 2,
     }
-    # TRANSLATOR_NOTE: The abbreviated label for the special key <space> on a standard keyboard.
-    space_label = _("space")
+
     KEY_SPACE = {
         "code": "SPACE",
-        "letter": space_label,
-        "font": COMPACT_KEY_FONT,
+        "letter": SeedSignerIconConstants.SPACE,
+        "font": ICON_KEY_FONT,
         "size": 1,
     }
     KEY_SPACE_2 = {
         "code": "SPACE",
-        "letter": space_label,
-        "font": COMPACT_KEY_FONT,
+        "letter": SeedSignerIconConstants.SPACE,
+        "font": ICON_KEY_FONT,
         "size": 2,
     }
     KEY_SPACE_3 = {
         "code": "SPACE",
-        "letter": space_label,
-        "font": COMPACT_KEY_FONT,
+        "letter": SeedSignerIconConstants.SPACE,
+        "font": ICON_KEY_FONT,
         "size": 3,
     }
     KEY_SPACE_4 = {
         "code": "SPACE",
-        "letter": space_label,
-        "font": COMPACT_KEY_FONT,
+        "letter": SeedSignerIconConstants.SPACE,
+        "font": ICON_KEY_FONT,
         "size": 4,
     }
     KEY_SPACE_5 = {
         "code": "SPACE",
-        "letter": space_label,
-        "font": COMPACT_KEY_FONT,
+        "letter": SeedSignerIconConstants.SPACE,
+        "font": ICON_KEY_FONT,
         "size": 5,
     }
     KEY_CURSOR_LEFT = {
@@ -123,9 +120,11 @@ class Keyboard:
 
         def render_key(self):
             font = self.keyboard.font
+            text_height = self.keyboard.text_height
             if self.is_additional_key:
-                if Keyboard.ADDITIONAL_KEYS[self.code]["font"] == Keyboard.COMPACT_KEY_FONT:
-                    font = self.keyboard.additonal_key_compact_font
+                if Keyboard.ADDITIONAL_KEYS[self.code]["font"] == Keyboard.ICON_KEY_FONT:
+                    font = self.keyboard.icon_key_font
+                    text_height = self.keyboard.icon_key_height
 
             outline_color = "#333"
             if not self.is_active:
@@ -159,15 +158,12 @@ class Keyboard:
                 radius=4
             )
 
-            # Fixed-width fonts will all have same height, ignoring below baseline (e.g. "Q" or "q")
-            (left, top, right, bottom) = font.getbbox("X", anchor="ls")
-            text_height = -1 * top
             self.keyboard.draw.text(
                 (
                     self.screen_x + int(self.keyboard.key_width * self.size / 2),
                     self.screen_y + self.keyboard.key_height - int((self.keyboard.key_height - text_height)/2)
                 ),
-                _(self.letter),
+                self.letter,
                 fill=font_color,
                 font=font,
                 anchor="ms"
@@ -217,8 +213,15 @@ class Keyboard:
 
         # Set up the rendering and state params
         self.active_keys = list(self.charset)
+        self.icon_key_font = Fonts.get_font(GUIConstants.ICON_FONT_NAME__SEEDSIGNER, 26)
 
-        self.additonal_key_compact_font = Fonts.get_font("RobotoCondensed-Bold", 18)
+        # Fixed-width fonts will all have same height, ignoring below baseline (e.g. "Q" or "q")
+        (left, top, right, bottom) = self.font.getbbox("X", anchor="ls")
+        self.text_height = -1 * top
+
+        (left, top, right, bottom) = self.icon_key_font.getbbox(SeedSignerIconConstants.DELETE + SeedSignerIconConstants.SPACE, anchor="ls")
+        self.icon_key_height = -1 * top
+
         self.x_start = rect[0]
         self.y_start = rect[1]
         self.x_gap = 2

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -71,14 +71,14 @@ class Keyboard:
     }
     KEY_CURSOR_LEFT = {
         "code": "CURSOR_LEFT",
-        "letter": "<",
-        "font": REGULAR_KEY_FONT,
+        "letter": SeedSignerIconConstants.CHEVRON_LEFT,
+        "font": ICON_KEY_FONT,
         "size": 1,
     }
     KEY_CURSOR_RIGHT = {
         "code": "CURSOR_RIGHT",
-        "letter": ">",
-        "font": REGULAR_KEY_FONT,
+        "letter": SeedSignerIconConstants.CHEVRON_RIGHT,
+        "font": ICON_KEY_FONT,
         "size": 1,
     }
     KEY_PREVIOUS_PAGE = {

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1013,9 +1013,12 @@ class WarningEdgesMixin:
 
 @dataclass
 class WarningScreen(WarningEdgesMixin, LargeIconStatusScreen):
+    """
+    Exclamation point icon + yellow WARNING color
+    """
     title: str = _mft("Caution")
     status_icon_name: str = SeedSignerIconConstants.WARNING
-    status_color: str = "yellow"
+    status_color: str = GUIConstants.WARNING_COLOR
     status_headline: str = _mft("Privacy Leak!")     # The colored text under the alert icon
     button_data: list = field(default_factory=lambda: [ButtonOption("I Understand")])
 
@@ -1023,8 +1026,22 @@ class WarningScreen(WarningEdgesMixin, LargeIconStatusScreen):
 
 @dataclass
 class DireWarningScreen(WarningScreen):
+    """
+    Exclamation point icon + orange DIRE_WARNING color
+    """
     status_headline: str = _mft("Classified Info!")     # The colored text under the alert icon
     status_color: str = GUIConstants.DIRE_WARNING_COLOR
+
+
+
+@dataclass
+class ErrorScreen(WarningScreen):
+    """
+    X icon + red ERROR color
+    """
+    title: str = _mft("Error")
+    status_icon_name: str = SeedSignerIconConstants.ERROR
+    status_color: str = GUIConstants.ERROR_COLOR
 
 
 

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -309,7 +309,7 @@ class ButtonListScreen(BaseTopNavScreen):
         if len(self.button_data) == 1:
             button_list_height = button_height
         else:
-            button_list_height = (len(self.button_data) * button_height) + (GUIConstants.COMPONENT_PADDING * (len(self.button_data) - 1))
+            button_list_height = (len(self.button_data) * button_height) + (GUIConstants.LIST_ITEM_PADDING * (len(self.button_data) - 1))
 
         if self.is_bottom_list:
             button_list_y = self.canvas_height - (button_list_height + GUIConstants.EDGE_PADDING)

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -6,7 +6,7 @@ from PIL.ImageOps import autocontrast
 from typing import List
 
 from seedsigner.helpers.l10n import mark_for_translation as _mft
-from seedsigner.gui.components import Button, CheckboxButton, CheckedSelectionButton, FontAwesomeIconConstants, Fonts, GUIConstants, Icon, IconButton, IconTextLine, TextArea
+from seedsigner.gui.components import Button, CheckboxButton, CheckedSelectionButton, FontAwesomeIconConstants, Fonts, GUIConstants, Icon, IconButton, IconTextLine, SeedSignerIconConstants, TextArea
 from seedsigner.gui.screens.scan_screens import ScanScreen
 from seedsigner.gui.screens.screen import BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption
 from seedsigner.hardware.buttons import HardwareButtonsConstants
@@ -82,7 +82,7 @@ class IOTestScreen(BaseTopNavScreen):
         self.components.append(self.joystick_click_button)
 
         self.joystick_up_button = IconButton(
-            icon_name=FontAwesomeIconConstants.ANGLE_UP,
+            icon_name=SeedSignerIconConstants.CHEVRON_UP,
             icon_size=GUIConstants.ICON_INLINE_FONT_SIZE,
             width=input_button_width,
             height=input_button_height,
@@ -93,7 +93,7 @@ class IOTestScreen(BaseTopNavScreen):
         self.components.append(self.joystick_up_button)
 
         self.joystick_down_button = IconButton(
-            icon_name=FontAwesomeIconConstants.ANGLE_DOWN,
+            icon_name=SeedSignerIconConstants.CHEVRON_DOWN,
             icon_size=GUIConstants.ICON_INLINE_FONT_SIZE,
             width=input_button_width,
             height=input_button_height,
@@ -104,9 +104,8 @@ class IOTestScreen(BaseTopNavScreen):
         self.components.append(self.joystick_down_button)
 
         self.joystick_left_button = IconButton(
-            text=FontAwesomeIconConstants.ANGLE_LEFT,
-            font_name=GUIConstants.ICON_FONT_NAME__FONT_AWESOME,
-            font_size=GUIConstants.ICON_INLINE_FONT_SIZE,
+            icon_name=SeedSignerIconConstants.CHEVRON_LEFT,
+            icon_size=GUIConstants.ICON_INLINE_FONT_SIZE,
             width=input_button_width,
             height=input_button_height,
             screen_x=dpad_center_x - input_button_width - GUIConstants.COMPONENT_PADDING,
@@ -116,7 +115,7 @@ class IOTestScreen(BaseTopNavScreen):
         self.components.append(self.joystick_left_button)
 
         self.joystick_right_button = IconButton(
-            icon_name=FontAwesomeIconConstants.ANGLE_RIGHT,
+            icon_name=SeedSignerIconConstants.CHEVRON_RIGHT,
             icon_size=GUIConstants.ICON_INLINE_FONT_SIZE,
             width=input_button_width,
             height=input_button_height,

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -140,7 +140,7 @@ class ToolsDiceEntropyEntryScreen(KeyboardScreen):
         self.rows = 3
         self.cols = 3
         self.keyboard_font_name = GUIConstants.ICON_FONT_NAME__FONT_AWESOME
-        self.keyboard_font_size = None  # Force auto-scaling to Key height
+        self.keyboard_font_size = 36
         self.keys_charset = "".join([
             FontAwesomeIconConstants.DICE_ONE,
             FontAwesomeIconConstants.DICE_TWO,

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -469,7 +469,6 @@ class PSBTAddressVerificationFailedView(View):
         DireWarningScreen(
             title=_("Suspicious PSBT"),
             status_headline=_("Address Verification Failed"),
-            status_icon_name=SeedSignerIconConstants.ERROR,
             text=text,
             button_data=[ButtonOption("Discard PSBT")],
             show_back_button=False,

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -460,17 +460,16 @@ class PSBTAddressVerificationFailedView(View):
 
     def run(self):
         if self.is_multisig:
-            title = _("Caution")
             # TRANSLATOR_NOTE: Variable is either "change" or "self-transfer".
-            text = _("PSBT's {} address could not be verified with your multisig wallet descriptor.").format(_("change") if self.is_change else _("self-transfer"))
+            text = _("PSBT's {} address could not be verified from wallet descriptor.").format(_("change") if self.is_change else _("self-transfer"))
         else:
-            title = _("Suspicious PSBT")
             # TRANSLATOR_NOTE: Variable is either "change" or "self-transfer".
             text = _("PSBT's {} address could not be generated from your seed.").format(_("change") if self.is_change else _("self-transfer"))
         
         DireWarningScreen(
-            title=title,
+            title=_("Suspicious PSBT"),
             status_headline=_("Address Verification Failed"),
+            status_icon_name=SeedSignerIconConstants.ERROR,
             text=text,
             button_data=[ButtonOption("Discard PSBT")],
             show_back_button=False,

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -2,10 +2,10 @@ import logging
 import re
 
 from gettext import gettext as _
-from seedsigner.gui.components import SeedSignerIconConstants
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
+from seedsigner.gui.screens.screen import ButtonOption
 
 logger = logging.getLogger(__name__)
 
@@ -164,18 +164,7 @@ class ScanView(View):
             # For now, don't even try to re-do the attempted operation, just reset and
             # start everything over.
             self.controller.resume_main_flow = None
-
-            # TODO: Refactor this warning screen into its own Screen class; the
-            # screenshot generator is currently manually re-creating it, but it would be
-            # better if a dedicated Screen could just be instantiated instead.
-            return Destination(ErrorView, view_args=dict(
-                title=_("Error"),
-                status_icon_name=SeedSignerIconConstants.WARNING,
-                status_headline=_("Unknown QR Type"),
-                text=_("QRCode is invalid or is a data format not yet supported."),
-                button_text=_("Done"),
-                next_destination=Destination(MainMenuView, clear_history=True),
-            ))
+            return Destination(ScanInvalidQRTypeView)
 
         return Destination(MainMenuView)
 
@@ -218,3 +207,23 @@ class ScanAddressView(ScanView):
     @property
     def is_valid_qr_type(self):
         return self.decoder.is_address
+
+
+
+class ScanInvalidQRTypeView(View):
+    def run(self):
+        from seedsigner.gui.screens import WarningScreen
+
+        # TODO: This screen says "Error" but is intentionally using the WarningScreen in
+        # order to avoid the perception that something is broken on our end. This should
+        # either change to use the red ErrorScreen or the "Error" title should be
+        # changed to something softer.
+        self.run_screen(
+            WarningScreen,
+            title=_("Error"),
+            status_headline=_("Unknown QR Type"),
+            text=_("QRCode is invalid or is a data format not yet supported."),
+            button_data=[ButtonOption("Done")],
+        )
+
+        return Destination(MainMenuView, clear_history=True)

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 from gettext import gettext as _
+from seedsigner.gui.components import SeedSignerIconConstants
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
@@ -163,8 +164,13 @@ class ScanView(View):
             # For now, don't even try to re-do the attempted operation, just reset and
             # start everything over.
             self.controller.resume_main_flow = None
+
+            # TODO: Refactor this warning screen into its own Screen class; the
+            # screenshot generator is currently manually re-creating it, but it would be
+            # better if a dedicated Screen could just be instantiated instead.
             return Destination(ErrorView, view_args=dict(
                 title=_("Error"),
+                status_icon_name=SeedSignerIconConstants.WARNING,
                 status_headline=_("Unknown QR Type"),
                 text=_("QRCode is invalid or is a data format not yet supported."),
                 button_text=_("Done"),

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -279,8 +279,9 @@ class SeedMnemonicInvalidView(View):
     def run(self):
         button_data = [self.EDIT, self.DISCARD]
         selected_menu_num = self.run_screen(
-            WarningScreen,
+            DireWarningScreen,
             title=_("Invalid Mnemonic!"),
+            status_icon_name=SeedSignerIconConstants.ERROR,
             status_headline=None,
             text=_("Checksum failure; not a valid seed phrase."),
             show_back_button=False,
@@ -1206,6 +1207,7 @@ class SeedBIP85InvalidChildIndexView(View):
         DireWarningScreen(
             title=_("BIP-85 Index Error"),
             show_back_button=False,
+            status_icon_name=SeedSignerIconConstants.ERROR,
             status_headline=_("Invalid Child Index"),
             text=_("BIP-85 Child Index must be between 0 and 2^31-1."),
             button_data=[ButtonOption("Try Again")]
@@ -1366,6 +1368,7 @@ class SeedWordsBackupTestMistakeView(View):
         selected_menu_num = DireWarningScreen(
             title=_("Verification Error"),
             show_back_button=False,
+            status_icon_name=SeedSignerIconConstants.ERROR,
             status_headline=status_headline,
             button_data=button_data,
             text=text,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -5,7 +5,7 @@ from typing import Type
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.gui.components import SeedSignerIconConstants
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON, RET_CODE__BACK_BUTTON
-from seedsigner.gui.screens.screen import BaseScreen, ButtonOption, DireWarningScreen, LargeButtonScreen, PowerOffScreen, PowerOffNotRequiredScreen, ResetScreen, WarningScreen
+from seedsigner.gui.screens.screen import BaseScreen, ButtonOption, LargeButtonScreen, WarningScreen, ErrorScreen
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread
@@ -245,6 +245,7 @@ class PowerOptionsView(View):
 
 class RestartView(View):
     def run(self):
+        from seedsigner.gui.screens.screen import ResetScreen
         thread = RestartView.DoResetThread()
         thread.start()
         self.run_screen(ResetScreen)
@@ -270,6 +271,7 @@ class RestartView(View):
 
 class PowerOffView(View):
     def run(self):
+        from seedsigner.gui.screens.screen import PowerOffNotRequiredScreen
         self.run_screen(PowerOffNotRequiredScreen)
         return Destination(BackStackView)
 
@@ -308,7 +310,7 @@ class ErrorView(View):
 
     def run(self):
         self.run_screen(
-            WarningScreen,
+            ErrorScreen,
             title=self.title,
             status_icon_name=self.status_icon_name,
             status_headline=self.status_headline,
@@ -349,12 +351,10 @@ class NetworkMismatchErrorView(ErrorView):
 class UnhandledExceptionView(View):
     error: list[str]
 
-
     def run(self):
         self.run_screen(
-            DireWarningScreen,
+            ErrorScreen,
             title=_("System Error"),
-            status_icon_name=SeedSignerIconConstants.ERROR,
             status_headline=self.error[0],
             text=self.error[1] + "\n" + self.error[2],
             allow_text_overflow=True,  # Fit what we can, let the rest go off the edges

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -300,6 +300,7 @@ class NotYetImplementedView(View):
 class ErrorView(View):
     title: str = _mft("Error")
     show_back_button: bool = True
+    status_icon_name: str = SeedSignerIconConstants.ERROR
     status_headline: str = None
     text: str = None
     button_text: str = None
@@ -309,6 +310,7 @@ class ErrorView(View):
         self.run_screen(
             WarningScreen,
             title=self.title,
+            status_icon_name=self.status_icon_name,
             status_headline=self.status_headline,
             text=self.text,
             button_data=[ButtonOption(self.button_text)],
@@ -324,9 +326,14 @@ class NetworkMismatchErrorView(ErrorView):
 
     def __post_init__(self):
         from seedsigner.views.settings_views import SettingsEntryUpdateSelectionView
-        self.title: str = _("Network Mismatch")
-        self.show_back_button: bool = False
-        self.button_text: str = _("Change Setting")
+
+        # TRANSLATOR_NOTE: The network setting (mainnet/testnet/regtest) doesn't match the provided derivation path
+        self.title = _("Network Mismatch")
+        self.status_icon_name = SeedSignerIconConstants.WARNING
+        self.show_back_button = False
+
+        # TRANSLATOR_NOTE: Button option to alter a setting
+        self.button_text = _("Change Setting")
         self.next_destination = Destination(SettingsEntryUpdateSelectionView, view_args=dict(attr_name=SettingsConstants.SETTING__NETWORK), clear_history=True)
         super().__post_init__()
 
@@ -347,6 +354,7 @@ class UnhandledExceptionView(View):
         self.run_screen(
             DireWarningScreen,
             title=_("System Error"),
+            status_icon_name=SeedSignerIconConstants.ERROR,
             status_headline=self.error[0],
             text=self.error[1] + "\n" + self.error[2],
             allow_text_overflow=True,  # Fit what we can, let the rest go off the edges

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -24,6 +24,7 @@ sys.modules['seedsigner.hardware.microsd'] = MagicMock()
 patch('PIL.ImageFont.core.HAVE_RAQM', False).start()
 
 from seedsigner.controller import Controller
+from seedsigner.gui.components import SeedSignerIconConstants
 from seedsigner.gui.renderer import Renderer
 from seedsigner.gui.screens.seed_screens import SeedAddPassphraseScreen
 from seedsigner.gui.toast import BaseToastOverlayManagerThread, RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
@@ -359,12 +360,17 @@ def generate_screenshots(locale):
                 ScreenshotConfig(UnhandledExceptionView, dict(error=["IndexError", "line 1, in some_buggy_code.py", "list index out of range"])),
                 ScreenshotConfig(NetworkMismatchErrorView, dict(derivation_path="m/84'/1'/0'")),
                 ScreenshotConfig(OptionDisabledView, dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
-                ScreenshotConfig(ErrorView, dict(
-                    title="Error",
-                    status_headline="Unknown QR Type",
-                    text="QRCode is invalid or is a data format not yet supported.",
-                    button_text="Back",
-                )),
+                ScreenshotConfig(
+                    ErrorView,
+                    dict(
+                        title="Error",
+                        status_icon_name=SeedSignerIconConstants.WARNING,
+                        status_headline="Unknown QR Type",
+                        text="QRCode is invalid or is a data format not yet supported.",
+                        button_text="Back",
+                    ),
+                    screenshot_name="ScanView__UnknownQRType"
+                ),
             ]
         }
 

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -24,10 +24,9 @@ sys.modules['seedsigner.hardware.microsd'] = MagicMock()
 patch('PIL.ImageFont.core.HAVE_RAQM', False).start()
 
 from seedsigner.controller import Controller
-from seedsigner.gui.components import SeedSignerIconConstants
 from seedsigner.gui.renderer import Renderer
 from seedsigner.gui.screens.seed_screens import SeedAddPassphraseScreen
-from seedsigner.gui.toast import BaseToastOverlayManagerThread, RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
+from seedsigner.gui.toast import RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.helpers import embit_utils
 from seedsigner.models.decode_qr import DecodeQR
@@ -37,9 +36,9 @@ from seedsigner.models.seed import Seed
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
-    psbt_views, seed_views, settings_views, tools_views)
+    psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
-from seedsigner.views.view import ErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView, View
+from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView
 
 from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
@@ -360,17 +359,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(UnhandledExceptionView, dict(error=["IndexError", "line 1, in some_buggy_code.py", "list index out of range"])),
                 ScreenshotConfig(NetworkMismatchErrorView, dict(derivation_path="m/84'/1'/0'")),
                 ScreenshotConfig(OptionDisabledView, dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
-                ScreenshotConfig(
-                    ErrorView,
-                    dict(
-                        title="Error",
-                        status_icon_name=SeedSignerIconConstants.WARNING,
-                        status_headline="Unknown QR Type",
-                        text="QRCode is invalid or is a data format not yet supported.",
-                        button_text="Back",
-                    ),
-                    screenshot_name="ScanView__UnknownQRType"
-                ),
+                ScreenshotConfig(scan_views.ScanInvalidQRTypeView)
             ]
         }
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -646,7 +646,7 @@ class TestMessageSigningFlows(FlowTest):
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
             FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
             FlowStep(scan_views.ScanView, before_run=load_invalid_signmessage_qr),  # simulate read message QR; ret val is ignored
-            FlowStep(ErrorView),
+            FlowStep(scan_views.ScanInvalidQRTypeView),
             FlowStep(MainMenuView),
         ])
 


### PR DESCRIPTION
## Description

See affected screenshot changes: https://github.com/SeedSigner/seedsigner-screenshots/pull/5

UPDATE: 2025-01-23:
1. Per @easyuxd's guidelines, tightened up the icon + color usage (7edcd33):

    >  There should be only 3 combinations for warnings and errors:
    > - Warning: WARNING / WARNING_COLOR (Yellow)
    > - Dire Warning: WARNING / DIRE_WARNING_COLOR (Orange)
    > - Error: ERROR / ERROR_COLOR (Red)

Note that the goal was to enforce his consistency rules, but I have not implemented his guidelines for when to use which warning/error. I think there are deeper discussions we need to have about what an error means and/or how it is perceived by the user (preview: I think "error" implies something is broken in our code and thus we need to take great care when telling the user there was an error).

2. And in order to begin to get a better handle on consistently applying those rules, I finally implemented `ScanInvalidQRTypeView` (c0fe676) which had previously been a manually-created View that the screenshot generator had to also manually create to provide the matching screenshot. Note the comment/misgivings about its "Error" title.

3. Misc trivial import cleanup while I was in those files.

---

Main purpose:
* Adds the new SPACE and DEL icons from #605 to `Keyboard`. Slight refactor in there required.
* Requires a minor bugfix on the icon constants mappings.


UI fixes:
* We had never used the `ERROR` icon (we were using the `WARNING` exclamation in red instead).


UI consistency tweaks:
* Slightly opinionated edits for when to use `ERROR` vs `WARNING` and red vs yellow.
* General principles applied:
  * Red = Extreme danger (displaying mnemonic, PSBT addr verification failed, etc)
  * Red = System error, bug, showstopper
  * Yellow = Warning; be aware but don't scare the user.
  * Yellow = Incompatibility (e.g. unknown QR format). Yes, something went wrong, but don't scare the user.
* Judgment call: Signing PSBT didn't produce a valid signature: I used `WARNING` in yellow.
  * Rationale: maybe they already signed the multisig PSBT with this key. That's not a reason to panic. Or they opted to try to sign with a key that we didn't think could sign in the first place (has the "(?)" on the selection screen).


Minor misc:
* `Keyboard`: Use our `CHEVRON_LEFT` / `CHEVRON_RIGHT` for cursor navigation.
* I/O Test Screen: Use our icons instead of FontAwesome.
* Remove legacy `load_icon()` function which was an early ~v0.5.0 relic.
* Minor spacing fix at the bottom edge of `ButtonListScreen` where `is_bottom_list=True` with more than one button.
* Render Dice icons to fill the `Keyboard` key size.
* Change to text when multisig self-transfer addr can't be verified by descriptor; edited to fit better in available space. Text change affects translations (`messages.pot`).
* Applied "Suspicious PSBT" consistently across single sig and multisig.
* Screenshot generator tweaked to generate same results as the `ScanView` error when it scans an unsupported QR format.

---

This pull request is categorized as a:
- [x] UI cleanup

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other