### PR TITLE
[Enhancement] Camera connection errors: Provide better error message

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -60,7 +60,7 @@ class BackgroundImportThread(BaseThread):
         def time_import(module_name):
             last = time.time()
             import_module(module_name)
-            # print(time.time() - last, module_name)
+            logger.debug(f"{time.time() - last:0.4f}: {module_name}")
 
         time_import('embit')
         time_import('seedsigner.helpers.embit_utils')
@@ -69,6 +69,9 @@ class BackgroundImportThread(BaseThread):
         time_import('seedsigner.models.seed_storage')
         from seedsigner.models.seed_storage import SeedStorage
         Controller.get_instance()._storage = SeedStorage()
+
+        time_import('numpy')  # used by PiVideoStream; by far the slowest import (2.29s)
+        time_import('seedsigner.hardware.pivideostream') 
 
         # Get MainMenuView ready to respond quickly
         time_import('seedsigner.views.scan_views')

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -60,7 +60,7 @@ class BackgroundImportThread(BaseThread):
         def time_import(module_name):
             last = time.time()
             import_module(module_name)
-            logger.debug(f"{time.time() - last:0.4f}: {module_name}")
+            # print(f"{time.time() - last:0.4f}: {module_name}")
 
         time_import('embit')
         time_import('seedsigner.helpers.embit_utils')
@@ -75,11 +75,8 @@ class BackgroundImportThread(BaseThread):
 
         # Get MainMenuView ready to respond quickly
         time_import('seedsigner.views.scan_views')
-
         time_import('seedsigner.views.seed_views')
-
         time_import('seedsigner.views.tools_views')
-
         time_import('seedsigner.views.settings_views')
 
 

--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -40,7 +40,6 @@ class Camera(Singleton):
             self._video_stream.start()
         except PiCameraError:
             # This error most often occurs because the camera connection is loose
-            from seedsigner.hardware.camera import CameraConnectionError
             raise CameraConnectionError()
 
 
@@ -74,7 +73,6 @@ class Camera(Singleton):
             self._picamera.start_preview()
         except PiCameraError:
             # This error most often occurs because the camera connection is loose
-            from seedsigner.hardware.camera import CameraConnectionError
             raise CameraConnectionError()
 
 

--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -1,9 +1,17 @@
 import io
 
+from gettext import gettext as _
 from PIL import Image
-from seedsigner.hardware.pivideostream import PiVideoStream
+
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.singleton import Singleton
+
+
+
+class CameraConnectionError(Exception):
+    def __init__(self, *args, **kwargs):
+        message = _("Camera error. Check camera connections.")
+        super().__init__(message)
 
 
 
@@ -22,12 +30,18 @@ class Camera(Singleton):
 
 
     def start_video_stream_mode(self, resolution=(512, 384), framerate=12, format="bgr"):
+        from picamera import PiCameraError
         from seedsigner.hardware.pivideostream import PiVideoStream
         if self._video_stream is not None:
             self.stop_video_stream_mode()
 
-        self._video_stream = PiVideoStream(resolution=resolution,framerate=framerate, format=format)
-        self._video_stream.start()
+        try:
+            self._video_stream = PiVideoStream(resolution=resolution,framerate=framerate, format=format)
+            self._video_stream.start()
+        except PiCameraError:
+            # This error most often occurs because the camera connection is loose
+            from seedsigner.hardware.camera import CameraConnectionError
+            raise CameraConnectionError()
 
 
     def read_video_stream(self, as_image=False):
@@ -49,14 +63,19 @@ class Camera(Singleton):
 
 
     def start_single_frame_mode(self, resolution=(720, 480)):
-        from picamera import PiCamera
+        from picamera import PiCamera, PiCameraError
         if self._video_stream is not None:
             self.stop_video_stream_mode()
         if self._picamera is not None:
             self._picamera.close()
 
