### PR TITLE
[DRAFT] "Build" workflow fails to compile SeedSigner OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         target: [ "pi0", "pi2", "pi02w", "pi4" ]
     steps:
       - name: checkout seedsigner-os
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "seedsigner/seedsigner-os"
           # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # ref defaults to repo default-branch=dev (cron) or SHA of event (workflow_dispatch)
           path: "seedsigner-os/opt/rootfs-overlay/opt"
@@ -78,7 +78,7 @@ jobs:
           ls -la src
 
       - name: restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
         # while consuming ~850 MB storage space).
         with:
@@ -101,7 +101,7 @@ jobs:
       - name: rename image
         run: |
           cd seedsigner-os/images
-          mv seedsigner_os*.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
+          mv *.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
 
       - name: print sha256sum
         run: |
@@ -113,9 +113,9 @@ jobs:
           ls -la seedsigner-os/images
 
       - name: upload images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_images-${{ matrix.target }}
           path: "seedsigner-os/images/*.img"
           if-no-files-found: error
           # maximum 90 days retention
@@ -127,9 +127,9 @@ jobs:
     needs: build
     steps:
       - name: download images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_images-${{ matrix.target }}
           path: images
 
       - name: list images
@@ -148,9 +148,9 @@ jobs:
           sha256sum *.img > seedsigner_os.${{ env.source_hash }}.sha256
 
       - name: upload checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: seedsigner_os_images
+          name: seedsigner_os_hashes-${{ matrix.target }}
           path: "images/*.sha256"
           if-no-files-found: error
           # maximum 90 days retention


### PR DESCRIPTION
## Description

The `build.yml` workflow has been broken since sometime [between Dec 23rd and Jan 12th](https://github.com/SeedSigner/seedsigner/commits/dev/?author=newtonick&since=2024-12-23&until=2025-01-12).

My attempts to resolve it keep failing. The error displayed in the workflow runs is wrong; it can't find the *.img file because the Buildroot compilation never succeeded.

I have not been able to see anything that might explain the failure in the compiler output.

And there were no SeedSigner OS changes in that time frame that would affect compilation.

Keeping this PR as a DRAFT since I don't have an actual solution yet.

---

Note: Ignore the failing CI / test workflows on this PR; those are addressed in #671.

---

This pull request is categorized as a:
- [x] Bug fix

## Checklist
If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] N/A
