### PR TITLE
[New Feature] Derive Nostr privkey / pubkey via NIP-06

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: seedsigner 0.8.5-rc1\n"
+"Project-Id-Version: seedsigner 0.8.5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-01-28 13:28-0600\n"
+"POT-Creation-Date: 2025-04-23 11:43-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,6 +48,27 @@ msgstr ""
 
 #: src/seedsigner/gui/toast.py
 msgid "SD card inserted"
+msgstr ""
+
+#: src/seedsigner/gui/screens/nostr_screens.py
+#: src/seedsigner/views/nostr_views.py src/seedsigner/views/seed_views.py
+msgid "Export Nostr Key"
+msgstr ""
+
+#. Short for "Next step"
+#: src/seedsigner/gui/screens/nostr_screens.py
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Next"
+msgstr ""
+
+#: src/seedsigner/gui/screens/nostr_screens.py
+msgid "Public key:"
+msgstr ""
+
+#: src/seedsigner/gui/screens/nostr_screens.py
+msgid "Private key:"
 msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
@@ -435,13 +456,6 @@ msgstr ""
 msgid "Review Message"
 msgstr ""
 
-#. Short for "Next step"
-#: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
-#: src/seedsigner/views/tools_views.py
-msgid "Next"
-msgstr ""
-
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Confirm Address"
 msgstr ""
@@ -763,6 +777,14 @@ msgid "BIP-85 child seeds"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
+msgid "Nostr NIP-06 keys"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Derive Nostr key from BIP-39 mnemonic"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
 msgid "Electrum seeds"
 msgstr ""
 
@@ -792,6 +814,46 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "QR background color"
+msgstr ""
+
+#: src/seedsigner/views/nostr_views.py
+msgid "Keep keys separate!"
+msgstr ""
+
+#: src/seedsigner/views/nostr_views.py
+msgid "If this key already secures bitcoin, do not use it as your nostr key!"
+msgstr ""
+
+#. Option to export a nostr public key; do not translate "npub".
+#: src/seedsigner/views/nostr_views.py
+msgid "Public key: npub"
+msgstr ""
+
+#. Option to export a nostr public key; "hex" == hexadecimal format.
+#: src/seedsigner/views/nostr_views.py
+msgid "Public key: hex"
+msgstr ""
+
+#. Option to export a nostr private key; do not translate "nsec".
+#: src/seedsigner/views/nostr_views.py
+msgid "Private key: nsec"
+msgstr ""
+
+#. Option to export a nostr private key; "hex" == hexadecimal format.
+#: src/seedsigner/views/nostr_views.py
+msgid "Private key: hex"
+msgstr ""
+
+#: src/seedsigner/views/nostr_views.py
+msgid "Nostr Private Key"
+msgstr ""
+
+#: src/seedsigner/views/nostr_views.py
+msgid "Protect your key!"
+msgstr ""
+
+#: src/seedsigner/views/nostr_views.py
+msgid "Anyone with your private key has full control of your nostr identity."
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
@@ -1254,11 +1316,11 @@ msgid "Review SeedQR"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Your transcribed SeedQR successfully scanned and yielded the same seed."
+msgid "Your transcribed SeedQR could not be read!"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Your transcribed SeedQR could not be read!"
+msgid "Your transcribed SeedQR successfully scanned and yielded the same seed."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -39,6 +39,7 @@ class GUIConstants:
     TESTNET_COLOR = "#00F100"
     REGTEST_COLOR = "#00CAF1"
     GREEN_INDICATOR_COLOR = "#00FF00"
+    NOSTR_ACCENT_COLOR = "#dd23ef"
 
     ICON_FONT_NAME__FONT_AWESOME = "Font_Awesome_6_Free-Solid-900"
     ICON_FONT_NAME__SEEDSIGNER = "seedsigner-icons"

