### PR TITLE
[bugfix] Only apply auto-scroll `ButtonListScreen` logic for long lists that need it

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -326,14 +326,14 @@ class ButtonListScreen(BaseTopNavScreen):
             button_list_y = self.top_nav.height
             self.has_scroll_arrows = True
 
-        # How many buttons fit on the screen before we need to start scrolling?
-        num_buttons_pre_scroll = math.floor((self.canvas_height - button_list_y - GUIConstants.EDGE_PADDING) / (button_height + GUIConstants.LIST_ITEM_PADDING))
+            # How many buttons fit on the screen before we need to start scrolling?
+            num_buttons_pre_scroll = math.floor((self.canvas_height - button_list_y - GUIConstants.EDGE_PADDING) / (button_height + GUIConstants.LIST_ITEM_PADDING))
 
-        # Force a scroll offset when necessary if none was provided
-        if self.selected_button + 1 > num_buttons_pre_scroll and not self.scroll_y_initial_offset:
-            # Scroll far enough to expose the selected button; +1 to account for the
-            # height of the target button itself!
-            self.scroll_y_initial_offset = (button_height + GUIConstants.LIST_ITEM_PADDING) * (self.selected_button - num_buttons_pre_scroll + 1)
+            # Force a scroll offset when necessary if none was provided
+            if self.selected_button + 1 > num_buttons_pre_scroll and not self.scroll_y_initial_offset:
+                # Scroll far enough to expose the selected button; +1 to account for the
+                # height of the target button itself!
+                self.scroll_y_initial_offset = (button_height + GUIConstants.LIST_ITEM_PADDING) * (self.selected_button - num_buttons_pre_scroll + 1)
 
         self.buttons: List[Button] = []
         for i, button_option in enumerate(self.button_data):

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -169,7 +169,6 @@ def generate_screenshots(locale):
                 dict(
                     visibility=SettingsConstants.VISIBILITY__ADVANCED,
                     selected_attr=SettingsConstants.SETTING__ELECTRUM_SEEDS,
-                    initial_scroll=240,  # Just guessing how many pixels to scroll down
                 ),
                 screenshot_name="SettingsMenuView__Advanced"
             )


### PR DESCRIPTION
## Description

PR #686 introduced a bug for any `ButtonListScreen` that consists of a single button with `is_bottom_list = True`.

The logic added in that PR to auto-scroll long lists (to make sure the `selected_button` would be visible) was being mis-applied in these simpler `is_bottom_button` screens.

## The fix
If the `button_data` list isn't long enough to require scrolling, don't even execute the auto-scroll logic.

aka: I fixed it with one `TAB` key press.

I regenerated all English screenshots to verify the change.

Manually tried multiple auto-scroll options with a large list of onboard languages to choose from.

Hands-on verified that simple `is_bottom_list` screens were presenting as expected.


## Misc
Tweaked the `SettingsMenuView__Advanced` screenshot to longer guesstimate an initial scroll value since the auto-scroll should do that for us now (this minor screenshot config change should have been part of the original PR).

---

This pull request is categorized as a:
- [x] Bug fix

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
