### PR TITLE
[Bugfix] TopNav titles not switching language font; misc l10n cleanup

### DIFF
--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -1360,8 +1360,12 @@ class Button(BaseComponent):
     text_y_offset: int = 0
     background_color: str = GUIConstants.BUTTON_BACKGROUND_COLOR
     selected_color: str = GUIConstants.ACCENT_COLOR
+
+    # Cannot define these class attrs w/the get_*_font_*() methods because the attrs will
+    # not be dynamically reinterpreted after initial class import.
     font_name: str = None
     font_size: int = None
+
     font_color: str = GUIConstants.BUTTON_FONT_COLOR
     selected_font_color: str = GUIConstants.BUTTON_SELECTED_FONT_COLOR
     outline_color: str = None
@@ -1674,8 +1678,12 @@ class TopNav(BaseComponent):
     background_color: str = GUIConstants.BACKGROUND_COLOR
     icon_name: str = None
     icon_color: str = GUIConstants.BODY_FONT_COLOR
-    font_name: str = GUIConstants.get_top_nav_title_font_name()
-    font_size: int = GUIConstants.get_top_nav_title_font_size()
+
+    # Cannot define these class attrs w/the get_*_font_*() methods because the attrs will
+    # not be dynamically reinterpreted after initial class import.
+    font_name: str = None
+    font_size: int = None
+
     font_color: str = GUIConstants.BODY_FONT_COLOR
     show_back_button: bool = True
     show_power_button: bool = False
@@ -1688,8 +1696,7 @@ class TopNav(BaseComponent):
         
         if not self.font_size:
             self.font_size = GUIConstants.get_top_nav_title_font_size()
-            print(f"self.font_size: {self.font_size}")
-
+        
         super().__post_init__()
         if not self.width:
             self.width = self.canvas_width

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -289,8 +289,12 @@ class ButtonListScreen(BaseTopNavScreen):
     selected_button: int = 0
     is_button_text_centered: bool = True
     is_bottom_list: bool = False
+
+    # Cannot define these class attrs w/the get_*_font_*() methods because the attrs will
+    # not be dynamically reinterpreted after initial class import.
     button_font_name: str = None
     button_font_size: int = None
+
     button_selected_color: str = GUIConstants.ACCENT_COLOR
 
     # Params for version of list used for Settings
@@ -554,8 +558,12 @@ class ButtonListScreen(BaseTopNavScreen):
 @dataclass
 class LargeButtonScreen(BaseTopNavScreen):
     button_data: list = None
+
+    # Cannot define these class attrs w/the get_*_font_*() methods because the attrs will
+    # not be dynamically reinterpreted after initial class import.
     button_font_name: str = None
     button_font_size: int = None
+
     button_selected_color: str = GUIConstants.ACCENT_COLOR
     selected_button: int = 0
 
@@ -563,6 +571,7 @@ class LargeButtonScreen(BaseTopNavScreen):
         if not self.button_font_name:
             self.button_font_name = GUIConstants.get_button_font_name()
         if not self.button_font_size:
+            # TODO: Define the +2 with a constant or via a formula (e.g. int(x * 1.1))
             self.button_font_size = GUIConstants.get_button_font_size() + 2
 
         super().__post_init__()

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -183,7 +183,12 @@ def generate_screenshots(locale):
             if settings_entry.visibility == SettingsConstants.VISIBILITY__HIDDEN:
                 continue
 
