### PR TITLE
Add Keeper to default coordinators list

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -40,10 +40,10 @@ class SettingsConstants:
     COORDINATOR__KEEPER = "kpr"
     ALL_COORDINATORS = [
         (COORDINATOR__BLUE_WALLET, "BlueWallet"),
+        (COORDINATOR__KEEPER, "Keeper"),
         (COORDINATOR__NUNCHUK, "Nunchuk"),
         (COORDINATOR__SPARROW, "Sparrow"),
         (COORDINATOR__SPECTER_DESKTOP, "Specter Desktop"),
-        (COORDINATOR__KEEPER, "Keeper"),
     ]
 
     LOCALE__ARABIC = "ar"
@@ -410,6 +410,7 @@ class SettingsDefinition:
                       selection_options=SettingsConstants.ALL_COORDINATORS,
                       default_value=[
                           SettingsConstants.COORDINATOR__BLUE_WALLET,
+                          SettingsConstants.COORDINATOR__KEEPER,
                           SettingsConstants.COORDINATOR__NUNCHUK,
                           SettingsConstants.COORDINATOR__SPARROW,
                           SettingsConstants.COORDINATOR__SPECTER_DESKTOP,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -91,7 +91,7 @@ class TestController(BaseTest):
         assert controller.settings.get_value(SettingsConstants.SETTING__LOCALE) == SettingsConstants.LOCALE__ENGLISH
         assert controller.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE) == SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
         assert controller.settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) == SettingsConstants.OPTION__DISABLED
-        assert controller.settings.get_value(SettingsConstants.SETTING__COORDINATORS) == [i for i,j in SettingsConstants.ALL_COORDINATORS if i!="kpr"]
+        assert controller.settings.get_value(SettingsConstants.SETTING__COORDINATORS) == [i for i,j in SettingsConstants.ALL_COORDINATORS]
         assert controller.settings.get_value(SettingsConstants.SETTING__BTC_DENOMINATION) == SettingsConstants.BTC_DENOMINATION__THRESHOLD
 
         # Advanced Settings defaults

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -317,8 +317,8 @@ class TestSeedFlows(FlowTest):
         script_type = ButtonOption(self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__SCRIPT_TYPES)[2], return_data=custom_derivation)
 
         specter = SettingsConstants.COORDINATOR__SPECTER_DESKTOP
-        assert SettingsConstants.ALL_COORDINATORS[3][0] == specter
-        coordinator = ButtonOption(self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__COORDINATORS)[3], return_data=specter)
+        assert SettingsConstants.ALL_COORDINATORS[4][0] == specter
+        coordinator = ButtonOption(self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__COORDINATORS)[4], return_data=specter)
 
         self.run_sequence(
             initial_destination_view_args=dict(seed_num=0),


### PR DESCRIPTION
## Description

Add Bitcoin Keeper to the list of coordinators enabled by default.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other