-        self._picamera = PiCamera(resolution=resolution, framerate=24)
-        self._picamera.start_preview()
+        try:
+            self._picamera = PiCamera(resolution=resolution, framerate=24)
+            self._picamera.start_preview()
+        except PiCameraError:
+            # This error most often occurs because the camera connection is loose
+            from seedsigner.hardware.camera import CameraConnectionError
+            raise CameraConnectionError()
 
 
     def capture_frame(self):

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -223,7 +223,7 @@ class ScanInvalidQRTypeView(View):
             title=_("Error"),
             status_headline=_("Unknown QR Type"),
             text=_("QRCode is invalid or is a data format not yet supported."),
-            button_data=[ButtonOption("Done")],
+            button_data=[ButtonOption("Back to Main Menu")],
         )
 
         return Destination(MainMenuView, clear_history=True)

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -368,6 +368,7 @@ class UnhandledExceptionView(View):
             title=_("System Error"),
             status_headline=self.error[0],
             text=self.error[1] + "\n" + self.error[2],
+            button_data=[ButtonOption("Back to Main Menu")],
             allow_text_overflow=True,  # Fit what we can, let the rest go off the edges
         )
         

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -362,6 +362,20 @@ class NetworkMismatchErrorView(ErrorView):
 class UnhandledExceptionView(View):
     error: list[str]
 
