### PR TITLE
[New Feature] Enable basic p2tr address verification

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1722,8 +1722,8 @@ class AddressVerificationStartView(View):
                 destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
 
         elif self.controller.unverified_address["script_type"] == SettingsConstants.TAPROOT:
-            # TODO: add Taproot support
-            return Destination(NotYetImplementedView)
+            sig_type = SettingsConstants.SINGLE_SIG
+            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
 
         derivation_path = embit_utils.get_standard_derivation_path(
             network=self.controller.unverified_address["network"],
@@ -1815,10 +1815,6 @@ class SeedAddressVerificationView(View):
         self.script_type = self.controller.unverified_address["script_type"]
         self.sig_type = self.controller.unverified_address["sig_type"]
         self.network = self.controller.unverified_address["network"]
-
-        if self.script_type == SettingsConstants.TAPROOT:
-            # TODO: Taproot addr verification
-            return Destination(NotYetImplementedView)
 
         # TODO: This should be in `Seed` or `PSBT` utility class
         embit_network = SettingsConstants.map_network_to_embit(self.network)

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -257,16 +257,25 @@ class TestToolsFlows(FlowTest):
         settings = controller.settings
         settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST)
 
-        def load_address_into_decoder(view: scan_views.ScanView):
+        addrs = [
             # Native segwit regtest receive addr @ index 6
-            view.decoder.add_data("bcrt1q4e9q5taxnsvc6m0uxv6h75mkzvnkxeqk6l90u2")
+            "bcrt1q4e9q5taxnsvc6m0uxv6h75mkzvnkxeqk6l90u2",
 
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
-            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
-            FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate read address QR
-            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
-            FlowStep(seed_views.SeedSelectSeedView, screen_return_value=0),
-            FlowStep(seed_views.SeedAddressVerificationView),
-            FlowStep(seed_views.SeedAddressVerificationSuccessView),
-        ])
+            # Taproot regtest change addr @ index 48
+            "bcrt1pj5v8ean2hc5lh2djsgfx4j9uc0n67942ngv6q9r49qv88ex5mrwsn3u4f7",
+        ]
+
+        for test_addr in addrs:
+            def load_address_into_decoder(view: scan_views.ScanView):
+                # Native segwit regtest receive addr @ index 6
+                view.decoder.add_data(test_addr)
+
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+                FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate read address QR
+                FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+                FlowStep(seed_views.SeedSelectSeedView, screen_return_value=0),
+                FlowStep(seed_views.SeedAddressVerificationView),
+                FlowStep(seed_views.SeedAddressVerificationSuccessView),
+            ])


### PR DESCRIPTION
## Description

Address verification flow (scan an address as a QR, select seed, brute force addr generation to find a match) had left taproot support disabled. That must have been early into our initial taproot support. But there's no reason to leave it disabled now.

---

"abandon" * 11 seed:
<img src="https://github.com/user-attachments/assets/9888b9f6-8455-49b4-8b09-ad29938f2cc0">

Test p2tr address QR (change addr @ index 48):
<img width="300" src="https://github.com/user-attachments/assets/255330af-ea99-45ce-8ac5-144b65cde507">

Verification result:
<img width="300" src="https://github.com/user-attachments/assets/52302f56-0444-4f19-928d-1514156388a7">

---

This pull request is categorized as a:
- [x] New feature

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] Yes

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
