### PR TITLE
[bugfix] backspace on empty passphrase field

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -997,10 +997,10 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                             pass
                         elif cursor_position == len(self.passphrase):
                             self.passphrase = self.passphrase[:-1]
+                            cursor_position -= 1
                         else:
                             self.passphrase = self.passphrase[:cursor_position - 1] + self.passphrase[cursor_position:]
-
-                        cursor_position -= 1
+                            cursor_position -= 1
 
                     elif ret_val == Keyboard.KEY_CURSOR_LEFT["code"]:
                         cursor_position -= 1


### PR DESCRIPTION
## Description

In the BIP-39 passphrase screen, only decrement the cursor position when a character is removed.

Pressing backspace one or more times on an empty passphrase field causes the subsequent typed characters to appear to the right of the cursor instead of the left, because cursor_position becomes negative. This can happen when a user holds down backspace to erase the passphrase field entirely.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
