### PR TITLE
[Fix] seed pagination logic in SeedWordsView

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1075,11 +1075,18 @@ class SeedWordsView(View):
         else:
             mnemonic = self.seed.mnemonic_display_list
             title = _("Seed Words")
-        words = mnemonic[self.page_index*words_per_page:(self.page_index + 1)*words_per_page]
+        
+        num_pages = (len(mnemonic)+words_per_page-1)//words_per_page
+        
+        if self.page_index >= num_pages:
+            self.page_index = num_pages - 1
+            
+        start_index = self.page_index*words_per_page
+        end_index = min(start_index+words_per_page,len(mnemonic))
+        words = mnemonic[start_index:end_index]
 
         button_data = []
-        num_pages = int(len(mnemonic)/words_per_page)
-        if self.page_index < num_pages - 1 or self.seed_num is None:
+        if self.page_index < num_pages - 1:
             button_data.append(self.NEXT)
         else:
             button_data.append(self.DONE)
@@ -1095,20 +1102,15 @@ class SeedWordsView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        if button_data[selected_menu_num] == self.NEXT:
-            if self.seed_num is None and self.page_index == num_pages - 1:
-                return Destination(
-                    SeedWordsBackupTestPromptView,
-                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
-                )
-            else:
-                return Destination(
-                    SeedWordsView,
-                    view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data)
-                )
-
-        elif button_data[selected_menu_num] == self.DONE:
-            # Must clear history to avoid BACK button returning to private info
+        selected_button = button_data[selected_menu_num]
+        if selected_button == self.NEXT:
+            #only increment page if we're not already at the last page
+            next_page = min(self.page_index + 1, num_pages - 1)
+            return Destination(
+                SeedWordsView,
+                view_args=dict(seed_num=self.seed_num, page_index=next_page, bip85_data=self.bip85_data)
+            )
+        elif selected_button == self.DONE:
             return Destination(
                 SeedWordsBackupTestPromptView,
                 view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),


### PR DESCRIPTION
## Description

Fixed a pagination bug in the SeedWordsView class that allowed users to navigate beyond the valid number of seed word pages. This caused the UI to display incorrect page numbers like "Seed Words: 4/3" when viewing 12-word seeds (which should only have 3 pages).

## Issue Demo
[Go_beyond.webm](https://github.com/user-attachments/assets/5fa482c3-13cf-4f6a-b791-0a3a88c0762b)

## After Fix
[go_beyond_fix.webm](https://github.com/user-attachments/assets/8a306a0d-fca4-4f5e-8034-72245db0bdc8)

This pull request is categorized as a:

- [x] Bug fix

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] Not required, UI Fix
I have tested this PR on the following platforms/os:

- [x] [Seedsigner-Emulator](https://github.com/enteropositivo/seedsigner-emulator)


