### PR TITLE
[Bugfix] Verification Views after transcribing SeedQR fixes, refactors, test, screenshots

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -13,7 +13,7 @@ sys.modules['seedsigner.hardware.buttons'] = MagicMock()
 sys.modules['seedsigner.hardware.camera'] = MagicMock()
 
 from seedsigner.controller import Controller, FlowBasedTestException, StopFlowBasedTest
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON, ButtonOption
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.settings import Settings
 from seedsigner.views.view import Destination, MainMenuView, UnhandledExceptionView, View
@@ -140,6 +140,12 @@ class FlowStep:
 
 
 
+class FlowTestInvalidButtonDataInstanceTypeException(FlowBasedTestException):
+    """ The button_data contained an item that was not a ButtonOption instance """
+    pass
+
+
+
 class FlowTestInvalidButtonDataSelectionException(FlowBasedTestException):
     """ The FlowStep's button_data_selection value was not found in the View's button_data """
     pass
@@ -249,6 +255,12 @@ class FlowTest(BaseTest):
                     Just returns the return value specified in the test sequence.
                     """
                     cur_flow_step = sequence[0]
+
+                    if "button_data" in kwargs:
+                        # Verify that they are all proper ButtonOption instances
+                        for button_option in kwargs.get("button_data"):
+                            if not isinstance(button_option, ButtonOption):
+                                raise FlowTestInvalidButtonDataInstanceTypeException(f"button_data must be a list of ButtonOption instances, not {type(button_option)}: {button_option}")
 
                     if cur_flow_step.button_data_selection:
                         # We're mocking out the View.run_screen() method, so we'll get all of the

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -290,6 +290,9 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedTranscribeSeedQRZoomedInView, dict(seed_num=0, seedqr_format=QRType.SEED__SEEDQR, initial_block_x=2, initial_block_y=2),        screenshot_name="SeedTranscribeSeedQRZoomedInView_12_Standard"),
 
                 ScreenshotConfig(seed_views.SeedTranscribeSeedQRConfirmQRPromptView, dict(seed_num=0)),
+                ScreenshotConfig(seed_views.SeedTranscribeSeedQRConfirmWrongSeedView),
+                ScreenshotConfig(seed_views.SeedTranscribeSeedQRConfirmInvalidQRView),
+                ScreenshotConfig(seed_views.SeedTranscribeSeedQRConfirmSuccessView, dict(seed_num=0)),
 
                 # Screenshot can't render live preview screens
                 # ScreenshotConfig(seed_views.SeedTranscribeSeedQRConfirmScanView, dict(seed_num=0)),

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -432,6 +432,9 @@ class TestSeedFlows(FlowTest):
         def load_wrong_seed_into_decoder(view: View):
             view.decoder.add_data("0138" * 24)
 
+        def load_completely_wrong_qr_type_into_decoder(view: View):
+            view.decoder.add_data("I like cheese")
+
         def load_right_seed_into_decoder(view: View):
             view.decoder.add_data("0000" * 11 + "0003")
 
@@ -449,6 +452,12 @@ class TestSeedFlows(FlowTest):
             # Intentionally "scan" the wrong SeedQR
             FlowStep(seed_views.SeedTranscribeSeedQRConfirmScanView, before_run=load_wrong_seed_into_decoder),
             FlowStep(seed_views.SeedTranscribeSeedQRConfirmWrongSeedView),
+            FlowStep(seed_views.SeedTranscribeSeedQRZoomedInView, is_redirect=True),  # Live interactive screens are still weird
+
+            # Intentionally scan QR data that makes no sense for this flow
+            FlowStep(seed_views.SeedTranscribeSeedQRConfirmQRPromptView, button_data_selection=seed_views.SeedTranscribeSeedQRConfirmQRPromptView.SCAN),
+            FlowStep(seed_views.SeedTranscribeSeedQRConfirmScanView, before_run=load_completely_wrong_qr_type_into_decoder),
+            FlowStep(seed_views.SeedTranscribeSeedQRConfirmInvalidQRView),
             FlowStep(seed_views.SeedTranscribeSeedQRZoomedInView, is_redirect=True),  # Live interactive screens are still weird
 
             # Now scan the correct SeedQR


### PR DESCRIPTION
## Description

Expected sequence:
Transcribe a SeedQR, choose to verify your results. After your SeedQR is scanned, see either success (the SeedQR that was just scanned matched the SeedQR you just transcribed) or error (did not match or the QR code you just scanned is a completely unexpected type).

BUG: An Exception is raised after scanning the SeedQR due to bad `button_data`.

---

### Outdated implementation hiding an l10n bug
`SeedTranscribeSeedQRConfirmScanView` was an outdated implementation that violated our "1 `View` instantiates 1 `Screen`" rule; after scanning back the transcribed SeedQR it was calling its own collection of follow up sub-`Screen`s.

Also these sub-`Screen`s had outdated `button_data` that weren't `ButtonOption` lists. Which, by design in the l10n refactor, now throws an Exception.

But a proper `FlowTest` couldn't be written for each of these `Screen`s because they were improperly nested inside that one big `View` (my fault; I wrote all that original code). And so none of our automated tests could alert of us of this Exception.

---

### The fixes in this PR
* Pull those sub-`Screen` calls into their own individual `View`s to match the conventions used everywhere else.
* Properly instantiate the `button_list` items as `ButtonOption`s.
* Write a `FlowTest` to hit each failure condition when verifying the transcribed SeedQR with eventual success.
* Add screenshots for the now properly isolated new `View`s: https://github.com/SeedSigner/seedsigner-screenshots/commit/c157f6e0dcbe71026280fabb0431e7b9742d296b
* Additional sanity checking in `FlowTest.run_screen` (in tests/base.py) to check for any bad `button_list` inputs (i.e. they all must be `ButtonOption`s).
* Additional test case to verify that `FlowTest` will catch bad `button_list` input.

Note: The edits in `SeedTranscribeSeedQRConfirmScanView` to pull out the three new `View`s are almost entirely just copy-paste. As is often the case, the web diff here looks more dramatic than it actually is.

Misc:
* Light refactors throughout the Transcribe SeedQR flow for compatibility with `FlowTest`.

---

This pull request is categorized as a:
- [x] Bug fix
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] Yes

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
