### PR TITLE
[CI Fix] Modify CI to run test checks on all commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - dev
-      - main
+      - '**'
   pull_request:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - '**'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Description


This PR modifies the CI workflow to run tests on **every commit**, not just on PR updates or merges to `dev` and `main`.  


Currently, the CI test suite only runs when a PR is updated or merged into `dev` or `main`. However, running CI on **every commit** provides immediate feedback to developers working in forks and branches.

This change ensures:  
- CI checks trigger for all commits on all branches.  
- Developers catch issues earlier in the development process.  
- There is **no impact on the upstream repo** since `dev` and `main` only receive PR merges.


Fixes  **#602**

---

This pull request is categorized as a:

- [x] Code refactor

## Checklist

 - [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR 
 
If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] N/A

