### PR TITLE
[Documentation] Mention `--ignore-missing` flag issue on older macOS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Now that you have confirmed that you do have the real SeedSigner Project's Publi
 ```
 shasum -a 256 --ignore-missing --check seedsigner.0.8.5.sha256.txt  
 ```
+Note: macOS versions earlier than v11 (Big Sur) do not support the `--ignore-missing` flag. You can omit it and disregard any missing file warnings.
 
 **On Windows (inside Powershell):** Run this command
 ```


### PR DESCRIPTION
## Description

This PR fixes #507 by adding a note that older macOS versions (pre-v11/Big Sur) do not support the `--ignore-missing` flag.

This update helps users avoid errors when using the unsupported flag on these versions.

This pull request is categorized as a:

- [x] Documentation

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Other ([Emulator](https://github.com/enteropositivo/seedsigner-emulator))
