### PR TITLE
[IMP] Disable screensaver during SeedQR transcription

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -480,4 +480,4 @@ class Controller(Singleton):
         from seedsigner.views import MainMenuView
         # Confusingly, the top item in the `BackStack` is actually the *current* View
         active_view = self.back_stack[-1].view if self.back_stack else MainMenuView()
-        return not self.is_screensaver_running and active_view.allow_screensaver
+        return not self.is_screensaver_running and active_view.is_screensaver_allowed

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -1,7 +1,6 @@
 import logging
 import time
 import traceback
-from typing import Optional
 
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
@@ -471,3 +470,7 @@ class Controller(Singleton):
     @property
     def active_view(self) -> Optional[View]:
         return self.back_stack[-1].view if self.back_stack else None
+    def active_view(self) -> View:
+        from seedsigner.views import MainMenuView
+        return self.back_stack[-1].view if self.back_stack else MainMenuView()
+

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import traceback
+from typing import Optional
 
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
@@ -14,7 +15,7 @@ from seedsigner.models.settings import Settings
 from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
 from seedsigner.views.screensaver import ScreensaverScreen
-from seedsigner.views.view import Destination
+from seedsigner.views.view import Destination, View
 
 
 logger = logging.getLogger(__name__)
@@ -466,3 +467,7 @@ class Controller(Singleton):
             exception_msg,
         ]
         return Destination(UnhandledExceptionView, view_args={"error": error}, clear_history=True)
+
+    @property
+    def active_view(self) -> Optional[View]:
+        return self.back_stack[-1].view if self.back_stack else None

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -471,14 +471,11 @@ class Controller(Singleton):
     @property
     def is_screensaver_start_allowed(self) -> bool:
         """
-        Determines whether the screensaver is allowed to run.
+            Determines whether the screensaver is allowed to start.
 
-        The screensaver can run only if:
-        - It is not currently running.
-        - The current active view allows screensaver activity.
-
-        Returns:
-            bool: True if the screensaver can run, False otherwise.
+            The screensaver can start only if:
+            - It is not currently running.
+            - The current active view allows screensaver activity.
         """
         from seedsigner.views import MainMenuView
         active_view = self.back_stack[-1].view if self.back_stack else MainMenuView()

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -468,9 +468,19 @@ class Controller(Singleton):
         return Destination(UnhandledExceptionView, view_args={"error": error}, clear_history=True)
 
     @property
-    def active_view(self) -> Optional[View]:
-        return self.back_stack[-1].view if self.back_stack else None
     def active_view(self) -> View:
         from seedsigner.views import MainMenuView
         return self.back_stack[-1].view if self.back_stack else MainMenuView()
 
+    def can_run_screensaver(self) -> bool:
+        """
+        Determines whether the screensaver is allowed to run.
+
+        The screensaver can run only if:
+        - It is not currently running.
+        - The current active view allows screensaver activity.
+
+        Returns:
+            bool: True if the screensaver can run, False otherwise.
+        """
+        return not self.is_screensaver_running and self.active_view.allow_screensaver

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -468,11 +468,7 @@ class Controller(Singleton):
         return Destination(UnhandledExceptionView, view_args={"error": error}, clear_history=True)
 
     @property
-    def active_view(self) -> View:
-        from seedsigner.views import MainMenuView
-        return self.back_stack[-1].view if self.back_stack else MainMenuView()
-
-    def can_run_screensaver(self) -> bool:
+    def is_screensaver_start_allowed(self) -> bool:
         """
         Determines whether the screensaver is allowed to run.
 
@@ -483,4 +479,6 @@ class Controller(Singleton):
         Returns:
             bool: True if the screensaver can run, False otherwise.
         """
-        return not self.is_screensaver_running and self.active_view.allow_screensaver
+        from seedsigner.views import MainMenuView
+        active_view = self.back_stack[-1].view if self.back_stack else MainMenuView()
+        return not self.is_screensaver_running and active_view.allow_screensaver

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -478,5 +478,6 @@ class Controller(Singleton):
             - The current active view allows screensaver activity.
         """
         from seedsigner.views import MainMenuView
+        # Confusingly, the top item in the `BackStack` is actually the *current* View
         active_view = self.back_stack[-1].view if self.back_stack else MainMenuView()
         return not self.is_screensaver_running and active_view.allow_screensaver

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -467,6 +467,7 @@ class Controller(Singleton):
         ]
         return Destination(UnhandledExceptionView, view_args={"error": error}, clear_history=True)
 
+
     @property
     def is_screensaver_start_allowed(self) -> bool:
         """

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -89,13 +89,7 @@ class HardwareButtons(Singleton):
                 return HardwareButtonsConstants.OVERRIDE
 
             cur_time = int(time.time() * 1000)