--- a/src/seedsigner/gui/screens/nostr_screens.py
+++ b/src/seedsigner/gui/screens/nostr_screens.py
@@ -1,0 +1,60 @@
+from gettext import gettext as _
+
+from dataclasses import dataclass
+from seedsigner.gui.components import GUIConstants, TextArea
+
+from seedsigner.gui.screens.screen import ButtonListScreen, ButtonOption, WarningEdgesMixin
+
+
+
+"""****************************************************************************
+    Nostr Key Export
+****************************************************************************"""
+@dataclass
+class BaseNostrKeyDisplayScreen(ButtonListScreen):
+    """
+    Base Screen class for either Nostr pubkey or privkey display.
+    """
+    key: str = None
+    is_pubkey: bool = True
+
+    def __post_init__(self):
+        # Customize defaults
+        self.title = _("Export Nostr Key")
+        self.button_data = [ButtonOption("Next")]
+        self.is_bottom_list = True
+
+        super().__post_init__()
+
+        keytype = TextArea(
+            text=_("Public key:") if self.is_pubkey else _("Private key:"),
+            is_text_centered=True,
+            screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING
+        )
+        self.components.append(keytype)
+
+        # npub and nsec are 63 chars; hex format is 64 chars. Break into 4 lines.
+        chars_per_line = 16
+        key_str = "\n".join([s for s in [self.key[i:i+chars_per_line] for i in range(0, len(self.key), chars_per_line)]])
+
+        key_display = TextArea(
+            text=key_str,
+            font_name=GUIConstants.FIXED_WIDTH_FONT_NAME,
+            font_color=GUIConstants.NOSTR_ACCENT_COLOR,
+            font_size=GUIConstants.get_button_font_size(),  # Intentionally using a bigger font size
+            is_text_centered=True,
+        )
+        key_display.screen_y = keytype.screen_y + keytype.height + 2*GUIConstants.COMPONENT_PADDING
+        self.components.append(key_display)
+
+
+
+class NostrPublicKeyDisplayScreen(BaseNostrKeyDisplayScreen):
+    pass
+
+
+
+@dataclass
+class NostrPrivateKeyDisplayScreen(WarningEdgesMixin, BaseNostrKeyDisplayScreen):
+    status_color: str = GUIConstants.DIRE_WARNING_COLOR
+    is_pubkey: bool = False

--- a/src/seedsigner/helpers/nostr.py
+++ b/src/seedsigner/helpers/nostr.py
@@ -1,0 +1,71 @@
+from binascii import hexlify
+from embit import bip32, bech32
+from embit import ec
+# from seedsigner.helpers import bech32
+from seedsigner.models.seed import Seed
+
+
+NOSTR__PUBKEY_NPUB = "npub"
+NOSTR__PUBKEY_HEX = "pubhex"
+NOSTR__PRIVKEY_NSEC = "nsec"
+NOSTR__PRIVKEY_HEX = "privhex"
+
+
+def derive_nostr_key(seed: Seed) -> bip32.HDKey:
+    """ Derive the NIP-06 Nostr key at m/44'/1237'/0'/0/0 """
+    """
+        Note: You could derive sibling seeds (e.g. m/44h/1237h/0h/0/1) from the same root
+        Seed, but so far Nostr use cases & best practices are limited to just a single
+        direct path from mnemonic to npub/nsec. No sibling or child Nostr keys.
+    """
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    return root.derive("m/44h/1237h/0h/0/0")
+
+
+
+def get_nsec(seed: Seed) -> str:
+    nostr_root = derive_nostr_key(seed=seed)
+    converted_bits = bech32.convertbits(nostr_root.secret, 8, 5)
+    return bech32.bech32_encode(encoding=bech32.Encoding.BECH32, hrp=NOSTR__PRIVKEY_NSEC, data=converted_bits)
+
+
+
+def get_npub(seed: Seed) -> str:
+    nostr_root = derive_nostr_key(seed=seed)
+    privkey = ec.PrivateKey(secret=nostr_root.secret)
+    pubkey = privkey.get_public_key().xonly()
+    converted_bits = bech32.convertbits(pubkey, 8, 5)
+    return bech32.bech32_encode(encoding=bech32.Encoding.BECH32, hrp=NOSTR__PUBKEY_NPUB, data=converted_bits)
+
+
+
+def get_pubkey_hex(seed: Seed) -> str:
+    nostr_root = derive_nostr_key(seed=seed)
+    privkey = ec.PrivateKey(secret=nostr_root.secret)
+    return hexlify(privkey.get_public_key().xonly()).decode()
+
+
+
+def get_privkey_hex(seed: Seed) -> str:
+    nostr_root = derive_nostr_key(seed=seed)
+    return hexlify(nostr_root.secret).decode()
+
+
+
+def get_nostr_key(seed: Seed, format: str = NOSTR__PUBKEY_NPUB) -> str:
+    """
+    Get the Nostr key in the requested format.
+    :param seed: Seed object
+    :param format: Format of the key (npub, pubhex, nsec, privhex)
+    :return: Nostr key in the requested format
+    """
+    if format == NOSTR__PUBKEY_NPUB:
+        return get_npub(seed)
+    elif format == NOSTR__PUBKEY_HEX:
+        return get_pubkey_hex(seed)
+    elif format == NOSTR__PRIVKEY_NSEC:
+        return get_nsec(seed)
+    elif format == NOSTR__PRIVKEY_HEX:
+        return get_privkey_hex(seed)
+    else:
+        raise ValueError(f"Invalid format: {format}")

