### PR TITLE
Refactor LogoScreen: Add docstring, rename variable, and add state flag

### DIFF
--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -19,8 +19,10 @@ logger = logging.getLogger(__name__)
 # TODO: This early code is now outdated vis-a-vis Screen vs View distinctions
 class LogoScreen(BaseScreen):
     def __init__(self):
+        """Initialize the logo display screen with the SeedSigner logo image path, partner logos, and active state."""
         super().__init__()
-        self.logo = load_image("logo_black_240.png")
+        self.image_path = load_image("logo_black_240.png")  # Renamed for consistency
+        self.is_active = False                             # Added state flag for UI pattern
 
         self.partners = [
             "hrf",


### PR DESCRIPTION
## Description

Refactored LogoScreen by:
- Adding a docstring for clarity.
- Renaming 'logo' to 'image_path' for consistency with other views.
- Adding 'is_active' flag to improve maintainability and align with UI patterns.

Reason: Improves code structure and documentation as part of the Code Cleanup for Loading Screens project, making it easier to maintain and extend (e.g., for future state-based logic).

Screenshots omitted: Changes are code-level (docstring, variable rename, state flag) with no UI impact. Full runtime testing failed due to missing 'spidev' (Raspberry Pi dependency) and import resolution issues (ModuleNotFoundError: seedsigner) on Windows, preventing screen rendering.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other: Windows (syntax tested with python -m py_compile; runtime limited due to spidev and import issues)


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.

I plan to follow up with Step 2, refactoring OpeningSplashScreen and ScreensaverScreen to use the new image_path and is_active attributes, addressing inheritance impacts. Please let me know if this aligns with the priorities or if other changes are preferred!
