### PR TITLE
[Enhancement] Display 'Seed already loaded' message when seed already loaded in memory

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -333,7 +333,16 @@ class SeedFinalizeView(View):
         )
 
         if button_data[selected_menu_num] == self.FINALIZE:
+            previous_seed_count = len(self.controller.storage.seeds)
             seed_num = self.controller.storage.finalize_pending_seed()
+            if len(self.controller.storage.seeds) == previous_seed_count:
+                from seedsigner.gui.screens.screen import LoadingScreenThread
+                loading_screen = LoadingScreenThread(text=_("Seed already loaded"), show_loading_icon=False)
+                loading_screen.start()
+                try:
+                    time.sleep(3)
+                finally:
+                    loading_screen.stop()
             return Destination(SeedOptionsView, view_args={"seed_num": seed_num}, clear_history=True)
 
         elif button_data[selected_menu_num] == self.PASSPHRASE:


### PR DESCRIPTION
## Description
Fixes #585 
This PR addresses the above issue by improving the user experience when a duplicate seed is detected during finalization. Instead of automatically navigating to the `SeedOptionsView`, a message ("Seed already loaded") is displayed using `LoadingScreenThread` for 3 seconds before proceeding.

---

### Changes Made
1. **Loading Screen Implementation**:
   - Used `LoadingScreenThread` in `SeedFinalizeView` to display the "Seed already loaded" message.
   - The loading screen appears for 3 seconds without a spinner (`show_loading_icon=False`).

2. **Error Handling**:
   - Ensured that the loading screen is stopped even if an error occurs during execution using a `try-finally` block.

This pull request is categorized as a:

- [x] New feature

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

I have tested this PR on the following platforms/os:

- [x] Other


