### PR TITLE
Use PyPI version for urtypes lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ embit==0.8.0
 Pillow==10.0.1
 pyzbar @ git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03
 qrcode==7.3.1
-urtypes @ git+https://github.com/selfcustody/urtypes.git@7fb280eab3b3563dfc57d2733b0bf5cbc0a96a6a
+urtypes==1.0.1


### PR DESCRIPTION
Change `requirements.txt` to use https://github.com/selfcustody/urtypes PyPI version instead of github commit hash