### PR TITLE
[Testing] Slight enhancement to `coverage` calcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Repository = "https://github.com/SeedSigner/seedsigner"
 
 [tool.coverage.html]
 directory = "coverage_html_report"
-skip_covered = false
+skip_covered = true
 skip_empty = true
 
 [tool.coverage.report]
@@ -48,8 +48,9 @@ omit = [
   "*/__init__.py",
   "*/tests/*",
 ]
-skip_covered = false
+skip_covered = true
 skip_empty = true
+precision = 2
 
 [tool.coverage.run]
 source = ["src"]


### PR DESCRIPTION
## Description

Very minor update to how `coverage` is configured. For things like small PRs, the two-decimal coverage percentage calculation is more useful/satisfying to be able to see small changes.

Minor note: the change to `skip_covered = true` (surprisingly) yields slightly different total coverage calcs.

<img width="740" alt="Screenshot 2025-03-31 at 11 18 48 AM" src="https://github.com/user-attachments/assets/3ec86d1b-46b7-4f67-8efa-1ec205561b7a" />

---

This pull request is categorized as a:
- [x] Other

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other (the test suite is only run in local dev and Github Actions)