### PR TITLE
[New Feature] Multi-resolution screenshot generator

### DIFF
--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -1,9 +1,7 @@
 from PIL import Image, ImageDraw
 from threading import Lock
 
-# from seedsigner.hardware.st7789_mpy import ST7789
 from seedsigner.hardware.displays.display_driver import ALL_DISPLAY_TYPES, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486, DISPLAY_TYPE__ST7789, DisplayDriver
-from seedsigner.hardware.displays.ili9341 import ILI9341, ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.models.singleton import ConfigurableSingleton

--- a/src/seedsigner/hardware/displays/display_driver.py
+++ b/src/seedsigner/hardware/displays/display_driver.py
@@ -1,14 +1,17 @@
 DISPLAY_TYPE__ST7789 = "st7789"
 DISPLAY_TYPE__ILI9341 = "ili9341"
 DISPLAY_TYPE__ILI9486 = "ili9486"
-
 ALL_DISPLAY_TYPES = [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486]
 
 
+
 class DisplayDriver:
-    def __init__(self, display_type: str = DISPLAY_TYPE__ST7789, width: int = None, height: int = None):
-        if display_type not in ALL_DISPLAY_TYPES:
-            raise ValueError(f"Invalid display type: {display_type}")
+    def __init__(self, display_type: str = DISPLAY_TYPE__ST7789, width: int = 240, height: int = 240):
+        from seedsigner.models.settings_definition import SettingsConstants
+
+        display_config = f"{display_type}_{width}x{height}"
+        if display_config not in [x for x,_ in SettingsConstants.ALL_DISPLAY_CONFIGURATIONS]:
+            raise ValueError(f"Invalid display config: {display_config}")
         self.display_type = display_type
 
         if self.display_type == DISPLAY_TYPE__ST7789:

--- a/tests/run_full_coverage.sh
+++ b/tests/run_full_coverage.sh
@@ -7,8 +7,9 @@ coverage erase
 # (otherwise it'll be overwritten in the next step)
 coverage run --parallel -m pytest
 
-# Generate screenshots (only need to run for one locale to assess coverage)
-coverage run --parallel -m pytest tests/screenshot_generator/generator.py --locale es
+# Generate screenshots (only need to run for one locale+resolution to assess coverage)
+# TODO: No longer completely true with certain language-specific logic (e.g. TextArea line breaking for Asian languages)
+coverage run --parallel -m pytest tests/screenshot_generator/generator.py --locale es --resolution 240x240
 
 # Combine the above coverage results
 coverage combine

--- a/tests/screenshot_generator/conftest.py
+++ b/tests/screenshot_generator/conftest.py
@@ -1,11 +1,36 @@
 import pytest
 
+from seedsigner.models.settings_definition import SettingsConstants
+
 
 
 def pytest_addoption(parser):
     parser.addoption("--locale", action="store", default=None)
+    parser.addoption("--resolution", action="store", default=None, help="Render at a specific width and height; enter as \"320x240\", \"480x320\", etc.")
+    parser.addoption("--no-clean", action="store_true", help="Do not wipe the screenshots directory before running tests.")
 
 
 @pytest.fixture(scope='session')
 def target_locale(request):
+    locale = request.config.option.locale
+    if locale and locale not in [lc for lc,_ in SettingsConstants.get_detected_languages()]:
+        pytest.fail(f"Invalid --locale: \"{locale}\". Must be one of {', '.join(sorted([lc for lc,_ in SettingsConstants.get_detected_languages()]))}")
+
     return request.config.option.locale
+
+
+@pytest.fixture(scope='session')
+def target_resolution(request):
+    resolution = request.config.option.resolution
+    if resolution is None:
+        return None
+    try:
+        resolution_dims = resolution.split("x")
+        return (int(resolution_dims[0]), int(resolution_dims[1]))
+    except Exception:
+        pytest.fail(f"Invalid --resolution: {target_resolution}. Must be in the form \"WIDTHxHEIGHT\" (e.g. 320x240)")
+
+
+@pytest.fixture(scope='session')
+def no_clean(request):
+    return request.config.getoption("--no-clean")

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -1,4 +1,8 @@
-from dataclasses import dataclass
+"""
+Run `pytest tests/screenshot_generator/generator.py -h` and see the "custom options"
+section for the screenshot generator options.
+"""
+import shutil
 import embit
 import pathlib
 import pytest