+    def __post_init__(self):
+        from seedsigner.hardware.camera import CameraConnectionError
+        super().__post_init__()
+
+        # Camera errors bubble up to here. Reroute to their custom error View.
+        if self.error[0] == CameraConnectionError.__name__:
+            self.set_redirect(
+                Destination(
+                    CameraConnectionErrorView,
+                    skip_current_view=True,
+                )
+            )
+
+
     def run(self):
         self.run_screen(
             ErrorScreen,
@@ -374,6 +388,21 @@ class UnhandledExceptionView(View):
         
         return Destination(MainMenuView, clear_history=True)
 
+
+
+@dataclass
+class CameraConnectionErrorView(View):
+    def run(self):
+        self.run_screen(
+            ErrorScreen,
+            title=_("Hardware Error"),
+            status_headline=_("Cannot access camera"),
+            text=_("Disconnect power and check for a loose camera connection."),
+            button_data=[ButtonOption("Back to Main Menu")],
+            show_back_button=False,
+        )
+
+        return Destination(MainMenuView, clear_history=True)
 
 
 @dataclass

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -408,7 +408,7 @@ class CameraConnectionErrorView(View):
 @dataclass
 class OptionDisabledView(View):
     UPDATE_SETTING = ButtonOption("Update setting")
-    DONE = ButtonOption("Done")
+    DONE = ButtonOption("Back to Main Menu")
     settings_attr: str
 
     def __post_init__(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,7 @@ sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
 sys.modules['seedsigner.gui.toast'] = MagicMock()
 sys.modules['seedsigner.views.screensaver'] = MagicMock()
 sys.modules['seedsigner.hardware.buttons'] = MagicMock()
-sys.modules['seedsigner.hardware.camera'] = MagicMock()
+sys.modules['seedsigner.hardware.camera.Camera'] = MagicMock()
 sys.modules['seedsigner.hardware.st7789_mpy'] = MagicMock()
 sys.modules['seedsigner.hardware.ili9341'] = MagicMock()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,12 +5,14 @@ from typing import Callable
 
 # Prevent importing modules w/Raspi hardware dependencies.
 # These must precede any SeedSigner imports.
+sys.modules['numpy'] = MagicMock()  # numpy is only in the Raspi requirements; not needed for tests. But is imported in BackgroundImportThread.
 sys.modules['seedsigner.gui.renderer'] = MagicMock()
 sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
 sys.modules['seedsigner.gui.toast'] = MagicMock()
 sys.modules['seedsigner.views.screensaver'] = MagicMock()
 sys.modules['seedsigner.hardware.buttons'] = MagicMock()
 sys.modules['seedsigner.hardware.camera.Camera'] = MagicMock()
+sys.modules['seedsigner.hardware.pivideostream'] = MagicMock()
 sys.modules['seedsigner.hardware.st7789_mpy'] = MagicMock()
 sys.modules['seedsigner.hardware.ili9341'] = MagicMock()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,7 +18,7 @@ from seedsigner.controller import Controller, FlowBasedTestException, StopFlowBa
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON, ButtonOption
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.models.settings import Settings
-from seedsigner.views.view import Destination, MainMenuView, UnhandledExceptionView, View
+from seedsigner.views.view import Destination, MainMenuView, View
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -414,7 +414,7 @@ def generate_screenshots(locale):
             ],
             "Misc Error Views": [
                 ScreenshotConfig(NotYetImplementedView),
-                ScreenshotConfig(UnhandledExceptionView, dict(error=["IndexError", "line 1, in some_buggy_code.py", "list index out of range"])),
+                ScreenshotConfig(UnhandledExceptionView, dict(error=["CameraConnectionError", "camera.py, 44, in start_video_stream_mode", "Camera error. Check camera connection."])),
                 ScreenshotConfig(NetworkMismatchErrorView, dict(derivation_path="m/84'/1'/0'")),
                 ScreenshotConfig(OptionDisabledView, dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
                 ScreenshotConfig(scan_views.ScanInvalidQRTypeView)

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -20,7 +20,7 @@ sys.modules['seedsigner.hardware.displays.ili9341'] = MagicMock()
 sys.modules['seedsigner.views.screensaver.ScreensaverScreen'] = MagicMock()
 sys.modules['RPi'] = MagicMock()
 sys.modules['RPi.GPIO'] = MagicMock()
-sys.modules['seedsigner.hardware.camera'] = MagicMock()
+sys.modules['seedsigner.hardware.camera.Camera'] = MagicMock()
 sys.modules['seedsigner.hardware.microsd'] = MagicMock()
 
 from seedsigner.controller import Controller
@@ -42,7 +42,7 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
-from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView
+from seedsigner.views.view import CameraConnectionErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView
 
 from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
@@ -414,7 +414,8 @@ def generate_screenshots(locale):
             ],
             "Misc Error Views": [
                 ScreenshotConfig(NotYetImplementedView),
-                ScreenshotConfig(UnhandledExceptionView, dict(error=["CameraConnectionError", "camera.py, 44, in start_video_stream_mode", "Camera error. Check camera connection."])),
+                ScreenshotConfig(UnhandledExceptionView, dict(error=["IndexError", "line 1, in some_buggy_code.py", "list index out of range"])),
+                ScreenshotConfig(CameraConnectionErrorView),
                 ScreenshotConfig(NetworkMismatchErrorView, dict(derivation_path="m/84'/1'/0'")),
                 ScreenshotConfig(OptionDisabledView, dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
                 ScreenshotConfig(scan_views.ScanInvalidQRTypeView)

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -4,9 +4,11 @@ from unittest.mock import patch
 from base import FlowTest, FlowStep
 
 from seedsigner.gui.screens.screen import RET_CODE__POWER_BUTTON
+from seedsigner.hardware.camera import CameraConnectionError
 from seedsigner.models.settings import Settings
+from seedsigner.views.scan_views import ScanView
 from seedsigner.views.tools_views import ToolsCalcFinalWordNumWordsView, ToolsMenuView
-from seedsigner.views.view import MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View
+from seedsigner.views.view import CameraConnectionErrorView, MainMenuView, NotYetImplementedView, PowerOptionsView, PowerOffView, RestartView, UnhandledExceptionView, View
 
 
 
@@ -62,5 +64,22 @@ class TestViewFlows(FlowTest):
             FlowStep(ToolsMenuView, button_data_selection=ToolsMenuView.KEYBOARD),
             FlowStep(ToolsCalcFinalWordNumWordsView, screen_return_value=Exception("Test exception")),  # <-- force an exception
             FlowStep(UnhandledExceptionView),
+            FlowStep(MainMenuView),
+        ])
+
+
+    def test__camera_connection_error__flow(self):
+        """
+        Simulate a camera connection error and ensure that we get the
+        CameraConnectionErrorView.
+        """        
+        def raise_camera_connection_error(view: View):
+            raise CameraConnectionError()
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(ScanView, before_run=raise_camera_connection_error),
+            FlowStep(UnhandledExceptionView, is_redirect=True),
+            FlowStep(CameraConnectionErrorView),
             FlowStep(MainMenuView),
         ])

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -72,14 +72,15 @@ class TestViewFlows(FlowTest):
         """
         Simulate a camera connection error and ensure that we get the
         CameraConnectionErrorView.
-        """        
-        def raise_camera_connection_error(view: View):
-            raise CameraConnectionError()
+        """
+        # Force a camera exception during `ScanView.run()`
+        with patch('seedsigner.views.scan_views.ScanView.run') as mock_run:
+            mock_run.side_effect = CameraConnectionError()
 
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
-            FlowStep(ScanView, before_run=raise_camera_connection_error),
-            FlowStep(UnhandledExceptionView, is_redirect=True),
-            FlowStep(CameraConnectionErrorView),
-            FlowStep(MainMenuView),
-        ])
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(ScanView),
+                FlowStep(UnhandledExceptionView, is_redirect=True),
+                FlowStep(CameraConnectionErrorView),
+                FlowStep(MainMenuView),
+            ])


### PR DESCRIPTION
## The problem

When the camera cable is not properly / fully connected, any attempt to access the camera (live preview video, I/O test still image capture) results in this misleading error:

<img src="https://github.com/user-attachments/assets/2e99694e-abbb-463c-920a-26a257b605bb" width="400">


---

## This PR
* Explicitly handles the `PiCameraError` and shows a more useful error message via a new custom error handler `CameraConnectionErrorView`:

![CameraConnectionErrorView](https://github.com/user-attachments/assets/40b55729-453b-4856-a300-97570385d2a2)

* Adds a flow test to verify the exception routing to the above error view.
* Moves `seedsigner.hardware.pivideostream` import into the Controller's `BackgroundImportThread` to explicitly preload the slow import (~2.7s) during the opening splash screen. I can't discern any additional loading time effect on the startup / splash screen sequence (which itself has 3s of sleep built into it, not including the time it takes to run the fade in animation).
* Adds additional test suite `Mock`s to account for the Raspi-only `numpy` as well as the Raspi-only dependencies in `pivideostream`.

---

## Implementation note
The test suite and screenshot generator now extend the module mock:
```python
# before
sys.modules['seedsigner.hardware.camera'] = MagicMock()

# after
sys.modules['seedsigner.hardware.camera.Camera'] = MagicMock()
```

This is because the `UnhandledExceptionView` now tests for `CameraConnectionError.__name__` which will be unavailable if the original module mock as unchanged (the `seedsigner.hardware.camera.CameraConnectionError` class would be mocked out of existence and that View would throw an error when trying to access the now nonexistent error class's `__name__`).

---

## How to test
Boot a SeedSigner with its camera disconnected. Access any View that relies on camera data (e.g. "Scan" from Home, Load Seed via SeedQR, New Seed via image entropy, I/O test still image, etc).

---

## Misc:
Minor button label changes on error screens from "Done" or "I understand" to "Back to Main Menu":

![OptionDisabledView](https://github.com/user-attachments/assets/734d81cc-2bbb-438b-94da-e38111bdf9af) ![OptionDisabledView](https://github.com/user-attachments/assets/b32c7a4d-7232-4034-a798-4ed6ee3d2906)

![ScanInvalidQRTypeView](https://github.com/user-attachments/assets/1fe6b760-b903-431a-a820-a6cf7c213434) ![ScanInvalidQRTypeView](https://github.com/user-attachments/assets/a7c93787-37b4-491c-9147-89504054736f)

![UnhandledExceptionView](https://github.com/user-attachments/assets/8007b88d-efe3-4c03-bef0-4e96057ad1fb) ![UnhandledExceptionView](https://github.com/user-attachments/assets/70b51a46-c6f0-4792-82b5-9f4cdd468a86)



---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A; test suite cannot run hardware-level code

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board