-            active_view = controller.active_view
-            active_view_allows_screensaver = True
-            if active_view:
-                active_view_allows_screensaver = active_view.allow_screensaver
-
-            if (cur_time - self.last_input_time > controller.screensaver_activation_ms
-                    and not controller.is_screensaver_running and active_view_allows_screensaver):
+            if cur_time - self.last_input_time > controller.screensaver_activation_ms and controller.can_run_screensaver():
                 # Start the screensaver. Will block execution until input detected.
                 controller.start_screensaver()
 

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -89,7 +89,13 @@ class HardwareButtons(Singleton):
                 return HardwareButtonsConstants.OVERRIDE
 
             cur_time = int(time.time() * 1000)
-            if cur_time - self.last_input_time > controller.screensaver_activation_ms and not controller.is_screensaver_running:
+            active_view = controller.active_view
+            active_view_allows_screensaver = True
+            if active_view:
+                active_view_allows_screensaver = active_view.allow_screensaver
+
+            if (cur_time - self.last_input_time > controller.screensaver_activation_ms
+                    and not controller.is_screensaver_running and active_view_allows_screensaver):
                 # Start the screensaver. Will block execution until input detected.
                 controller.start_screensaver()
 

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -89,7 +89,7 @@ class HardwareButtons(Singleton):
                 return HardwareButtonsConstants.OVERRIDE
 
             cur_time = int(time.time() * 1000)
-            if cur_time - self.last_input_time > controller.screensaver_activation_ms and controller.can_run_screensaver():
+            if cur_time - self.last_input_time > controller.screensaver_activation_ms and controller.is_screensaver_start_allowed:
                 # Start the screensaver. Will block execution until input detected.
                 controller.start_screensaver()
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1568,7 +1568,7 @@ class SeedTranscribeSeedQRZoomedInView(View):
         self.seed = self.controller.get_seed(seed_num)
         self.initial_zone_x = initial_zone_x
         self.initial_zone_y = initial_zone_y
-        self.allow_screensaver = False
+        self.is_screensaver_allowed = False
 
 
     def run(self):

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1567,7 +1567,8 @@ class SeedTranscribeSeedQRZoomedInView(View):
         self.seedqr_format = seedqr_format
         self.seed = self.controller.get_seed(seed_num)
         self.initial_zone_x = initial_zone_x
-        self.initial_zone_y = initial_zone_y 
+        self.initial_zone_y = initial_zone_y
+        self.allow_screensaver = False
 
 
     def run(self):

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -67,6 +67,7 @@ class View:
         self.screen = None
 
         self._redirect: 'Destination' = None
+        self.allow_screensaver = True
 
 
     def __init__(self):

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -67,7 +67,7 @@ class View:
         self.screen = None
 
         self._redirect: 'Destination' = None
-        self.allow_screensaver = True
+        self.is_screensaver_allowed = True
 
 
     def __init__(self):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -476,6 +476,25 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView),
         ])
 
+    def test_transcribe_seedqr_screensaver_startable_status(self):
+        """
+            The controller should return False for screensaver startable status when SeedTranscribeSeedQRZoomedInView
+            is active.
+        """
+        # Load a finalized Seed into the Controller
+        mnemonic = ["abandon"] * 11 + ["about"]
+        self.controller.storage.set_pending_seed(Seed(mnemonic=mnemonic))
+        self.controller.storage.finalize_pending_seed()
+
+        self.run_sequence(
+            initial_destination_view_args={'num_modules': 21, 'seed_num': 0, 'seedqr_format': 'seed__seedqr'},
+            sequence=[
+                FlowStep(seed_views.SeedTranscribeSeedQRWholeQRView),
+                FlowStep(seed_views.SeedTranscribeSeedQRZoomedInView, is_redirect=True),  # Live interactive screens are a bit weird; not sure why `is_redirect` is necessary here
+        ])
+
+        assert self.controller.is_screensaver_start_allowed == False
+
 
 
 class TestMessageSigningFlows(FlowTest):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -476,6 +476,7 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView),
         ])
 
+    # TODO: ideally this test should be part of controller related test? move it there
     def test_transcribe_seedqr_screensaver_startable_status(self):
         """
             The controller should return False for screensaver startable status when SeedTranscribeSeedQRZoomedInView

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -476,7 +476,6 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView),
         ])
 
-    # TODO: ideally this test should be part of controller related test? move it there
     def test_transcribe_seedqr_screensaver_startable_status(self):
         """
             The controller should return False for screensaver startable status when SeedTranscribeSeedQRZoomedInView


### PR DESCRIPTION
## Description

This PR addresses part of the discussed SoB idea in the `seedsigner dev` group providing a solution for the issue of the screensaver interrupting the seed QR transcribing process. Views now have a property that indicates whether the screensaver is allowed while the view is running. As a result, the screensaver will not start when users are transcribing the QR. This improves usability, especially when transcribing 21×21 SeedQRs, where the screensaver previously interrupted the flow.  A future update may introduce a long timeout wipe or reboot as a fallback for inactivity.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