--- a/src/seedsigner/helpers/nostr.py
+++ b/src/seedsigner/helpers/nostr.py
@@ -1,7 +1,6 @@
 from binascii import hexlify
 from embit import bip32, bech32
 from embit import ec
-# from seedsigner.helpers import bech32
 from seedsigner.models.seed import Seed
 
 
@@ -12,11 +11,11 @@ NOSTR__PRIVKEY_HEX = "privhex"
 
 
 def derive_nostr_key(seed: Seed) -> bip32.HDKey:
-    """ Derive the NIP-06 Nostr key at m/44'/1237'/0'/0/0 """
-    """
-        Note: You could derive sibling seeds (e.g. m/44h/1237h/0h/0/1) from the same root
-        Seed, but so far Nostr use cases & best practices are limited to just a single
-        direct path from mnemonic to npub/nsec. No sibling or child Nostr keys.
+    """ Derive the NIP-06 Nostr key at m/44'/1237'/0'/0/0
+
+        Note: NIP-06 mentions the possibility of deriving sibling seeds by incrementing
+        `account` (i.e. m/44'/1237'/<account>'/0/0) from the same root Seed, but for now
+        we only support the simplest (`account == 0`) use case.
     """
     root = bip32.HDKey.from_seed(seed.seed_bytes)
     return root.derive("m/44h/1237h/0h/0/0")
@@ -53,12 +52,6 @@ def get_privkey_hex(seed: Seed) -> str:
 
 
 def get_nostr_key(seed: Seed, format: str = NOSTR__PUBKEY_NPUB) -> str:
-    """
-    Get the Nostr key in the requested format.
-    :param seed: Seed object
-    :param format: Format of the key (npub, pubhex, nsec, privhex)
-    :return: Nostr key in the requested format
-    """
     if format == NOSTR__PUBKEY_NPUB:
         return get_npub(seed)
     elif format == NOSTR__PUBKEY_HEX:

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -330,6 +330,7 @@ class SettingsConstants:
     SETTING__CAMERA_ROTATION = "camera_rotation"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
+    SETTING__NOSTR_NIP06_EXPORT = "nostr_nip06_export"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
@@ -637,6 +638,14 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,
                       abbreviated_name="bip85",
                       display_name=_mft("BIP-85 child seeds"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__NOSTR_NIP06_EXPORT,
+                      abbreviated_name="nip06",
+                      display_name=_mft("Nostr NIP-06 keys"),
+                      help_text=_mft("Derive Nostr key from BIP-39 mnemonic"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
 

--- a/src/seedsigner/views/nostr_views.py
+++ b/src/seedsigner/views/nostr_views.py
@@ -1,0 +1,148 @@
+from gettext import gettext as _
+
+from seedsigner.helpers import nostr
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.views.view import BackStackView, Destination, View
+
+
+
+"""****************************************************************************
+    Nostr Export Key
+****************************************************************************"""
+class NostrExportKeyStartView(View):
+    def __init__(self, seed_num: int):
+        super().__init__()
+        self.seed_num = seed_num
+
+    def run(self):
+        from seedsigner.gui.screens.screen import WarningScreen
+        selected_menu_num = self.run_screen(
+            WarningScreen,
+            title=_("Export Nostr Key"),
+            status_headline=_("Keep keys separate!"),
+            text=_("If this key already secures bitcoin, do not use it as your nostr key!"),
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        return Destination(NostrExportKeySelectTypeView, view_args=dict(seed_num=self.seed_num))
+
+
+
+class NostrExportKeySelectTypeView(View):
+    # TRANSLATOR_NOTE: Option to export a nostr public key; do not translate "npub".
+    PUBKEY_NPUB = ButtonOption("Public key: npub", return_data=nostr.NOSTR__PUBKEY_NPUB)
+
+    # TRANSLATOR_NOTE: Option to export a nostr public key; "hex" == hexadecimal format.
+    PUBKEY_HEX = ButtonOption("Public key: hex", return_data=nostr.NOSTR__PUBKEY_HEX)
+
+    # TRANSLATOR_NOTE: Option to export a nostr private key; do not translate "nsec".
+    PRIVKEY_NSEC = ButtonOption("Private key: nsec", return_data=nostr.NOSTR__PRIVKEY_NSEC)
+
+    # TRANSLATOR_NOTE: Option to export a nostr private key; "hex" == hexadecimal format.
+    PRIVKEY_HEX = ButtonOption("Private key: hex", return_data=nostr.NOSTR__PRIVKEY_HEX)
+
+
+    def __init__(self, seed_num: int):
+        super().__init__()
+        self.seed_num = seed_num
+        self.seed = self.controller.get_seed(seed_num)
+    
+
+    def run(self):
+        button_data = [self.PUBKEY_NPUB, self.PUBKEY_HEX, self.PRIVKEY_NSEC, self.PRIVKEY_HEX]
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Export Nostr Key"),
+            button_data=button_data,
+            is_button_text_centered=False,
+            is_bottom_list=True,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        
+        nostr_key_format = button_data[selected_menu_num].return_data
+
+        if nostr_key_format in [nostr.NOSTR__PUBKEY_NPUB, nostr.NOSTR__PUBKEY_HEX]:
+            return Destination(NostrExportKeyDisplayKeyView, view_args=dict(seed_num=self.seed_num, nostr_key_format=nostr_key_format))
+        else:
+            # Show the warning screen before showing the private key
+            return Destination(NostrExportKeyPrivateKeyWarningView, view_args=dict(seed_num=self.seed_num, nostr_key_format=nostr_key_format))
+
+
+
+class BaseNostrKeyView(View):
+    """ Base View class for most of the Nostr export key Views. """
+    def __init__(self, seed_num: int, nostr_key_format: str = nostr.NOSTR__PRIVKEY_NSEC):
+        super().__init__()
+        self.seed_num = seed_num
+        self.nostr_key_format = nostr_key_format
+
+
+    @property
+    def nostr_key(self) -> str:
+        return nostr.get_nostr_key(
+            seed=self.controller.get_seed(self.seed_num),
+            format=self.nostr_key_format,
+        )
+    
+
+    @property
+    def is_pubkey(self) -> bool:
+        return self.nostr_key_format in [nostr.NOSTR__PUBKEY_NPUB, nostr.NOSTR__PUBKEY_HEX]
+
+
+
+class NostrExportKeyPrivateKeyWarningView(BaseNostrKeyView):
+    def run(self):
+        from seedsigner.gui.screens.screen import DireWarningScreen
+        selected_menu_num = self.run_screen(
+            DireWarningScreen,
+            title=_("Nostr Private Key"),
+            status_headline=_("Protect your key!"),
+            text=_("Anyone with your private key has full control of your nostr identity."),
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        return Destination(NostrExportKeyDisplayKeyView, view_args=dict(seed_num=self.seed_num, nostr_key_format=self.nostr_key_format))
+
+
+
+class NostrExportKeyDisplayKeyView(BaseNostrKeyView):
+    def run(self):
+        from seedsigner.gui.screens.nostr_screens import NostrPublicKeyDisplayScreen, NostrPrivateKeyDisplayScreen
+
+        selected_menu_num = self.run_screen(
+            NostrPublicKeyDisplayScreen if self.is_pubkey else NostrPrivateKeyDisplayScreen,
+            key=self.nostr_key,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        return Destination(NostrExportKeyQRView, view_args=dict(seed_num=self.seed_num, nostr_key_format=self.nostr_key_format))
+
+
+
+class NostrExportKeyQRView(BaseNostrKeyView):
+    def run(self):
+        from seedsigner.gui.screens import QRDisplayScreen
+        from seedsigner.models.encode_qr import GenericStaticQrEncoder
+        from seedsigner.views.seed_views import SeedOptionsView
+
+        qr_encoder = GenericStaticQrEncoder(
+            qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+            data=self.nostr_key,
+        )
+
+        self.run_screen(
+            QRDisplayScreen,
+            qr_encoder=qr_encoder
+        )
+
+        return Destination(SeedOptionsView, view_args=dict(seed_num=self.seed_num), skip_current_view=True, clear_history=True)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -529,6 +529,7 @@ class SeedOptionsView(View):
     SIGN_MESSAGE = ButtonOption("Sign Message")
     BACKUP = ButtonOption("Backup Seed", right_icon_name=SeedSignerIconConstants.CHEVRON_RIGHT)
     BIP85_CHILD_SEED = ButtonOption("BIP-85 Child Seed")
+    EXPORT_NOSTR_KEY = ButtonOption("Export Nostr Key")
     DISCARD = ButtonOption("Discard Seed", button_label_color="red")
 
 
@@ -589,6 +590,9 @@ class SeedOptionsView(View):
         if self.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS) == SettingsConstants.OPTION__ENABLED and self.seed.bip85_supported:
             button_data.append(self.BIP85_CHILD_SEED)
 
+        if self.settings.get_value(SettingsConstants.SETTING__NOSTR_NIP06_EXPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.EXPORT_NOSTR_KEY)
+
         button_data.append(self.DISCARD)
         
         selected_menu_num = self.run_screen(
@@ -628,6 +632,10 @@ class SeedOptionsView(View):
 
         elif button_data[selected_menu_num] == self.BIP85_CHILD_SEED:
             return Destination(SeedBIP85ApplicationModeView, view_args={"seed_num": self.seed_num})
+
+        elif button_data[selected_menu_num] == self.EXPORT_NOSTR_KEY:
+            from seedsigner.views.nostr_views import NostrExportKeyStartView
+            return Destination(NostrExportKeyStartView, view_args={"seed_num": self.seed_num})
 
         elif button_data[selected_menu_num] == self.DISCARD:
             return Destination(SeedDiscardView, view_args=dict(seed_num=self.seed_num))

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -29,7 +29,7 @@ from seedsigner.gui.screens.seed_screens import SeedAddPassphraseScreen
 from seedsigner.gui.toast import RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
 from seedsigner.gui.toast import DefaultToast, InfoToast, SuccessToast, WarningToast, ErrorToast, DireWarningToast
 from seedsigner.hardware.microsd import MicroSD
-from seedsigner.helpers import embit_utils
+from seedsigner.helpers import embit_utils, nostr
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.psbt_parser import OPCODES, PSBTParser
 from seedsigner.models.qr_type import QRType
@@ -37,7 +37,7 @@ from seedsigner.models.seed import Seed
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
-    psbt_views, seed_views, settings_views, tools_views, scan_views)
+    nostr_views, psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
 from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView
 
@@ -317,6 +317,13 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedSignMessageConfirmAddressView),
 
                 ScreenshotConfig(seed_views.SeedElectrumMnemonicStartView),
+
+                ScreenshotConfig(nostr_views.NostrExportKeyStartView, dict(seed_num=0)),
+                ScreenshotConfig(nostr_views.NostrExportKeySelectTypeView, dict(seed_num=0)),
+                ScreenshotConfig(nostr_views.NostrExportKeyPrivateKeyWarningView, dict(seed_num=0)),
+                ScreenshotConfig(nostr_views.NostrExportKeyDisplayKeyView, dict(seed_num=0, nostr_key_format=nostr.NOSTR__PUBKEY_NPUB), screenshot_name="NostrExportKeyDisplayKeyView__npub"),
+                ScreenshotConfig(nostr_views.NostrExportKeyDisplayKeyView, dict(seed_num=0, nostr_key_format=nostr.NOSTR__PRIVKEY_NSEC), screenshot_name="NostrExportKeyDisplayKeyView__nsec"),
+                ScreenshotConfig(nostr_views.NostrExportKeyDisplayKeyView, dict(seed_num=0, nostr_key_format=nostr.NOSTR__PRIVKEY_HEX), screenshot_name="NostrExportKeyDisplayKeyView__privkey_hex"),
             ],
             "PSBT Views": [
                 ScreenshotConfig(psbt_views.PSBTSelectSeedView, run_before=PSBTSelectSeedView_cb_before),

--- a/tests/test_flows_nostr.py
+++ b/tests/test_flows_nostr.py
@@ -1,0 +1,59 @@
+# Must import test base before the Controller
+from base import FlowStep, FlowTest
+
+from seedsigner.models.seed import Seed
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.views import nostr_views, seed_views
+from seedsigner.views.view import MainMenuView
+
+
+
+class TestNostrFlows(FlowTest):
+    def setup_method(self):
+        super().setup_method()
+
+        # Load a finalized Seed into the Controller; same mnemonic as the NIP-06 test vector
+        mnemonic = "leader monkey parrot ring guide accident before fence cannon height naive bean".split()
+        self.controller.storage.set_pending_seed(Seed(mnemonic=mnemonic))
+        self.controller.storage.finalize_pending_seed()
+
+        # NIP-06 option must be enabled
+        self.settings.set_value(SettingsConstants.SETTING__NOSTR_NIP06_EXPORT, SettingsConstants.OPTION__ENABLED)
+
+
+    def test__export_nostr_pubkey__flow(self):
+        """
+        Exporting a Nostr pubkey should work for npub or pubkey hex format, display it as
+        a QR code, and return to Seed Options.
+        """
+        for nostr_type_selection in [nostr_views.NostrExportKeySelectTypeView.PUBKEY_NPUB, nostr_views.NostrExportKeySelectTypeView.PUBKEY_HEX]:
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, screen_return_value=0),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.EXPORT_NOSTR_KEY),
+                FlowStep(nostr_views.NostrExportKeyStartView),
+                FlowStep(nostr_views.NostrExportKeySelectTypeView, button_data_selection=nostr_type_selection),
+                FlowStep(nostr_views.NostrExportKeyDisplayKeyView),
+                FlowStep(nostr_views.NostrExportKeyQRView),
+                FlowStep(seed_views.SeedOptionsView),
+            ])
+
+
+    def test__export_nostr_privkey__flow(self):
+        """
+        Exporting a Nostr privkey should work for nsec or privkey hex format, display a
+        dire warning message, display the privkey as a QR code, and return to Seed
+        Options.
+        """
+        for nostr_type_selection in [nostr_views.NostrExportKeySelectTypeView.PRIVKEY_NSEC, nostr_views.NostrExportKeySelectTypeView.PRIVKEY_HEX]:
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, screen_return_value=0),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.EXPORT_NOSTR_KEY),
+                FlowStep(nostr_views.NostrExportKeyStartView),
+                FlowStep(nostr_views.NostrExportKeySelectTypeView, button_data_selection=nostr_type_selection),
+                FlowStep(nostr_views.NostrExportKeyPrivateKeyWarningView),  # Unique to the privkey export flow
+                FlowStep(nostr_views.NostrExportKeyDisplayKeyView),
+                FlowStep(nostr_views.NostrExportKeyQRView),
+                FlowStep(seed_views.SeedOptionsView),
+            ])

--- a/tests/test_nostr.py
+++ b/tests/test_nostr.py
@@ -1,0 +1,40 @@
+from seedsigner.helpers import nostr
+from seedsigner.models.seed import Seed
+
+from base import BaseTest
+
+
+
+class TestNostr(BaseTest):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+
+
+    def test__derive_nostr_key(self):
+        """ Should follow the NIP-06 process to derive a nostr key from a BIP-39 mnemonic. """
+        # Test vectors from NIP-06: https://github.com/nostr-protocol/nips/blob/master/06.md
+        test_vectors = [
+            dict(
+                mnemonic="leader monkey parrot ring guide accident before fence cannon height naive bean".split(),
+                privkey_hex="7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a",
+                nsec="nsec10allq0gjx7fddtzef0ax00mdps9t2kmtrldkyjfs8l5xruwvh2dq0lhhkp",
+                pubkey_hex="17162c921dc4d2518f9a101db33695df1afb56ab82f5ff3e5da6eec3ca5cd917",
+                npub="npub1zutzeysacnf9rru6zqwmxd54mud0k44tst6l70ja5mhv8jjumytsd2x7nu"
+            ),
+            dict(
+                mnemonic="what bleak badge arrange retreat wolf trade produce cricket blur garlic valid proud rude strong choose busy staff weather area salt hollow arm fade".split(),
+                privkey_hex="c15d739894c81a2fcfd3a2df85a0d2c0dbc47a280d092799f144d73d7ae78add",
+                nsec="nsec1c9wh8xy5eqdzln7n5t0ctgxjcrdug73gp5yj0x03gntn67h83twssdfhel",
+                pubkey_hex="d41b22899549e1f3d335a31002cfd382174006e166d3e658e3a5eecdb6463573",
+                npub="npub16sdj9zv4f8sl85e45vgq9n7nsgt5qphpvmf7vk8r5hhvmdjxx4es8rq74h",
+            )
+        ]
+
+        for test_vector in test_vectors:
+            seed = Seed(test_vector["mnemonic"])
+            assert nostr.get_privkey_hex(seed) == test_vector["privkey_hex"]
+            assert nostr.get_nsec(seed) == test_vector["nsec"]
+            assert nostr.get_pubkey_hex(seed) == test_vector["pubkey_hex"]
+            assert nostr.get_npub(seed) == test_vector["npub"]
+


### PR DESCRIPTION
## Background

I originally built a [full nostr integration for the 2023 Nostrica conference](https://youtu.be/DvnAHp60zpU?t=16675). That branch was always meant to just be a fun demo and a conversation starter (primarily around NIP-26 delegated signing). It was not intended to ever be PRed into the main SeedSigner repo.

However, the NIP-06 key derivation portions are actually broadly useful.


## What is nostr
see: https://nostr.org/


## What is NIP-06
see: https://github.com/nostr-protocol/nips/blob/master/06.md

It's a very simple BIP-32 derivation of a new privkey / pubkey pair using the specified derivation path. From there you can generate your nsec/npub for use in nostr clients. The nostr hex key formats are also trivially generated.


## Nostr client support
Nostr clients have varying support for NIP-06 (either presenting the user with a BIP-39 mnemonic backup for a newly created nostr key or importing from a BIP-39 mnemonic to restore your nostr key).

But for purposes, NIP-06 integration isn't even necessary. Every nostr client or remote signer will support keys entered as nsec or hex format. And at least one, [Amber](https://github.com/greenart7c3/Amber), can read keys in via QR. I haven't exhaustively researched which other clients and apps support QR. I would assume others exist and, given the pace of nostr development, I'm sure other clients could add QR support quickly if there was enough interest.


## This PR
### Rationale
SeedSigner and nostr have always been aligned in the FOSS and self-sovereignty ethos. We can encourage and facilitate using BIP-39 mnemonics as the backup format for nostr keys, which by itself is a big win. And leveraging SeedSigner's bring-your-own-entropy seed creation as part of a user's Nostr key creation flow is another big win.

Also, new developments such as [Frostr](https://www.frostr.org/) (literally FROST + nostr) possibly lend themselves to more offline key creation features that could some day be built into SeedSigner.


### Details
I've refactored some of that original Nostrica demo code and stripped out everything except the NIP-06 key derivation features.

Creates a new Settings option (disabled by default) to add Nostr key export as an option for a given Seed.

![SettingsMenuView__Advanced](https://github.com/user-attachments/assets/f865bcc1-0442-469c-a400-7d2ef43b23f2) ![SettingsEntryUpdateSelectionView_nostr_nip06_export](https://github.com/user-attachments/assets/2c6224ee-4544-451f-985d-d8e62756f826)

---

![SeedOptionsView](https://github.com/user-attachments/assets/3b7788d4-1597-4fe6-823b-44c4e08fdffb) ![NostrKeyExportStartView](https://github.com/user-attachments/assets/a7877f17-4abd-4143-b5ec-9c3862279228) ![NostrKeyExportSelectTypeView](https://github.com/user-attachments/assets/a9cc5f1c-a997-416f-9f8f-6918640327e9)

---

If you select one of the privkey formats:

![NostrKeyExportPrivateKeyWarningView](https://github.com/user-attachments/assets/666dc5c2-a7c9-4a96-ad97-26e21f07f278)

---

![NostrExportKeyDisplayKeyView__npub](https://github.com/user-attachments/assets/926fb35f-6279-4b8f-a733-7f7a86d136aa) ![NostrExportKeyDisplayKeyView__nsec](https://github.com/user-attachments/assets/388597ed-9778-46e0-9424-922a89a8f91e) ![NostrExportKeyDisplayKeyView__privkey_hex](https://github.com/user-attachments/assets/d21f0fb0-eab1-4521-b114-e94370e20f2a)

After this screen the nostr privkey or pubkey is displayed as a static QR.

---

## Related changes
I opted to isolate the nostr functionality in its own:
* `helpers.nostr`
* `views.nostr_views`
* `screens.nostr_screens`

Minimal touchpoints to the rest of the code. Just the necessary integrations in `SeedOptionsView`, Settings, screenshot generator.

Full unit tests and flow tests added.

Updated `messages.pot` master translation file for the new nostr-related display strings.

Note the obvious color scheme violation with the nostr-themed purple in the final display screen. As always I defer to @easyuxd if this indulgence should be allowed. My argument: it's a fun, harmless one-off that's buried deep in a specific flow that's disabled by default. But I will accept Easy's decision either way without gripe.

---

This pull request is categorized as a:
- [x] New feature

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] Yes

I have tested this PR on the following platforms/os:
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board