### PR TITLE
Add input string length and contents verification in mnemonic_generation

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -90,6 +90,14 @@ def generate_mnemonic_from_coin_flips(coin_flips: str, wordlist_language_code: s
         * binary digit stream is treated as string data.
         * hashed via SHA256.
     """
+    # Validate content (must be either 0 or 1)
+    if not all(c in "01" for c in coin_flips):
+        raise ValueError("Invalid input: coin flips must only contain '0' or '1'.")
+    
+    # Validate length (must be 128 or 256 bits)
+    if len(coin_flips) not in (128, 256):
+        raise ValueError("Coin flips must be exactly 128 or 256 bits long.")
+    
     entropy_bytes = hashlib.sha256(coin_flips.encode()).digest()
 
     if len(coin_flips) == 128:


### PR DESCRIPTION
## Description

_Describe the change simply. Provide a reason for the change._
Introduced verification of length of coin flip input string and its contents (must be 0 or 1), as suggested here:
https://github.com/SeedSigner/seedsigner/pull/619#issuecomment-2495647104

Related: #619 

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other

##Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other


