### PR TITLE
Refactor screensaver splash logic

### DIFF
--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -119,14 +119,14 @@ class ScanScreen(BaseScreen):
                     scan_text = None
                     progress_percentage = self.decoder.get_percent_complete()
                     if progress_percentage == 0:
-                        # We've just started scanning, no results yet
+                        # No progress yet, show the instructions text
                         if show_framerate:
                             scan_text = f"{cur_fps:0.2f} | {self.decoder_fps}"
                         else:
                             scan_text = self.instructions_text
 
                     elif debug:
-                        # Special debugging output for animated QRs
+                        # Debugging mode, show the current FPS and decoder FPS
                         scan_text = f"{self.decoder.get_percent_complete()}% | {self.decoder.get_percent_complete(weight_mixed_frames=True)}% (new)"
                         if show_framerate:
                             scan_text += f" {cur_fps:0.2f} | {self.decoder_fps}"
@@ -139,38 +139,23 @@ class ScanScreen(BaseScreen):
                             )
 
                         if scan_text:
-                            # Note: shadowed text (adding a 'stroke' outline) can
-                            # significantly slow down the rendering.
-                            # Temp solution: render a slight 1px shadow behind the text
-                            # TODO: Replace the instructions_text with a disappearing
-                            # toast/popup (see: QR Brightness UI)?
-                            draw = ImageDraw.Draw(frame)
-                            draw.text(xy=(
-                                        int(self.renderer.canvas_width/2 + 2),
-                                        self.renderer.canvas_height - GUIConstants.EDGE_PADDING + 2
-                                     ),
-                                     text=scan_text,
-                                     fill="black",
-                                     font=instructions_font,
-                                     anchor="ms")
-
-                            # Render the onscreen instructions
-                            draw.text(xy=(
-                                        int(self.renderer.canvas_width/2),
-                                        self.renderer.canvas_height - GUIConstants.EDGE_PADDING
-                                     ),
-                                     text=scan_text,
-                                     fill=GUIConstants.BODY_FONT_COLOR,
-                                     font=instructions_font,
-                                     anchor="ms")
+                            
+                            screen = ScanScreen  # Use the class itself to access the static method
+                            screen_instance = screen.__new__(screen)
+                            screen_instance.renderer = self.renderer
+                            screen_instance.render_bottom_instruction_text(
+                                draw=ImageDraw.Draw(frame),
+                                text=scan_text
+                            )
 
                         else:
-                            # Render the progress bar
+                            # Draw the instructions text
+                            # TRANSLATOR_NOTE: Inserts the animated QR scan instructions
                             rectangle = Image.new('RGBA', (self.renderer.canvas_width - 2*GUIConstants.EDGE_PADDING, GUIConstants.BUTTON_HEIGHT), (0, 0, 0, 0))
                             draw = ImageDraw.Draw(rectangle)
 
