### PR TITLE
[Refactoring] 'wallet_type' to conform to 'sig_type' naming convention

### DIFF
--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -19,43 +19,43 @@ from seedsigner.models.settings_definition import SettingsConstants
 # TODO: PR these directly into `embit`? Or replace with new/existing methods already in `embit`?
 
 
-# TODO: Refactor `wallet_type` to conform to our `sig_type` naming convention
-def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, wallet_type: str = SettingsConstants.SINGLE_SIG, script_type: str = SettingsConstants.NATIVE_SEGWIT) -> str:
+# Refactoring `wallet_type` to conform to our `sig_type` naming convention
+def get_standard_derivation_path(network : str = SettingsConstants.MAINNET, sig_type : str = SettingsConstants.SINGLE_SIG, script_type = SettingsConstants.NATIVE_SEGWIT ) -> str :
+
     if network == SettingsConstants.MAINNET:
         network_path = "0'"
-    elif network == SettingsConstants.TESTNET:
-        network_path = "1'"
-    elif network == SettingsConstants.REGTEST:
+    elif network in [SettingsConstants.TESTNET, SettingsConstants.REGTEST]:
         network_path = "1'"
     else:
         raise Exception("Unexpected network")
 
-    if wallet_type == SettingsConstants.SINGLE_SIG:
-        if script_type == SettingsConstants.LEGACY_P2PKH:
-            return f"m/44'/{network_path}/0'"
-        elif script_type == SettingsConstants.NESTED_SEGWIT:
-            return f"m/49'/{network_path}/0'"
-        elif script_type == SettingsConstants.NATIVE_SEGWIT:
-            return f"m/84'/{network_path}/0'"
-        elif script_type == SettingsConstants.TAPROOT:
-            return f"m/86'/{network_path}/0'"
-        else:
-            raise Exception("Unexpected script type")
+    # Validating script_type using ALL_SCRIPT_TYPES
+    valid_script_types = {st[0] for st in SettingsConstants.ALL_SCRIPT_TYPES}
+    if script_type not in valid_script_types:
+        raise Exception(f"Unexpected script type: {script_type}")
 
-    elif wallet_type == SettingsConstants.MULTISIG:
-        if script_type == SettingsConstants.LEGACY_P2PKH:
-            return f"m/45'" #BIP45
-        elif script_type == SettingsConstants.NESTED_SEGWIT:
-            return f"m/48'/{network_path}/0'/1'"
-        elif script_type == SettingsConstants.NATIVE_SEGWIT:
-            return f"m/48'/{network_path}/0'/2'"
-        elif script_type == SettingsConstants.TAPROOT:
-            raise Exception("Taproot multisig not yet supported")
-        else:
-            raise Exception("Unexpected script type")
+
+    if sig_type == SettingsConstants.SINGLE_SIG:
+        script_paths = {
+            SettingsConstants.LEGACY_P2PKH: f"m/44'/{network_path}/0'",
+            SettingsConstants.NESTED_SEGWIT: f"m/49'/{network_path}/0'",
+            SettingsConstants.NATIVE_SEGWIT: f"m/84'/{network_path}/0'",
+            SettingsConstants.TAPROOT: f"m/86'/{network_path}/0'",
+        }
+    elif sig_type == SettingsConstants.MULTISIG:
+        script_paths = {
+            SettingsConstants.LEGACY_P2PKH: "m/45'",  # BIP45
+            SettingsConstants.NESTED_SEGWIT: f"m/48'/{network_path}/0'/1'",
+            SettingsConstants.NATIVE_SEGWIT: f"m/48'/{network_path}/0'/2'",
+        }
     else:
-        raise Exception("Unexpected wallet type")    # checks that all inputs are from the same wallet
+        raise Exception("Unexpected sig type")
 