-            settings_views_list.append(ScreenshotConfig(settings_views.SettingsEntryUpdateSelectionView, dict(attr_name=settings_entry.attr_name), screenshot_name=f"SettingsEntryUpdateSelectionView_{settings_entry.attr_name}"))
+            if settings_entry.attr_name == SettingsConstants.SETTING__LOCALE:
+                # Locale selection has its own dedicated View
+                settings_views_list.append(ScreenshotConfig(settings_views.LocaleSelectionView))
+            else:
+                # Generic SettingsEntry selection View
+                settings_views_list.append(ScreenshotConfig(settings_views.SettingsEntryUpdateSelectionView, dict(attr_name=settings_entry.attr_name), screenshot_name=f"SettingsEntryUpdateSelectionView_{settings_entry.attr_name}"))
 
         settingsqr_data_persistent = f"settings::v1 name=English_noob_mode persistent=E coords=spa,spd denom=thr network=M qr_density=M xpub_export=E sigs=ss scripts=nat xpub_details=E passphrase=E camera=0 compact_seedqr=E bip85=D priv_warn=E dire_warn=E partners=E locale={locale}"
         settingsqr_data_not_persistent = f"settings::v1 name=Mode_Ephemeral persistent=D coords=spa,spd denom=thr network=M qr_density=M xpub_export=E sigs=ss scripts=nat xpub_details=E passphrase=E camera=0 compact_seedqr=E bip85=D priv_warn=E dire_warn=E partners=E locale={locale}"

--- a/tests/test_flows_l10n.py
+++ b/tests/test_flows_l10n.py
@@ -13,7 +13,6 @@ from seedsigner.views.view import MainMenuView
 class TestL10nFlows(FlowTest):
     def test_change_locale(self):
         settings_entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__LOCALE)
-        spanish_display_name = SettingsConstants.ALL_LOCALES[SettingsConstants.LOCALE__SPANISH]
 
         # Initially we get English
         assert _(MainMenuView.SCAN.button_label) == "Scan"


### PR DESCRIPTION
## Bug Description
TopNav titles are not correctly rendering when an Asian language is selected.

![MainMenuView](https://github.com/user-attachments/assets/9783304d-5eb1-4434-9577-1db23ef31b49) ![MainMenuView](https://github.com/user-attachments/assets/170f0ed5-91f4-41fe-b2b4-f5e9a54844a6) ![MainMenuView](https://github.com/user-attachments/assets/91ad95c0-1a67-4f17-84e8-bb50cfc77926)

This is because the TopNav's default title font/size class attrs are being set via dynamic methods:
```python
    font_name: str = GUIConstants.get_top_nav_title_font_name()
    font_size: int = GUIConstants.get_top_nav_title_font_size()
```

But such class-level attrs are only interpreted once when the class is first imported. Subsequent instantiations of the class do NOT re-evaluate those values; the `get_*_font_*()` methods are not re-run. This is exhibited in the screenshot generator which initially defaults to English when the class is imported. So the correct Asian font is never made available after the locale switch.

When I rebased some l10n-related changes for a now-merged PR, I'm pretty sure I messed this up. I knew to watch out for this at one point but then forgot.


## This PR
Simple fix for the class attrs. Also adds comments wherever necessary to remind us that the class attrs are not re-evaluated.

![MainMenuView](https://github.com/user-attachments/assets/dbae9ea7-56f5-42a1-bfc6-47e5a30a004f) ![MainMenuView](https://github.com/user-attachments/assets/e9e2932c-81d3-4f0c-a6d5-d15417b50bf5) ![MainMenuView](https://github.com/user-attachments/assets/a1f66bd6-c9d1-4baf-b99e-23b4aad66fc9)


## Secondary bug
The screenshot generator was not rendering the `LocaleSelectionView` but (somewhat confusingly) was rendering locale selection using the generic `SettingsEntryUpdateSelectionView`. So there WAS a screenshot for locale selection but it was not going through the code that actually presents locale selection in normal use.

This fix is included here since at first it looked like the same bug as above; note the placeholder boxes for Korean and Chinese:
![SettingsEntryUpdateSelectionView_locale](https://github.com/user-attachments/assets/18a78ae2-05a0-4c88-a1a9-32fa4ef68364)

...but turned out to be its own bug in what we were asking the screenshot generator to do.

![LocaleSelectionView](https://github.com/user-attachments/assets/d155962e-2c35-405c-907d-c94cebcb5e01)

Since there was some other misc cleanup, this turned into a minor l10n catch-all cleanup PR. Also includes:
* `tests/test_flows_l10n.py`: removed unreferenced var.

---

This pull request is categorized as a:
- [x] Bug fix

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