@@ -6,6 +10,7 @@ import os
 import random
 import sys
 import time
+from dataclasses import dataclass
 from unittest.mock import Mock, patch, MagicMock
 from PIL import ImageFont
 
@@ -24,7 +29,6 @@ sys.modules['seedsigner.hardware.camera'] = MagicMock()
 sys.modules['seedsigner.hardware.microsd'] = MagicMock()
 
 from seedsigner.controller import Controller
-from seedsigner.gui.components import GUIConstants
 from seedsigner.gui.renderer import Renderer
 from seedsigner.gui.screens.screen import BaseScreen
 from seedsigner.gui.screens.seed_screens import SeedAddPassphraseScreen
@@ -48,23 +52,142 @@ from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
 import warnings; warnings.warn = lambda *args, **kwargs: None
 
-# Dynamically generate a pytest test run for each locale
-@pytest.mark.parametrize("locale", [x for x, y in SettingsConstants.get_detected_languages()])
-def test_generate_all(locale, target_locale):
-    """
-    `target_locale` is a fixture created in conftest.py via the `--locale` command line arg.
 
-    Optionally skips all other locales.
+SCREENSHOT_ROOT = os.path.join(os.getcwd(), "seedsigner-screenshots")
+
+
+
+class TestRunScreenshotGenerator:
     """