+
+    if script_type not in script_paths:
+        raise Exception(f"Unsupported script type for {sig_type}: {script_type}")
+
+    return script_paths[script_type]  
 
 
 def get_xpub(seed_bytes, derivation_path: str, embit_network: str = "main") -> HDKey:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -918,7 +918,7 @@ class SeedExportXpubDetailsView(View):
             from seedsigner.helpers import embit_utils
             derivation_path = embit_utils.get_standard_derivation_path(
                 network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
-                wallet_type=self.sig_type,
+                sig_type=self.sig_type,
                 script_type=self.script_type
             )
 
@@ -1778,7 +1778,7 @@ class AddressVerificationStartView(View):
 
         derivation_path = embit_utils.get_standard_derivation_path(
             network=self.controller.unverified_address["network"],
-            wallet_type=sig_type,
+            sig_type=sig_type,
             script_type=self.controller.unverified_address["script_type"]
         )
 
@@ -1824,7 +1824,7 @@ class AddressVerificationSigTypeView(View):
         self.controller.unverified_address["sig_type"] = sig_type
         derivation_path = embit_utils.get_standard_derivation_path(
             network=self.controller.unverified_address["network"],
-            wallet_type=sig_type,
+            sig_type=sig_type,
             script_type=self.controller.unverified_address["script_type"]
         )
         self.controller.unverified_address["derivation_path"] = derivation_path

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -558,7 +558,7 @@ class ToolsAddressExplorerAddressTypeView(View):
                 from seedsigner.helpers import embit_utils
                 derivation_path = embit_utils.get_standard_derivation_path(
                     network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
-                    wallet_type=SettingsConstants.SINGLE_SIG,
+                    sig_type=SettingsConstants.SINGLE_SIG,
                     script_type=self.script_type,
                 )
 

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -95,6 +95,13 @@ def test_get_standard_derivation_path():
             with pytest.raises(expected):
                 func(**a_dict)
 
+def test_get_standard_derivation_path_unsupported_script_type():
+    with pytest.raises(Exception, match=f"Unsupported script type for {SC.MULTISIG}: {SC.CUSTOM_DERIVATION}"):
+        embit_utils.get_standard_derivation_path(
+                network = SC.MAINNET,
+                sig_type=SC.MULTISIG,
+                script_type=SC.CUSTOM_DERIVATION
+        )
 
 def test_get_xpub():
     """

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -74,8 +74,8 @@ def test_get_standard_derivation_path():
             # call with named params
             a_dict = {}
             if len(args) == 1: a_dict = {'network': args[0]}
-            elif len(args) == 2: a_dict = {'network': args[0], 'wallet_type': args[1]}
-            elif len(args) == 3: a_dict = {'network': args[0], 'wallet_type': args[1], 'script_type': args[2]}
+            elif len(args) == 2: a_dict = {'network': args[0], 'sig_type': args[1]}
+            elif len(args) == 3: a_dict = {'network': args[0], 'sig_type': args[1], 'script_type': args[2]}
             print(f"asserting {func.__name__}(**{a_dict}) == {repr(expected)}")
             assert func(**a_dict) == expected
 
@@ -89,8 +89,8 @@ def test_get_standard_derivation_path():
             # call with named params
             a_dict = {}
             if len(args) == 1: a_dict = {'network': args[0]}
-            elif len(args) == 2: a_dict = {'network': args[0], 'wallet_type': args[1]}
-            elif len(args) == 3: a_dict = {'network': args[0], 'wallet_type': args[1], 'script_type': args[2]}
+            elif len(args) == 2: a_dict = {'network': args[0], 'sig_type': args[1]}
+            elif len(args) == 3: a_dict = {'network': args[0], 'sig_type': args[1], 'script_type': args[2]}
             print(f"asserting {func.__name__}(**{a_dict}) raises Exception")
             with pytest.raises(expected):
                 func(**a_dict)


### PR DESCRIPTION
## Description

_The file embit_utils.py had a superflous parameterv``` wallet_type```, which was commented to be refactored to ```sig_type```, the more prominently used convention in the whole of codebase_

_This PR is an attempt to refactor every instance where  ```wallet_type``` is used to change it to ```sig_type```_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] N/A
