### PR TITLE
[CI Fix] Version up all deprecated CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
       - name: rename image
         run: |
           cd seedsigner-os/images
-          mv seedsigner_os*.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
+          mv *.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
 
       - name: print sha256sum
         run: |
@@ -129,7 +129,7 @@ jobs:
       - name: download images
         uses: actions/download-artifact@v4
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_images-${{ matrix.target }}
           path: images
 
       - name: list images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,17 +77,17 @@ jobs:
           ls -la .
           ls -la src
 
-      - name: restore build cache
-        uses: actions/cache@v4
-        # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
-        # while consuming ~850 MB storage space).
-        with:
-          path: |
-            ~/.buildroot-ccache/
-            seedsigner-os/buildroot_dl
-          key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
-          restore-keys: |
-            build-cache-${{ matrix.target }}-
+      # - name: restore build cache
+      #   uses: actions/cache@v4
+      #   # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
+      #   # while consuming ~850 MB storage space).
+      #   with:
+      #     path: |
+      #       ~/.buildroot-ccache/
+      #       seedsigner-os/buildroot_dl
+      #     key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
+      #     restore-keys: |
+      #       build-cache-${{ matrix.target }}-
 
       - name: build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         target: [ "pi0", "pi2", "pi02w", "pi4" ]
     steps:
       - name: checkout seedsigner-os
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "seedsigner/seedsigner-os"
           # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # ref defaults to repo default-branch=dev (cron) or SHA of event (workflow_dispatch)
           path: "seedsigner-os/opt/rootfs-overlay/opt"
@@ -78,7 +78,7 @@ jobs:
           ls -la src
 
       - name: restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
         # while consuming ~850 MB storage space).
         with:
@@ -113,7 +113,7 @@ jobs:
           ls -la seedsigner-os/images
 
       - name: upload images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: seedsigner_os_images
           path: "seedsigner-os/images/*.img"
@@ -127,7 +127,7 @@ jobs:
     needs: build
     steps:
       - name: download images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: seedsigner_os_images
           path: images
@@ -148,7 +148,7 @@ jobs:
           sha256sum *.img > seedsigner_os.${{ env.source_hash }}.sha256
 
       - name: upload checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: seedsigner_os_images
           path: "images/*.sha256"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           ls -la src
 
       - name: restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
         # while consuming ~850 MB storage space).
         with:
@@ -92,7 +92,7 @@ jobs:
       - name: build
         run: |
           cd seedsigner-os/opt
-          ./build.sh --${{ matrix.target }} --skip-repo --no-clean
+          ./build.sh --${{ matrix.target }} --skip-repo
 
       - name: list image (before rename)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         target: [ "pi0", "pi2", "pi02w", "pi4" ]
     steps:
       - name: checkout seedsigner-os
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: "seedsigner/seedsigner-os"
           # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           # ref defaults to repo default-branch=dev (cron) or SHA of event (workflow_dispatch)
           path: "seedsigner-os/opt/rootfs-overlay/opt"
@@ -77,22 +77,22 @@ jobs:
           ls -la .
           ls -la src
 
-      # - name: restore build cache
-      #   uses: actions/cache@v4
-      #   # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
-      #   # while consuming ~850 MB storage space).
-      #   with:
-      #     path: |
-      #       ~/.buildroot-ccache/
-      #       seedsigner-os/buildroot_dl
-      #     key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
-      #     restore-keys: |
-      #       build-cache-${{ matrix.target }}-
+      - name: restore build cache
+        uses: actions/cache@v3
+        # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
+        # while consuming ~850 MB storage space).
+        with:
+          path: |
+            ~/.buildroot-ccache/
+            seedsigner-os/buildroot_dl
+          key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
+          restore-keys: |
+            build-cache-${{ matrix.target }}-
 
       - name: build
         run: |
           cd seedsigner-os/opt
-          ./build.sh --${{ matrix.target }} --skip-repo
+          ./build.sh --${{ matrix.target }} --skip-repo --no-clean
 
       - name: list image (before rename)
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: rename image
         run: |
           cd seedsigner-os/images
-          mv *.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
+          mv seedsigner_os*.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
 
       - name: print sha256sum
         run: |
@@ -113,9 +113,9 @@ jobs:
           ls -la seedsigner-os/images
 
       - name: upload images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: seedsigner_os_images-${{ matrix.target }}
+          name: seedsigner_os_images
           path: "seedsigner-os/images/*.img"
           if-no-files-found: error
           # maximum 90 days retention
@@ -127,9 +127,9 @@ jobs:
     needs: build
     steps:
       - name: download images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
-          name: seedsigner_os_images-${{ matrix.target }}
+          name: seedsigner_os_images
           path: images
 
       - name: list images
@@ -148,9 +148,9 @@ jobs:
           sha256sum *.img > seedsigner_os.${{ env.source_hash }}.sha256
 
       - name: upload checksums
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: seedsigner_os_hashes-${{ matrix.target }}
+          name: seedsigner_os_images
           path: "images/*.sha256"
           if-no-files-found: error
           # maximum 90 days retention

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: upload images
         uses: actions/upload-artifact@v4
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_images-${{ matrix.target }}
           path: "seedsigner-os/images/*.img"
           if-no-files-found: error
           # maximum 90 days retention
@@ -150,7 +150,7 @@ jobs:
       - name: upload checksums
         uses: actions/upload-artifact@v4
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_hashes-${{ matrix.target }}
           path: "images/*.sha256"
           if-no-files-found: error
           # maximum 90 days retention

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           ls -la src
 
       - name: restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
         # while consuming ~850 MB storage space).
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,12 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Needs to also pull the seedsigner-translations repo
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Coverage report
         run: coverage report
       - name: Archive CI Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts
           path: artifacts/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Archive CI Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ci-artifacts
+          name: ci-artifacts-${{ matrix.python-version }}
           path: artifacts/**
           retention-days: 10
         # Upload also when tests fail. The workflow result (red/green) will


### PR DESCRIPTION
## Description

CI test runner is automatically failing all runs with:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

For example: https://github.com/SeedSigner/seedsigner/actions/runs/12932802283

---

Changes:
* This PR updates all CI actions that have a newer version available.
* Per `actions/upload-artifact@v4` changes, each artifact uploaded must have a distinct name.

`tests.yml` will run with these changes in its own CI checks for this PR; if this PR is ✅, then these changes were successful.

---

This pull request is categorized as a:
- [x] Bug fix

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] N/A
