### PR TITLE
[Feature] Warning Screen for High Tx Fees

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -25,6 +25,7 @@ class PSBTOverviewScreen(ButtonListScreen):
     num_change_outputs: int = 0
     destination_addresses: list[str] = None
     has_op_return: bool = False
+    is_high_fee_tx: bool = False
     
 
     def __post_init__(self):
@@ -308,11 +309,17 @@ class PSBTOverviewScreen(ButtonListScreen):
 
         output_curves = []
         for destination in destination_column:
+            text_color = chart_font_color
+            # if high fee, change color and add (!)
+            if destination == _("fee") and self.is_high_fee_tx:
+                text_color = GUIConstants.DIRE_WARNING_COLOR
+                destination += " (!)"
+
             draw.text(
                 (recipients_text_x, destination_y),
                 text=destination,
                 font=font,
-                fill=chart_font_color,
+                fill=text_color,
                 anchor="lt"
             )
 
@@ -471,6 +478,7 @@ class PSBTMathScreen(ButtonListScreen):
     num_recipients: int = 0
     fee_amount: int = 0
     change_amount: int = 0
+    is_high_fee_tx: bool = False
 
 
     def __post_init__(self):
@@ -569,10 +577,18 @@ class PSBTMathScreen(ButtonListScreen):
             )
 
         cur_y += digits_height + GUIConstants.BODY_LINE_SPACING * ssf
+
+        info_text=_("fee")
+        info_text_color=GUIConstants.BODY_FONT_COLOR
+        # if high fee, change color and add (!)
+        if self.is_high_fee_tx:
+            info_text += " (!)"
+            info_text_color = GUIConstants.DIRE_WARNING_COLOR
         render_amount(
             cur_y,
             f"-{self.fee_amount}",
-            info_text=_("fee"),
+            info_text=info_text,
+            info_text_color=info_text_color,
         )
 
         cur_y += digits_height + GUIConstants.BODY_LINE_SPACING * ssf

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -141,6 +141,9 @@ class PSBTParser():
 
         self.root = None
 
+        # TODO: Possibly make this configurable via settings
+        self.HIGH_FEES_WARNING_THRESHOLD = 25  # in percent
+
         if self.seed is not None:
             self.parse()
 
@@ -828,3 +831,45 @@ class PSBTParser():
 
         for out in self.psbt.outputs:
             _fill_scope(out)
+
+
+    def get_total_output_value(self, include_change: bool = False):
+        """
+            Returns the sum of all outputs (fee not included).
+            
+            If `include_change=True`, all outputs are included.
+            If `False`, subtracts *true* change outputs (from derivation path with chain index 1),
+            but keeps self-transfer amounts (from chain index 0) included in the total.
+            
+            This is used to to calculate whether the fee is relatively high
+            and show a warning screen if it is.
+        """
+        total = sum(out.value for out in self.psbt.tx.vout)
+
+        if include_change:
+            return total
+
+        # Subtract only *true* change (chain index == 1)
+        # In both single- and multi-sig, all derivation paths in an entry share the same chain index,
+        # so checking the first path is sufficient.
+        true_change = sum(
+            entry["amount"]
+            for entry in self.change_data
+            if int(entry["claimed_derivation_paths"][0].split("/")[-2]) == 1
+        )
+        return total - true_change
+
+
+    def has_high_fee(self):
+        """
+            Returns True if the fee is high.
+            i.e. fee amount > <HIGH_FEES_WARNING_THRESHOLD>% of total outputs excluding change
+        """
+        total_output_value_excluding_change = self.get_total_output_value()
+
+        # If there are no outputs other than change, then it can't be a high fee
+        if total_output_value_excluding_change <= 0:
+            return False
+
+        else:
+            return self.fee_amount > ((self.HIGH_FEES_WARNING_THRESHOLD / 100) * total_output_value_excluding_change)

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -148,6 +148,8 @@ class PSBTOverviewView(View):
             else:
                 num_self_transfer_outputs += 1
 
+        is_high_fee_tx = psbt_parser.has_high_fee()
+
         # Run the overview screen
         selected_menu_num = self.run_screen(
             PSBTOverviewScreen,
@@ -169,6 +171,9 @@ class PSBTOverviewView(View):
         # skip change warning and psbt math view
         if psbt_parser.policy == None:
             return Destination(PSBTUnsupportedScriptTypeWarningView)
+
+        elif is_high_fee_tx:
+            return Destination(PSBTHighFeeWarningView, view_args={"warning_threshold_percent": psbt_parser.HIGH_FEES_WARNING_THRESHOLD})
         
         elif psbt_parser.change_amount == 0:
             return Destination(PSBTNoChangeWarningView)
@@ -217,6 +222,39 @@ class PSBTNoChangeWarningView(View):
             PSBTMathView,
             skip_current_view=True,  # Prevent going BACK to WarningViews
         )
