### PR TITLE
[Enhanced] seed management with BIP-85 support

### DIFF
--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -22,7 +22,9 @@ class Seed:
     def __init__(self,
                  mnemonic: List[str] = None,
                  passphrase: str = "",
-                 wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> None:
+                 wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH,
+                 bip85_parent: int = None,
+                 bip85_index: int = None) -> None:
         self._wordlist_language_code = wordlist_language_code
 
         if not mnemonic:
@@ -32,8 +34,19 @@ class Seed:
         self._passphrase: str = ""
         self.set_passphrase(passphrase, regenerate_seed=False)
 
+        self.bip85_parent = bip85_parent  
+        self.bip85_index = bip85_index   
+
         self.seed_bytes: bytes = None
         self._generate_seed()
+
+    @property
+    def display_name(self) -> str:
+        """Returns a display name including child index if it's a BIP-85 child seed"""
+        fingerprint = self.get_fingerprint(SettingsConstants.MAINNET)
+        if self.bip85_parent is not None and self.bip85_index is not None:
+            return f"{fingerprint} (Child #{self.bip85_index})"
+        return fingerprint
 
 
     @staticmethod

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -45,7 +45,8 @@ class Seed:
         """Returns a display name including child index if it's a BIP-85 child seed"""
         fingerprint = self.get_fingerprint(SettingsConstants.MAINNET)
         if self.bip85_parent is not None and self.bip85_index is not None:
-            return f"{fingerprint} (Child #{self.bip85_index})"
+            ##BIP-85 child seeds, show with arrow to indicate relationship
+            return f"  ↳ #{self.bip85_index}: {fingerprint}"
         return fingerprint
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1093,18 +1093,26 @@ class SeedWordsView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        selected_button = button_data[selected_menu_num]
-        if selected_button == self.NEXT:
-            return Destination(
-                SeedWordsView,
-                view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data)
-            )
-        elif selected_button == self.DONE:
+        elif button_data[selected_menu_num] == self.NEXT:
+            if self.seed_num is None and self.page_index == num_pages - 1:
+                return Destination(
+                    SeedWordsBackupTestPromptView,
+                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                )
+            else:
+                return Destination(
+                    SeedWordsView,
+                    view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data)
+                )
+
+        elif button_data[selected_menu_num] == self.DONE:
+            # Must clear history to avoid BACK button returning to private info
             return Destination(
                 SeedWordsBackupTestPromptView,
                 view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
             )