-    if target_locale and locale != target_locale:
-        pytest.skip(f"Skipping {locale}")
+        The screenshot generator is built on top of pytest functionality so we need the
+        usual "class Test*" and "def test_*" naming convention here.
+        But to be clear: this code is NOT testing the screenshot generator, it IS the
+        screenshot generator!
+    """
+    @classmethod
+    def setup_class(cls):
+        # class-level state vars to preserve info across multiple screenshot generation
+        # invocations within a given run.
+        cls.locale_combos = {}
+        cls.have_cleaned_screenshots_dir = False
     
-    if not ImageFont.core.HAVE_RAQM:
-        # We can't generate pixel-perfect screenshots that match what gets rendered on
-        # the device if we don't have libraqm.
-        pytest.fail("libraqm is not installed.")
-    
-    generate_screenshots(locale)
+
+    @classmethod
+    def add_locale_combo(cls, locale: str, width: int, height: int):
+        """
+        Add a locale + resolution combo to the class-level state. This is used to
+        generate the README.md file at the end of the test run.
+        """
+        if locale not in cls.locale_combos:
+            cls.locale_combos[locale] = []
+        cls.locale_combos[locale].append((width, height))
+
+
+    @classmethod
+    def clean_screenshots_dir(cls, no_clean: bool):
+        """
+        State management has to be at the class level in order to properly retain state
+        across instantiations throughout the run.
+        """
+        # Ensure we only clean ONCE or not at all if `no_clean`.
+        if cls.have_cleaned_screenshots_dir or no_clean:
+            return
+
+        # Wipe all subdirs and files from the screenshots directory
+        if os.path.exists(SCREENSHOT_ROOT):
+            for subdir in [f.path for f in os.scandir(SCREENSHOT_ROOT) if f.is_dir()]:
+                shutil.rmtree(subdir)
+        else:
+            os.makedirs(SCREENSHOT_ROOT)
+        cls.have_cleaned_screenshots_dir = True
+
+
+    # Dynamically generate a pytest test run for each locale
+    @pytest.mark.parametrize("locale", [x for x, y in SettingsConstants.get_detected_languages()])
+    def test_generate_screenshots(self, locale: str, target_locale: str, target_resolution: tuple[int,int], no_clean: bool):
+        """
+        Generate screenshots for the given locale. In typical usage this will be run
+        multiple times for various locales.
+
+        The following fixture options are defined in conftest.py:
+        * `target_locale: Optionally skips all other locales.
+        * `target_resolution`: Renders screenshots at the given resolution, whether that
+            resolution is normally supported or not. Note that the default 240x240 is
+            always rendered, regardless of this option.
+        * `no_clean`: If set, the test will not delete the screenshots directory before
+            generating new screenshots.
+        """
+        if target_locale and locale != target_locale:
+            pytest.skip(f"Skipping {locale}")
+
+        if not ImageFont.core.HAVE_RAQM:
+            # We can't generate pixel-perfect screenshots that match what gets rendered on
+            # the device if we don't have libraqm.
+            pytest.fail("libraqm is not installed.")
+
+        TestRunScreenshotGenerator.clean_screenshots_dir(no_clean)
+
+        # By rule, always render our baseline 240x240
+        resolutions = set([(240, 240)])
+
+        if target_resolution:
+            # We're only going to add the target resolution provided at the command line
+            resolutions.add(target_resolution)
+        else:
+            # Add all supported resolutions
+            for display_config in SettingsConstants.ALL_DISPLAY_CONFIGURATIONS:
+                resolution_str = display_config[0].split("_")[1]
+                width, height = resolution_str.split("x")
+                resolutions.add((int(width), int(height)))
+
+        # Prevent the Renderer from trying to instantiate the hardware display driver
+        Renderer.configure_instance = Mock()
+
+        for width, height in resolutions:
+            ScreenshotRenderer.configure_instance(width=width, height=height)
+            screenshot_renderer = ScreenshotRenderer.get_instance()
+
+            # Patch the Renderer so that the ScreenshotRenderer is used instead
+            with patch.object(Renderer, 'get_instance') as mock_get_instance:
+                mock_get_instance.return_value = screenshot_renderer
+                generate_screenshots(locale, width, height)
+            
+            # Keep track of which locale + resolution combos we've rendered
+            TestRunScreenshotGenerator.add_locale_combo(locale, width, height)
+
+
+    @classmethod
+    def teardown_class(cls):
+        # Write the final README that links to all the locale+resolution screenshots
+        with open(os.path.join("tests", "screenshot_generator", "template.md"), 'r') as readme_template:
+            main_readme = readme_template.read()
+
+            # Extract the locales we just generated screenshots for and sort by
+            # human-readable name; separately sort beta locales at the end.
+            locales_tuples = []
+            beta_locales_tuples = []
+            for language_code in cls.locale_combos.keys():
+                display_name = SettingsConstants.ALL_LOCALES.get(language_code, language_code)
+                if "(beta)" in display_name:
+                    beta_locales_tuples.append((language_code, display_name))
+                else:
+                    locales_tuples.append((language_code, display_name))
+
+            locales_tuples.sort(key=lambda x: x[1])
+            beta_locales_tuples.sort(key=lambda x: x[1])
+
+            for locale, locale_name in locales_tuples + beta_locales_tuples:
+                main_readme += f"* {locale_name}: "
+                # Link to each resolution generated for this locale
+                for i, (width, height) in enumerate(sorted(cls.locale_combos[locale])):
+                    resolution = f"{width}x{height}"
+                    if i > 0:
+                        main_readme += " | "
+                    main_readme += f"[{resolution}]({locale}/{resolution}/README.md)"
+                main_readme += "\n"
+
+        with open(os.path.join(SCREENSHOT_ROOT, "README.md"), 'w') as readme_file:
+            readme_file.write(main_readme)
 
 
 
@@ -133,22 +256,10 @@ class SeedExportXpubQR_ScreenBrightnessView(seed_views.SeedExportXpubQRDisplayVi
 
 
 
-def generate_screenshots(locale):
+def generate_screenshots(locale:str, width:int, height:int):
     """
-        The `Renderer` class is mocked so that calls in the normal code are ignored
-        (necessary to avoid having it trying to wire up hardware dependencies).
-
-        When the `Renderer` instance is needed, we patch in our own test-only
-        `ScreenshotRenderer`.
     """
-    # Prep the ScreenshotRenderer that will be patched over the normal Renderer
-    screenshot_root = os.path.join(os.getcwd(), "seedsigner-screenshots")
-    ScreenshotRenderer.configure_instance()
-    screenshot_renderer: ScreenshotRenderer = ScreenshotRenderer.get_instance()
-
-    # Replace the core `Singleton` calls so that only our ScreenshotRenderer is used.
-    Renderer.configure_instance = Mock()
-    Renderer.get_instance = Mock(return_value=screenshot_renderer)
+    resolution = f"{width}x{height}"
 
 
     def setup_screenshots(locale: str) -> dict[str, list[ScreenshotConfig]]:
@@ -429,7 +540,8 @@ def generate_screenshots(locale):
         # we were occasionally running into confusing race conditions where the next
         # screenshot would begin rendering over the previous one. Claiming the lock
         # guarantees that the previous screenshot has been fully rendered and saved.
-        with screenshot_renderer.lock:
+        screenshot_renderer = ScreenshotRenderer.get_instance()
+        with ScreenshotRenderer.lock:
             screenshot_renderer.set_screenshot_filename(f"{screenshot_config.screenshot_name}.png")
 
         controller = Controller.get_instance()
@@ -480,11 +592,12 @@ def generate_screenshots(locale):
     if not locale_tuple_list:
         raise Exception(f"Invalid locale: {locale}")
 
-    locale, display_name = locale_tuple_list[0]
+    locale, locale_display_name = locale_tuple_list[0]
 
     Settings.get_instance().set_value(SettingsConstants.SETTING__LOCALE, value=locale)
 
-    locale_readme = f"""# SeedSigner Screenshots: {display_name}\n"""
+    locale_readme = f"""# SeedSigner Screenshots: {locale_display_name}\n"""
+    locale_readme += f"Resolution: {resolution}\n\n"
 
     # Report the translation progress
     if locale != SettingsConstants.LOCALE__ENGLISH:
@@ -503,7 +616,7 @@ def generate_screenshots(locale):
 
     for section_name, screenshot_list in setup_screenshots(locale).items():
         subdir = section_name.lower().replace(" ", "_")
-        screenshot_renderer.set_screenshot_path(os.path.join(screenshot_root, locale, subdir))
+        ScreenshotRenderer.get_instance().set_screenshot_path(os.path.join(SCREENSHOT_ROOT, locale, resolution, subdir))
         locale_readme += "\n\n---\n\n"
         locale_readme += f"## {section_name}\n\n"
         locale_readme += """<table style="border: 0;">"""
@@ -516,20 +629,7 @@ def generate_screenshots(locale):
 
         locale_readme += "</td></tr></table>"
 
-    with open(os.path.join(screenshot_root, locale, "README.md"), 'w') as readme_file:
+    with open(os.path.join(SCREENSHOT_ROOT, locale, resolution, "README.md"), 'w') as readme_file:
         readme_file.write(locale_readme)
 
-    print(f"Done with locale: {locale}.")
-
-    # Write the main README; ensure it writes all locales, not just the one that may
-    # have been specified for this run.
-    with open(os.path.join("tests", "screenshot_generator", "template.md"), 'r') as readme_template:
-        main_readme = readme_template.read()
-
-    for locale, display_name in SettingsConstants.get_detected_languages():
-        main_readme += f"* [{display_name}]({locale}/README.md)\n"
-
-    with open(os.path.join(screenshot_root, "README.md"), 'w') as readme_file:
-        readme_file.write(main_readme)
-
-    print(f"Screenshots rendered: {screenshot_renderer.render_count}")
+    print(f"Done with locale: {locale} @ {resolution}.")

--- a/tests/screenshot_generator/template.md
+++ b/tests/screenshot_generator/template.md
@@ -2,9 +2,9 @@
 
 SeedSigner screenshots can be freely used in any tutorial, article, video, etc. As a courtesy, please link back to this repo or the SeedSigner website in your attribution.
 
-![](en/main_menu_views/MainMenuView.png) ![](en/psbt_views/PSBTOverviewView.png)
+![](en/240x240/main_menu_views/MainMenuView.png) ![](en/240x240/psbt_views/PSBTOverviewView.png)
 
-![](en/seed_views/SeedOptionsView.png) ![](en/tools_views/ToolsMenuView.png)
+![](en/240x240/seed_views/SeedOptionsView.png) ![](en/240x240/tools_views/ToolsMenuView.png)
 
 
 ## Generating screenshots

--- a/tests/screenshot_generator/utils.py
+++ b/tests/screenshot_generator/utils.py
@@ -27,14 +27,13 @@ class ScreenshotRenderer(Renderer):
         return True
 
     @classmethod
-    def configure_instance(cls):
+    def configure_instance(cls, width:int = 240, height:int = 240):
         # Instantiate the one and only Renderer instance
         renderer = cls.__new__(cls)
         cls._instance = renderer
 
-        # Hard-coding output values for now
-        renderer.canvas_width = 240
-        renderer.canvas_height = 240
+        renderer.canvas_width = width
+        renderer.canvas_height = height
 
         renderer.canvas = Image.new('RGB', (renderer.canvas_width, renderer.canvas_height))
         renderer.draw = ImageDraw.Draw(renderer.canvas)


### PR DESCRIPTION
## Overview
Adds support for generating screenshots beyond our original 240x240 resolution.
* Automatically adds all supported display resolutions found in `SettingsConstants`.
* Adds a `--resolution` command line option to render any new arbitrary resolution. Note that our baseline 240x240 resolution is always rendered, regardless of this option.
* Adds a `--no-clean` option to prevent wiping out the screenshots dir before generating.
* Minor refactor in `generator.py` to treat it as a class-based test case. This provides a clear universal setup/teardown, regardless of how many screenshot combinations (locale @ resolution) are generated.

---

The default run will generate all languages at all supported resolutions (as defined in Settings):

<img width="617" height="395" alt="Screenshot 2025-10-24 at 9 02 55 AM" src="https://github.com/user-attachments/assets/1279f8f4-c0c9-4b19-b6c1-d3946110fdd8" />

---

<img width="320" height="240" alt="MainMenuView-1" src="https://github.com/user-attachments/assets/eb27a145-d013-48a3-9ed7-b13725011d82" />
<img width="320" height="240" alt="PSBTOverviewView-1" src="https://github.com/user-attachments/assets/54497510-dc2b-4387-9c5e-ae7c454f5b65" />

---

Custom / arbitrary resolutions can also be specified at the command line:
```bash
pytest tests/screenshot_generator/generator.py --locale=en --resolution=640x480
```
<img width="569" height="151" alt="Screenshot 2025-10-24 at 9 10 19 AM" src="https://github.com/user-attachments/assets/f850b17f-8046-4ee2-870e-9cb453594b1a" />

<img width="640" height="480" alt="MainMenuView-2" src="https://github.com/user-attachments/assets/c4364573-1a5f-4bcc-a39e-eca1dd64d299" />

🤣 Well, if nothing else it lets us see just how much work will be needed whenever we're ready to scale up our supported screen resolution!

---

# Discussion items
* I needed to be able to track state in the screenshot generator across individual locale / resolution invocations within a given run. Now that it's been refactored into a class based test, I opted to use some slightly hack-y class-level attrs for that state management (`locale_combos`, `have_cleaned_screenshots_dir`). I can't decide if it's clever, ugly, or somewhere inbetween.

* Default behavior: clean the screenshots dir. Many times in the past I've been confused by a screenshot that turned out to just be stale that wasn't part of the most recent run. But on the flip side, there have definitely been times when I found it convenient to keep prior screenshots around (e.g. screenshots for a new locale I'm testing), even if they did risk becoming a bit stale. So the `--no-clean` option gives us flexibility. But either way, the final README will only link up the screenshots from that particular run.


## Future TODO items
* For (my) convenience I would prefer to eventually default the screenshot generation run to only generate English @ 240x240. But add an option like `--all` to do all langages @ all resolutions for other automations. Existing options can already be used to specify any target language at any target resolution. So we'd retain full flexibility. It's just that right now in my local dev I'm constantly providing `--locale=en` to limit the amount generated.
* As we get deeper into supporting a wider variety of screens, it'll be easier to figure out how to clean up the slightly half-baked organizational overlap between `SettingsConstants.ALL_DISPLAY_CONFIGURATIONS` and the `display_driver.ALL_DISPLAY_TYPES` constants. It's currently a little redundant but it's not horrible enough to need refactoring right now.

* The final README hard codes four of the English 240x240 screenshots to enhance the README's presentation. But the `--locale` option plus the default dir clean means that those screenshots aren't guaranteed to exist. A future enhancement would be to make those preview embeds dynamic.

* Presentation bug at wider resolutions on the new Screen Brightness tip during QR code display:

<img width="320" height="240" alt="SeedExportXpubQR_ScreenBrightnessView" src="https://github.com/user-attachments/assets/47ba4759-a467-4eb6-87b9-948588e9c293" />


---

This pull request is categorized as a:
- [x] New feature

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: screenshot generator is only meant to run in local dev