-                            # Start with a background rounded rectangle, same dims as the buttons
-                            overlay_color = (0, 0, 0, 191)  # opacity ranges from 0-255
+                            # 
+                            overlay_color = (0, 0, 0, 191)  
                             draw.rounded_rectangle(
                                 (
                                     (0, 0),

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -132,6 +132,48 @@ class BaseScreen(BaseComponent):
         """
         raise Exception("Must implement in a child class")
 
+    def render_bottom_instruction_text(self, draw, text, font=None, fill_color=GUIConstants.BODY_FONT_COLOR, stroke_width=4, stroke_fill=GUIConstants.BACKGROUND_COLOR):
+        """
+        Renders standardized instruction text at the bottom of the screen.
+        
+        Args:
+            draw: ImageDraw object to render on
+            text: Text to display
+            font: Font to use (defaults to button font)
+            fill_color: Color of the text
+            stroke_width: Width of the text outline/shadow
+            stroke_fill: Color of the text outline/shadow
+        """
+        if font is None:
+            font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_button_font_size())
+            
+        # First render shadow/outline if stroke_width > 0
+        if stroke_width > 0:
+            draw.text(
+                xy=(
+                    int(self.renderer.canvas_width/2),
+                    self.renderer.canvas_height - GUIConstants.EDGE_PADDING
+                ),
+                text=text,
+                fill=stroke_fill,
+                font=font,
+                stroke_width=stroke_width,
+                stroke_fill=stroke_fill,
+                anchor="ms"
+            )
+        
+        # Then render the actual text
+        draw.text(
+            xy=(
+                int(self.renderer.canvas_width/2),
+                self.renderer.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            text=text,
+            fill=fill_color,
+            font=font,
+            anchor="ms"
+        )
+
 
 
 class LoadingScreenThread(BaseThread):

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -88,7 +88,7 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
 
             if len(preview_images) == max_entropy_frames:
                 # Keep a moving window of the last n preview frames; pop the oldest
-                # before we add the currest frame.
+                # before we add the current frame.
                 preview_images.pop(0)
             preview_images.append(frame)
 
@@ -109,17 +109,12 @@ class ToolsImageEntropyFinalImageScreen(BaseScreen):
 
             # TRANSLATOR_NOTE: A prompt to the user to either accept or reshoot the image
             accept = _("accept")
-            self.renderer.draw.text(
-                xy=(
-                    int(self.renderer.canvas_width/2),
-                    self.renderer.canvas_height - GUIConstants.EDGE_PADDING
-                ),
-                text=" < " + reshoot + "  |  " + accept + " > ",
-                fill=GUIConstants.BODY_FONT_COLOR,
-                font=instructions_font,
-                stroke_width=4,
-                stroke_fill=GUIConstants.BACKGROUND_COLOR,
-                anchor="ms"
+            
+            instruction_text = " < " + reshoot + "  |  " + accept + " > "
+            self.render_bottom_instruction_text(
+                draw=self.renderer.draw,
+                text=instruction_text,
+                font=instructions_font
             )
             self.renderer.show_image()
 

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -15,30 +15,60 @@ from seedsigner.views.view import View
 logger = logging.getLogger(__name__)
 
 
-
-# TODO: This early code is now outdated vis-a-vis Screen vs View distinctions
-class LogoScreen(BaseScreen):
+class BaseLogoScreen(BaseScreen):
     def __init__(self):
         super().__init__()
         self.logo = load_image("logo_black_240.png")
+        self.load_partner_logos()
 
-        self.partners = [
-            "hrf",
-        ]
-
-        self.partner_logos: dict = {}
+    def load_partner_logos(self):
+        self.partners = ["hrf"]
+        self.partner_logos = {}
         for partner in self.partners:
             logo_url = os.path.join("partners", f"{partner}_logo.png")
             self.partner_logos[partner] = load_image(logo_url)
 
-
-    def _run(self):
-        pass
-
-
     def get_random_partner(self) -> str:
         return self.partners[random.randrange(len(self.partners))]
-
+    
+    def animate_fade_in(self, image, offset_y=0, skip_animation=False):
+        from PIL import Image
+        background = Image.new("RGBA", size=image.size, color="black")
+        if not skip_animation:
+            for i in range(250, -1, -25):
+                image.putalpha(255 - i)
+                self.renderer.canvas.paste(Image.alpha_composite(background, image), (0, offset_y))
+                self.renderer.show_image()
+        else:
+            self.renderer.canvas.paste(image, (0, offset_y))
+    
+    def display_version(self, version, offset_y=0):
+        font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_top_nav_title_font_size())
+        logo_height = 70
+        version_x = int(self.renderer.canvas_width/2)
+        version_y = int(self.canvas_height/2) + int(logo_height/2) + offset_y + GUIConstants.COMPONENT_PADDING
+        self.renderer.draw.text(xy=(version_x, version_y), text=version, font=font, fill=GUIConstants.ACCENT_COLOR, anchor="mt")
+    
+    def display_partner_logo(self, partner=None, skip_animation=False):
+        if not partner:
+            partner = self.get_random_partner()
+        partner_logo = self.partner_logos[partner]
+        font = Fonts.get_font(GUIConstants.get_top_nav_title_font_name(), GUIConstants.get_body_font_size())
+        sponsor_text = _("With support from:")
+        (left, top, tw, th) = font.getbbox(sponsor_text, anchor="lt")
+        
+        x = int((self.renderer.canvas_width) / 2)
+        y = self.canvas_height - GUIConstants.COMPONENT_PADDING - partner_logo.height - int(GUIConstants.COMPONENT_PADDING/2) - th
+        self.renderer.draw.text(xy=(x, y), text=sponsor_text, font=font, fill="#ccc", anchor="mt")
+        self.renderer.canvas.paste(
+            partner_logo,
+            (
+                int((self.renderer.canvas_width - partner_logo.width) / 2),
+                y + th + int(GUIConstants.COMPONENT_PADDING/2)
+            )
+        )
+        if not skip_animation:
+            self.renderer.show_image()
 
 
 @dataclass
@@ -54,87 +84,36 @@ class OpeningSplashView(View):
         )
 
 
-
-class OpeningSplashScreen(LogoScreen):
+class OpeningSplashScreen(BaseLogoScreen):
     def __init__(self, is_screenshot_renderer=False, force_partner_logos=None):
         self.is_screenshot_renderer = is_screenshot_renderer
         self.force_partner_logos = force_partner_logos
         super().__init__()
-
-
+    
     def _render(self):
-        from PIL import Image
         from seedsigner.controller import Controller
         controller = Controller.get_instance()
-
-        # TODO: Fix for the screenshot generator. When generating screenshots for
-        # multiple locales, there is a button still in the canvas from the previous
-        # screenshot, even though the Renderer has been reconfigured and re-
-        # instantiated. This is a hack to clear the screen for now.
         self.clear_screen()
 
         show_partner_logos = Settings.get_instance().get_value(SettingsConstants.SETTING__PARTNER_LOGOS) == SettingsConstants.OPTION__ENABLED
         if self.force_partner_logos is not None:
             show_partner_logos = self.force_partner_logos
 
-        if show_partner_logos:
-            logo_offset_y = -56
-        else:
-            logo_offset_y = 0
+        logo_offset_y = -56 if show_partner_logos else 0
 
-        background = Image.new("RGBA", size=self.logo.size, color="black")
-        if not self.is_screenshot_renderer:
-            # Fade in alpha
-            for i in range(250, -1, -25):
-                self.logo.putalpha(255 - i)
-                self.renderer.canvas.paste(Image.alpha_composite(background, self.logo), (0, logo_offset_y))
-                self.renderer.show_image()
-        else:
-            # Skip animation for the screenshot generator
-            self.renderer.canvas.paste(self.logo, (0, logo_offset_y))
-
-        # Display version num below SeedSigner logo
-        font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_top_nav_title_font_size())
+        self.animate_fade_in(self.logo, logo_offset_y, skip_animation=self.is_screenshot_renderer)
         version = f"v{controller.VERSION}"
-
-        # The logo png is 240x240, but the actual logo is 70px tall, vertically centered
-        logo_height = 70
-        version_x = int(self.renderer.canvas_width/2)
-        version_y = int(self.canvas_height/2) + int(logo_height/2) + logo_offset_y + GUIConstants.COMPONENT_PADDING
-        self.renderer.draw.text(xy=(version_x, version_y), text=version, font=font, fill=GUIConstants.ACCENT_COLOR, anchor="mt")
-
+        self.display_version(version, logo_offset_y)
         if not self.is_screenshot_renderer:
             self.renderer.show_image()
 
         if show_partner_logos:
             if not self.is_screenshot_renderer:
-                # Hold on the version num for a moment
                 time.sleep(1)
-
-            # Set up the partner logo
-            partner_logo: Image.Image = self.partner_logos[self.get_random_partner()]
-            font = Fonts.get_font(GUIConstants.get_top_nav_title_font_name(), GUIConstants.get_body_font_size())
-            # TRANSLATOR_NOTE: This is on the opening splash screen, displayed above the HRF logo
-            sponsor_text = _("With support from:")
-            (left, top, tw, th) = font.getbbox(sponsor_text, anchor="lt")
-
-            x = int((self.renderer.canvas_width) / 2)
-            y = self.canvas_height - GUIConstants.COMPONENT_PADDING - partner_logo.height - int(GUIConstants.COMPONENT_PADDING/2) - th
-            self.renderer.draw.text(xy=(x, y), text=sponsor_text, font=font, fill="#ccc", anchor="mt")
-            self.renderer.canvas.paste(
-                partner_logo,
-                (
-                    int((self.renderer.canvas_width - partner_logo.width) / 2),
-                    y + th + int(GUIConstants.COMPONENT_PADDING/2)
-                )
-            )
-
-            self.renderer.show_image()
+            self.display_partner_logo(skip_animation=self.is_screenshot_renderer)
 
         if not self.is_screenshot_renderer:
-            # Hold on the splash screen for a moment
             time.sleep(2)
-
 
 
 @dataclass
@@ -144,7 +123,6 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
 
         self.camera = Camera.get_instance()
         self.camera.start_video_stream_mode(resolution=(self.canvas_width, self.canvas_height), framerate=24, format="rgb")
-
 
     def _run(self):
         # save preview image frames to use as additional entropy below
@@ -156,7 +134,6 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
             if self.hw_inputs.check_for_low(HardwareButtonsConstants.KEY_LEFT):
                 # Have to manually update last input time since we're not in a wait_for loop
                 self.hw_inputs.update_last_input_time()
-                self.words = []
                 self.camera.stop_video_stream_mode()
                 return RET_CODE__BACK_BUTTON
 
@@ -206,14 +183,12 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
             preview_images.append(frame)
 
 
-class ScreensaverScreen(LogoScreen):
+class ScreensaverScreen(BaseLogoScreen):
     def __init__(self, buttons):
         from PIL import Image
         super().__init__()
 
         self.buttons = buttons
-
-        # Paste the logo in a bigger image that is 2x the size of the logo
         self.image = Image.new("RGB", (2 * self.logo.size[0], 2 * self.logo.size[1]), (0,0,0))
         self.image.paste(self.logo, (int(self.logo.size[0] / 2), int(self.logo.size[1] / 2)))
 
@@ -224,16 +199,13 @@ class ScreensaverScreen(LogoScreen):
         self.increment_y = self.rand_increment()
         self.cur_x = int(self.logo.size[0] / 2)
         self.cur_y = int(self.logo.size[1] / 2)
-
         self._is_running = False
         self.last_screen = None
-
 
     @property
     def is_running(self):
         return self._is_running
     
-
     def rand_increment(self):
         max_increment = 10.0
         min_increment = 1.0
@@ -242,27 +214,21 @@ class ScreensaverScreen(LogoScreen):
             return -1.0 * increment
         return increment
 
-
     def start(self):
         if self.is_running:
             return
-
         self._is_running = True
 
-        # Store the current screen in order to restore it later
         self.last_screen = self.renderer.canvas.copy()
 
         screensaver_start = int(time.time() * 1000)
 
-        # Screensaver must block any attempts to use the Renderer in another thread so it
-        # never gives up the lock until it returns.
         with self.renderer.lock:
             try:
                 while self._is_running:
                     if self.buttons.has_any_input() or self.buttons.override_ind:
                         break
 
-                    # Must crop the image to the exact display size
                     crop = self.image.crop((
                         self.cur_x, self.cur_y,
                         self.cur_x + self.renderer.canvas_width, self.cur_y + self.renderer.canvas_height))
@@ -271,7 +237,6 @@ class ScreensaverScreen(LogoScreen):
                     self.cur_x += self.increment_x
                     self.cur_y += self.increment_y
 
-                    # At each edge bump, calculate a new random rate of change for that axis
                     if self.cur_x < self.min_coords[0]:
                         self.cur_x = self.min_coords[0]
                         self.increment_x = self.rand_increment()
@@ -295,21 +260,11 @@ class ScreensaverScreen(LogoScreen):
                             self.increment_y *= -1.0
 
             except KeyboardInterrupt as e:
-                # Exit triggered; close gracefully
                 logger.info("Shutting down Screensaver")
-
-                # Have to let the interrupt bubble up to exit the main app
                 raise e
-
             finally:
                 self._is_running = False
-
-                # Restore the original screen
                 self.renderer.show_image(self.last_screen)
-
-
 
     def stop(self):
         self._is_running = False
-
-

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -137,6 +137,75 @@ class OpeningSplashScreen(LogoScreen):
 
 
 
+@dataclass
+class ToolsImageEntropyLivePreviewScreen(BaseScreen):
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.camera = Camera.get_instance()
+        self.camera.start_video_stream_mode(resolution=(self.canvas_width, self.canvas_height), framerate=24, format="rgb")
+
+
+    def _run(self):
+        # save preview image frames to use as additional entropy below
+        preview_images = []
+        max_entropy_frames = 50
+        instructions_font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_button_font_size())
+
+        while True:
+            if self.hw_inputs.check_for_low(HardwareButtonsConstants.KEY_LEFT):
+                # Have to manually update last input time since we're not in a wait_for loop
+                self.hw_inputs.update_last_input_time()
+                self.words = []
+                self.camera.stop_video_stream_mode()
+                return RET_CODE__BACK_BUTTON
+
+            frame = self.camera.read_video_stream(as_image=True)
+
+            if frame is None:
+                # Camera probably isn't ready yet
+                time.sleep(0.01)
+                continue
+
+            # Check for ANYCLICK to take final entropy image
+            if self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
+                # Have to manually update last input time since we're not in a wait_for loop
+                self.hw_inputs.update_last_input_time()
+                self.camera.stop_video_stream_mode()
+
+                with self.renderer.lock:
+                    self.renderer.canvas.paste(frame)
+
+                    self.render_bottom_instruction_text(
+                        draw=self.renderer.draw,
+                        text=_("Capturing image..."),
+                        fill_color=GUIConstants.ACCENT_COLOR,
+                        font=instructions_font
+                    )
+                    self.renderer.show_image()
+
+                return preview_images
+
+            # If we're still here, it's just another preview frame loop
+            with self.renderer.lock:
+                self.renderer.canvas.paste(frame)
+
+                # Use the standardized helper method instead of manual text rendering
+                instruction_text = "< " + _("back") + "  |  " + _("click a button")  # TODO: Render with UI elements instead of text
+                self.render_bottom_instruction_text(
+                    draw=self.renderer.draw,
+                    text=instruction_text,
+                    font=instructions_font
+                )
+                self.renderer.show_image()
+
+            if len(preview_images) == max_entropy_frames:
+                # Keep a moving window of the last n preview frames; pop the oldest
+                # before we add the current frame.
+                preview_images.pop(0)
+            preview_images.append(frame)
+
+
 class ScreensaverScreen(LogoScreen):
     def __init__(self, buttons):
         from PIL import Image


### PR DESCRIPTION
This PR refactors the splash screen and screensaver code to improve readability, maintainability, and code reuse. Core functionality remains unchanged.

## Key improvements:

- Introduced a `BaseLogoScreen` class to centralize shared logo and partner logo logic.
- Extracted repeated logic into modular methods like `animate_fade_in()`, `display_version()`, and `display_partner_logo()`.
- Simplified `OpeningSplashScreen` and `ScreensaverScreen` by reducing duplication.


## This pull request is categorized as a:

- [x] Code refactor

## Checklist

- [x] I’ve run pytest and made sure all unit tests pass before submitting the PR.


I have tested this PR on the following platforms/os:


[SeedSigner Emulator](https://github.com/enteropositivo/seedsigner-emulator) 