+
+
+
+class PSBTHighFeeWarningView(View):
+    def __init__(self, warning_threshold_percent: int):
+        super().__init__()
+        
+        self.warning_threshold_percent = warning_threshold_percent
+    
+    def run(self):
+        selected_menu_num = self.run_screen(
+            DireWarningScreen,
+            status_headline=_("High Fee!"),
+            # TRANSLATOR_NOTE: Variable is the percentage of the total output value (excluding change) that the fee exceeds. (e.g. "This transaction has a fee higher than 25% of the total output value (excluding change).")
+            text=_("This transaction has a fee higher than {}% of the total output value (excluding change).").format(self.warning_threshold_percent),
+            button_data=[ButtonOption("Continue")],
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        # PSBT may have high fee + no change
+        if self.controller.psbt_parser.change_amount == 0:
+            return Destination(
+                PSBTNoChangeWarningView,
+                skip_current_view=True,  # Prevent going BACK to WarningViews
+            )
+
+        else:
+            return Destination(
+                PSBTMathView,
+                skip_current_view=True,  # Prevent going BACK to WarningViews
+            )
 
 
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -161,6 +161,7 @@ class PSBTOverviewView(View):
             num_change_outputs=num_change_outputs,
             destination_addresses=psbt_parser.destination_addresses,
             has_op_return=psbt_parser.op_return_data is not None,
+            is_high_fee_tx=is_high_fee_tx,
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
@@ -282,6 +283,7 @@ class PSBTMathView(View):
             num_recipients=psbt_parser.num_destinations,
             fee_amount=psbt_parser.fee_amount,
             change_amount=psbt_parser.change_amount,
+            is_high_fee_tx=psbt_parser.has_high_fee(),
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -439,6 +439,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(psbt_views.PSBTOverviewView,   mock_context_manager=mock_multisig_psbt_loaded),
                 ScreenshotConfig(psbt_views.PSBTUnsupportedScriptTypeWarningView),
                 ScreenshotConfig(psbt_views.PSBTNoChangeWarningView),
+                ScreenshotConfig(psbt_views.PSBTHighFeeWarningView, dict(warning_threshold_percent=25)),
                 ScreenshotConfig(psbt_views.PSBTMathView, mock_context_manager=mock_multisig_psbt_loaded),
                 ScreenshotConfig(psbt_views.PSBTAddressDetailsView, dict(address_num=0), mock_context_manager=mock_multisig_psbt_loaded),
 

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -3,6 +3,7 @@ import random
 
 from binascii import a2b_base64
 from copy import deepcopy
+from types import SimpleNamespace
 from unittest.mock import patch
 from embit import bip32, script
 from embit.ec import PublicKey
@@ -57,7 +58,11 @@ class TestPSBTParser:
             assert psbt_parser.change_amount == input_amount - recipient_amount - fee_amount
             assert psbt_parser.fee_amount == fee_amount
             assert psbt_parser.input_amount == psbt_parser.spend_amount + psbt_parser.change_amount + psbt_parser.fee_amount
-        
+
+            # No self-transfer here, so all change is true change
+            assert psbt_parser.get_total_output_value() == psbt_parser.spend_amount
+            assert psbt_parser.get_total_output_value(include_change=True) == psbt_parser.spend_amount + psbt_parser.change_amount
+
         # Internally cycle the input(s) back to sender via the `self_transfer_data`
         psbt.outputs.clear()
         psbt.outputs.append(create_output(self_transfer_data, input_amount - fee_amount))
@@ -72,6 +77,11 @@ class TestPSBTParser:
         assert psbt_parser.change_amount == input_amount - fee_amount  # PSBTParser considers self-transfers == change
         assert psbt_parser.fee_amount == fee_amount
         assert psbt_parser.input_amount == psbt_parser.spend_amount + psbt_parser.change_amount + psbt_parser.fee_amount
+
+        # Only self-transfer, and no "true" change, so `change_amount` is included in total output
+        # Both calls should return the same value
+        assert psbt_parser.get_total_output_value() == psbt_parser.spend_amount + psbt_parser.change_amount
+        assert psbt_parser.get_total_output_value(include_change=True) == psbt_parser.spend_amount + psbt_parser.change_amount
 
         # Now do full spends with no change
         fee_amount = random.randint(5_000, 100_000)
@@ -91,6 +101,10 @@ class TestPSBTParser:
             assert psbt_parser.change_amount == 0
             assert psbt_parser.fee_amount == fee_amount
             assert psbt_parser.input_amount == psbt_parser.spend_amount + psbt_parser.change_amount + psbt_parser.fee_amount
+
+            # No self-transfer here, so all change is true change
+            assert psbt_parser.get_total_output_value() == psbt_parser.spend_amount
+            assert psbt_parser.get_total_output_value(include_change=True) == psbt_parser.spend_amount + psbt_parser.change_amount
 
         # Now try a single mega psbt with ALL the outputs at once
         psbt.outputs.clear()
@@ -113,6 +127,10 @@ class TestPSBTParser:
         assert psbt_parser.change_amount == change_amount
         assert psbt_parser.fee_amount == fee_amount
         assert psbt_parser.input_amount == psbt_parser.spend_amount + psbt_parser.change_amount + psbt_parser.fee_amount
+
+        # No self-transfer here, so all change is true change
+        assert psbt_parser.get_total_output_value() == psbt_parser.spend_amount
+        assert psbt_parser.get_total_output_value(include_change=True) == psbt_parser.spend_amount + psbt_parser.change_amount
 
 
     def test_singlesig_native_segwit(self):
@@ -336,6 +354,85 @@ class TestPSBTParser:
                 else:
                     assert psbt_parser.verify_multisig_output(descriptor, change_num=0) == False
                     assert psbt_parser.verify_multisig_output(descriptor, change_num=1) == False
+
+
+    @pytest.mark.parametrize("vout_values, change_data, expected", [
+        # single destination + single change
+        ([100, 200], [{"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 200}], 100),
+        # multiple destinations + single change
+        ([50, 75, 25], [{"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 25}], 50 + 75),
+        # no change outputs at all
+        ([10, 20, 30], [], 10 + 20 + 30),
+        # only change outputs
+        ([123], [{"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 123}], 0),
+        # mix of true change and self-transfer
+        (
+            [100, 200, 300], 
+            [
+                {"claimed_derivation_paths": ["m/84h/0h/0h/0/0"], "amount": 200},  # self-transfer
+                {"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 300},  # true change
+            ], 
+            100 + 200  # Only subtract true change (300)
+        ),
+    ])
+    def test_get_total_output_value(self, vout_values, change_data, expected):
+        """
+            get_total_output_value() should return
+            sum(vout_values) - sum(true_change),
+            where true change is determined by derivation path having chain index 1.
+        """
+        # Build a dummy parser without running .parse()
+        parser = PSBTParser.__new__(PSBTParser)
+
+        # Stub out parser.psbt.tx.vout as list of objects with a .value attribute
+        parser.psbt = SimpleNamespace(
+            tx=SimpleNamespace(
+                vout=[SimpleNamespace(value=v) for v in vout_values]
+            )
+        )
+        parser.change_data = change_data
+
+        assert parser.get_total_output_value() == expected
+
+
+    @pytest.mark.parametrize("vin, vout_values, change_data, expected", [
+        # fee=30 (24%) -> NOT high
+        (180, [50, 75, 25], [{"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 25}], False),
+        # fee=40 (32%) -> HIGH
+        (190, [50, 75, 25], [{"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 25}], True),
+        # fee=15 (exactly 25%) -> NOT high
+        (75, [10, 20, 30], [], False),
+        # only change outputs: excluding change=0 -> never high by definition
+        (130, [123], [{"claimed_derivation_paths": ["m/84h/0h/0h/1/5"], "amount": 123}], False),
+        # fee=60 (20%) -> NOT high
+        (660, [100, 200, 300], [
+            {"claimed_derivation_paths": ["m/84h/0h/0h/0/0"], "amount": 200},  # self-transfer
+            {"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 300},  # true change
+        ], False),
+        # same mix but high fee: fee=100 (33%) -> HIGH
+        (700, [100, 200, 300], [
+            {"claimed_derivation_paths": ["m/84h/0h/0h/0/0"], "amount": 200},
+            {"claimed_derivation_paths": ["m/84h/0h/0h/1/0"], "amount": 300},
+        ], True),
+    ])
+    def test_has_high_fee(self, vin, vout_values, change_data, expected):
+        """
+            Should correctly identify if a PSBT has a high fee.
+        """
+        # Build a dummy parser without running .parse()
+        parser = PSBTParser.__new__(PSBTParser)
+        parser.HIGH_FEES_WARNING_THRESHOLD = 25
+
+        # Stub out parser.psbt.tx.vout as list of objects with a .value attribute
+        parser.psbt = SimpleNamespace(
+            tx=SimpleNamespace(
+                vout=[SimpleNamespace(value=v) for v in vout_values]
+            )
+        )
+        parser.change_data = change_data
+        parser.fee_amount = vin - sum(vout_values)
+
+        assert parser.has_high_fee() is expected
 
 
 


### PR DESCRIPTION
## Description

This PR introduces a warning screen that appears before the PSBT math screen if the transaction includes unusually high fees. The goal is to ensure the user is explicitly made aware of any excessive fees before proceeding to sign the transaction.

Closes #721

## Warning Condition
The warning is shown when:
- The fee amount exceeds 25% of the sum of all outputs excluding change, and
- There are outputs other than _true_ change (and fee).

## New Warning Screen:

<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/597d624d-e58f-4d47-b862-c67027a28f9c" />

## Visual Warning in PSBT Flow Views

<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/e808aa61-3007-41e8-b435-c4fdee3ea299" /> <img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/d142b391-c77a-4c23-a969-9fcac0ace075" />

---

This pull request is categorized as a:

- [x] New feature

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] Yes

The warning screen doesn’t currently apply to any of the existing test PSBT flows. I also noticed there aren’t tests for similar warnings (e.g. Full Spend), so figured it's not needed here either. Do let me know if a test needs to be added!

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
