### PR TITLE
Define BIP85 Application Number Constants

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -242,7 +242,15 @@ class SettingsConstants:
     custom_extension = _mft("Custom Extension")
     LABEL__CUSTOM_EXTENSION = custom_extension
 
-
+    # BIP-85 Application Numbers
+    BIP85_APP_NUM_BIP39 = 39
+    BIP85_APP_NUM_HD_SEED_WIF = 2 
+    BIP85_APP_NUM_XPRV = 32
+    BIP85_APP_NUM_HEX = 128169   
+    BIP85_APP_NUM_PWD_BASE64 = 707764
+    BIP85_APP_NUM_PWD_BASE85 = 707785
+    BIP85_APP_NUM_RSA = 828365
+    BIP85_APP_NUM_DICE = 89101
 
 @dataclass
 class SettingsEntry:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1135,7 +1135,7 @@ class SeedBIP85ApplicationModeView(View):
         super().__init__()
         self.seed_num = seed_num
         self.num_words = 0
-        self.bip85_app_num = 39     # TODO: Support other Application numbers; TODO: Define this as a constant
+        self.bip85_app_num = SettingsConstants.BIP85_APP_NUM_BIP39     # TODO: Support other Application numbers
 
 
     def run(self):


### PR DESCRIPTION
## Description

This PR replaces hardcoded BIP85 application number values with named constants, improving code readability and maintainability. The changes address a TODO item while preparing the codebase for potential future support of additional BIP85 application types.

The constant values follow the BIP-85 specification: https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#applications


## Changes Made
- Added new constants for BIP85 application numbers in `src/seedsigner/models/settings_definition.py`:

```python
 # BIP-85 Application Numbers
    BIP85_APP_NUM_BIP39 = 39
    BIP85_APP_NUM_HD_SEED_WIF = 2 
    BIP85_APP_NUM_XPRV = 32
    BIP85_APP_NUM_HEX = 128169   
    BIP85_APP_NUM_PWD_BASE64 = 707764
    BIP85_APP_NUM_PWD_BASE85 = 707785
    BIP85_APP_NUM_RSA = 828365
    BIP85_APP_NUM_DICE = 89101
```

- Updated `SeedBIP85ApplicationModeView.__init__` in `src/seedsigner/views/seed_views.py` to use the new constant instead of hardcoded value:

```python
# Before
def __init__(self, seed_num: int):
    super().__init__()
    self.seed_num = seed_num
    self.num_words = 0
    self.bip85_app_num = 39    

# After
def __init__(self, seed_num: int):
    super().__init__()
    self.seed_num = seed_num
    self.num_words = 0
    self.bip85_app_num = SettingsConstants.BIP85_APP_BIP39 
```


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other