-        elif selected_button == self.LOAD_SEED:
+        
+        elif button_data[selected_menu_num] == self.LOAD_SEED:
             #derive child mnemonic and create new Seed object
             derived_mnemonic = self.seed.get_bip85_child_mnemonic(
                 self.bip85_data["child_index"],

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -28,12 +28,7 @@ class SeedsMenuView(View):
 
     def __init__(self):
         super().__init__()
-        self.seeds = []
-        for seed in self.controller.storage.seeds:
-            self.seeds.append({
-                "fingerprint": seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            })
-
+        self.seeds = self.controller.storage.seeds
 
     def run(self):
         if not self.seeds:
@@ -42,7 +37,7 @@ class SeedsMenuView(View):
 
         button_data = []
         for seed in self.seeds:
-            button_data.append(ButtonOption(seed["fingerprint"], SeedSignerIconConstants.FINGERPRINT))
+            button_data.append(ButtonOption(seed.display_name, SeedSignerIconConstants.FINGERPRINT))
         button_data.append(self.LOAD)
 
         selected_menu_num = self.run_screen(
@@ -1052,6 +1047,7 @@ class SeedWordsWarningView(View):
 class SeedWordsView(View):
     NEXT = ButtonOption("Next")
     DONE = ButtonOption("Done")
+    LOAD_SEED = ButtonOption("Load Seed")
 
     def __init__(self, seed_num: int, bip85_data: dict = None, page_index: int = 0):
         super().__init__()
@@ -1083,6 +1079,8 @@ class SeedWordsView(View):
             button_data.append(self.NEXT)
         else:
             button_data.append(self.DONE)
+            if self.bip85_data is not None:
+                button_data.append(self.LOAD_SEED)
 
         selected_menu_num = seed_screens.SeedWordsScreen(
             title=f"{title}: {self.page_index+1}/{num_pages}",
@@ -1095,25 +1093,35 @@ class SeedWordsView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        if button_data[selected_menu_num] == self.NEXT:
-            if self.seed_num is None and self.page_index == num_pages - 1:
-                return Destination(
-                    SeedWordsBackupTestPromptView,
-                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
-                )
-            else:
-                return Destination(
-                    SeedWordsView,
-                    view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data)
-                )
-
-        elif button_data[selected_menu_num] == self.DONE:
-            # Must clear history to avoid BACK button returning to private info
+        selected_button = button_data[selected_menu_num]
+        if selected_button == self.NEXT:
+            return Destination(
+                SeedWordsView,
+                view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data)
+            )
+        elif selected_button == self.DONE:
             return Destination(
                 SeedWordsBackupTestPromptView,
                 view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
             )
-
+        elif selected_button == self.LOAD_SEED:
+            #derive child mnemonic and create new Seed object
+            derived_mnemonic = self.seed.get_bip85_child_mnemonic(
+                self.bip85_data["child_index"],
+                self.bip85_data["num_words"]
+            )
+            derived_seed = Seed(
+                mnemonic=derived_mnemonic.split(),
+                passphrase="",
+                bip85_parent=self.seed_num,
+                bip85_index=self.bip85_data["child_index"]
+            )
+            self.controller.storage.seeds.append(derived_seed)
+            derived_seed_num = len(self.controller.storage.seeds) - 1
+            return Destination(
+                SeedWordsBackupTestPromptView,
+                view_args=dict(seed_num=derived_seed_num)
+            )
 
 
 """****************************************************************************

--- a/tests/test_bip85.py
+++ b/tests/test_bip85.py
@@ -1,5 +1,5 @@
 from seedsigner.models.seed import Seed
-
+from seedsigner.controller import Controller
 
 def test_derive_child_mnemonic():
 
@@ -15,3 +15,24 @@ def test_derive_child_mnemonic():
 
     actual = seed.get_bip85_child_mnemonic(0, 24)
     assert actual == expected
+
+def test_derive_and_load_child_seed():
+    controller = Controller.get_instance()
+    master_seed = Seed(mnemonic=["word"] * 12)
+    controller.storage.seeds.append(master_seed)
+    seed_num = 0
+    bip85_data = {"child_index": 0, "num_words": 12}
+    
+    #simulate BIP-85 derivation and loading
+    derived_mnemonic = master_seed.get_bip85_child_mnemonic(0, 12)
+    derived_seed = Seed(
+        mnemonic=derived_mnemonic.split(),
+        passphrase="",
+        bip85_parent=seed_num,
+        bip85_index=0
+    )
+    controller.storage.seeds.append(derived_seed)
+    
+    assert len(controller.storage.seeds) == 2
+    assert controller.storage.seeds[1].get_fingerprint() != master_seed.get_fingerprint()
+    assert controller.storage.seeds[1].display_name.endswith("(Child #0)")


### PR DESCRIPTION
## Description

Adds optional loading of BIP-85 child keys into SeedSigner’s seed list.

- **Changes:** Added "Load Seed" option for BIP-85 child seeds, updated seed list UI to show "fingerprint (Child #index)", and extended `Seed` class with BIP-85 metadata.
- **Tests:** Added `test_derive_and_load_child_seed()` in `test_bip85.py` plus manual tests for loading, signing, and discarding.

For mocking I have created a mockhardware.py inside hardware folder and replicate MockSpiDev ,MockGPIO and MockPiCamera as

```python
import time
import numpy as np

class MockSpiDev:
    def __init__(self, *args, **kwargs):
        pass
    
    def open(self, *args, **kwargs):
        return self
    
    def max_speed_hz(self, speed=None):
        if speed is None:
            return 0
        self._max_speed_hz = speed
        
    def writebytes(self, data):
        pass
        
    def writebytes2(self, data):
        pass
    
    def close(self):
        pass

class MockGPIO:
    BOARD = 1
    OUT = 1
    IN = 2
    HIGH = 1
    LOW = 0
    PUD_UP = 1
    PUD_DOWN = 2
    
    RPI_INFO = {
        'P1_REVISION': 3  # Default to 40-pin GPIO (Raspberry Pi 2 and above)
    }
    
    _pin_states = {}  # Fixed the typo in your original code
    
    @staticmethod
    def setmode(*args, **kwargs):
        pass
        
    @staticmethod
    def setwarnings(*args, **kwargs):
        pass
        
    @staticmethod
    def setup(pin, direction, pull_up_down=None):
        MockGPIO._pin_states[pin] = MockGPIO.HIGH  # Default to HIGH for pull-up resistors
    
    @staticmethod
    def output(pin, value):
        MockGPIO._pin_states[pin] = value
    
    @staticmethod
    def input(pin):
        return MockGPIO._pin_states.get(pin, MockGPIO.HIGH)
    
    @staticmethod
    def cleanup():
        MockGPIO._pin_states.clear()
    
    @staticmethod
    def simulate_button_press(pin):
        MockGPIO._pin_states[pin] = MockGPIO.LOW
    
    @staticmethod
    def simulate_button_release(pin):
        MockGPIO._pin_states[pin] = MockGPIO.HIGH

class MockPiCamera:
    def __init__(self, resolution=(320, 240), framerate=32, **kwargs):
        self.resolution = resolution
        self.framerate = framerate
        self.closed = False
        self._recording = False
        self._preview = False
        self._rotation = 0
        self._brightness = 50
        self._contrast = 0
        self._image_effect = 'none'
        for key, value in kwargs.items():
            setattr(self, key, value)
    
    def capture_continuous(self, output, format="jpeg", use_video_port=False, **kwargs):
        """Mock continuous capture generator"""
        while not self.closed:
            yield MockFrame(self.resolution, format)
            time.sleep(1.0 / self.framerate)  # Simulate framerate
    
    def start_recording(self, output, format=None, **kwargs):
        self._recording = True
    
    def stop_recording(self):
        self._recording = False
    
    def start_preview(self, **kwargs):
        self._preview = True
    
    def stop_preview(self):
        self._preview = False
    
    def close(self):
        self.closed = True


class MockFrame:
    def __init__(self, resolution, format="jpeg"):
        self.resolution = resolution
        self.format = format
        if format.lower() in ["rgb", "bgr"]:
            self.array = np.zeros((resolution[1], resolution[0], 3), dtype=np.uint8)
            width = resolution[0] // 3
            self.array[:, 0:width, 0] = 255  
            self.array[:, width:width*2, 1] = 255  
            self.array[:, width*2:, 2] = 255  
        else:
            self.array = np.zeros((resolution[1], resolution[0]), dtype=np.uint8)
            for i in range(resolution[1]):
                self.array[i, :] = i * 255 // resolution[1]


class MockPiRGBArray:
    def __init__(self, camera, size=None):
        self.camera = camera
        self.size = size if size is not None else camera.resolution
        self.array = np.zeros((self.size[1], self.size[0], 3), dtype=np.uint8)
        self.closed = False
    
    def truncate(self, size=0):
        """Reset the array to zeros or specified size"""
        if size == 0:
            self.array = np.zeros((self.size[1], self.size[0], 3), dtype=np.uint8)
    
    def close(self):
        self.closed = True
```

**_WITH FOLLOWING REPLACE_**   

Replace the line from 
```python
import RPi.GPIO as GPIO
```
to
```python
from seedsigner.hardware.mock_hardware import MockGPIO as GPIO
```
`OR`
Replace the line from 
```python
import spidev
```
to
```python
from seedsigner.hardware.mock_hardware import MockSpiDev, MockGPIO as GPIO
```
`AND`
Replace the line from 
```python
from picamera.array import PiRGBArray
from picamera import PiCamera
```
to
```python
from seedsigner.hardware.mock_hardware import MockPiCamera, MockPiRGBArray
PiCamera = MockPiCamera
```

For testing purposes, Make sure to use pytest for testing.
`\seedsigner\tests> pytest .\test_bip85.py`
![image](https://github.com/user-attachments/assets/c6db7d70-722e-4fee-aa19-13ba53b1a690)

This pull request is categorized as a:

- [x] New feature

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] Yes


I have tested this PR on the following platforms/os:

- [x] Other

