### PR TITLE
Tests that fail for BlueWallet-v7.0.7 upper-cased addresses

### DIFF
--- a/tests/test_decodepsbtqr.py
+++ b/tests/test_decodepsbtqr.py
@@ -299,6 +299,7 @@ def test_bitcoin_address():
     main_bech32_address3 = "BITCOIN:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?junk"
     main_bech32_address4 = "bitcoin:BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ?junk"
     main_bech32_address5 = "BITCOIN:BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ?junk"
+    main_bech32_address6 = "BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ"
     
     d = DecodeQR()
     d.add_data(bad1)
@@ -322,7 +323,8 @@ def test_bitcoin_address():
         main_bech32_address2,
         main_bech32_address3,
         main_bech32_address4,
-        main_bech32_address5
+        main_bech32_address5,
+        main_bech32_address6
     ):
         d = DecodeQR()
         d.add_data(address_test_case)

--- a/tests/test_decodepsbtqr.py
+++ b/tests/test_decodepsbtqr.py
@@ -297,6 +297,8 @@ def test_bitcoin_address():
     
     main_bech32_address2 = "bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?amount=12000"
     main_bech32_address3 = "BITCOIN:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?junk"
+    main_bech32_address4 = "bitcoin:BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ?junk"
+    main_bech32_address5 = "BITCOIN:BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ?junk"
     
     d = DecodeQR()
     d.add_data(bad1)
@@ -315,12 +317,18 @@ def test_bitcoin_address():
     assert d.get_address() == legacy_address2
     assert d.get_address_type() == (SettingsConstants.LEGACY_P2PKH, SettingsConstants.MAINNET)
     
-    d = DecodeQR()
-    d.add_data(main_bech32_address)
-    
-    assert d.get_address() == main_bech32_address
-    assert d.get_address_type() == (SettingsConstants.NATIVE_SEGWIT, SettingsConstants.MAINNET)
-    
+    for address_test_case in (
+        main_bech32_address,
+        main_bech32_address2,
+        main_bech32_address3,
+        main_bech32_address4,
+        main_bech32_address5
+    ):
+        d = DecodeQR()
+        d.add_data(address_test_case)
+        assert d.get_address() == main_bech32_address
+        assert d.get_address_type() == (SettingsConstants.NATIVE_SEGWIT, SettingsConstants.MAINNET)
+
     d = DecodeQR()
     d.add_data(test_bech32_address)
     


### PR DESCRIPTION
## Description

resolves #665

Recently released BlueWallet v7.0.7 changed their bech32 address format for qr-codes.
https://github.com/BlueWallet/BlueWallet/pull/7461

2 commits that add failing test-cases for latest BlueWallet v7.0.7 bech32 addresses that look like "bitcoin:BC1Q..."

TODO: resolve models/decode_qr.py to support uppercased bech32 addresses and avoids future BlueWallet user complaints about not being able to verify addresses.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
