### PR TITLE
[New screenshot] Brightness tip during QR display

### DIFF
--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -44,7 +44,7 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
-from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView, View
+from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView
 
 from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
@@ -262,8 +262,8 @@ def generate_screenshots(locale):
             controller.psbt_parser = PSBTParser(p=controller.psbt, seed=seed_12b)
 
 
-        # Mimic SeedExportXpubQRDisplayView calls in a light View + Screen so we can call
-        # `render_brightness_tip`.
+        # Wrap QRDisplayScreen's `render_brightness_tip` in a simple View + Screen so we
+        # can call it outside of its child thread and generate a screenshot.
         class SeedExportXpubQR_ScreenBrightnessView(seed_views.SeedExportXpubQRDisplayView):
             @dataclass
             class QRDisplayScreenBrightnessTipScreen(BaseScreen):

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -111,6 +111,26 @@ seed_24_w_passphrase = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9"
 MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFfsBrmpj226ZYiRszYi2qK6iGvh2vkkghfGB2YiRUVY4rqqedHCFEgw12FwDkm7rUoVtq9wLTKc6BN2sxswvQeQgp7m8st4FP8WtP8go76/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*))#3jhtf6yx"""
 
 
+# Wrap QRDisplayScreen's `render_brightness_tip` in a simple View + Screen so we
+# can call it outside of its child thread and generate a screenshot.
+class SeedExportXpubQR_ScreenBrightnessView(seed_views.SeedExportXpubQRDisplayView):
+    @dataclass
+    class QRDisplayScreenBrightnessTipScreen(BaseScreen):
+        qr_encoder: BaseQrEncoder = None
+
+        def _render(self):
+            from seedsigner.gui.screens.screen import QRDisplayScreen
+            image = self.qr_encoder.part_to_image(self.qr_encoder.cur_part(), 240, 240, border=2, background_color="white")
+            QRDisplayScreen.QRDisplayThread.render_brightness_tip(None, image)
+            self.renderer.show_image(image)
+
+    def run(self):
+        self.run_screen(
+            SeedExportXpubQR_ScreenBrightnessView.QRDisplayScreenBrightnessTipScreen,
+            qr_encoder=self.qr_encoder,  # initialized by SeedExportXpubQRDisplayView
+        )
+
+
 
 def generate_screenshots(locale):
     """
@@ -262,26 +282,6 @@ def generate_screenshots(locale):
             controller.psbt_parser = PSBTParser(p=controller.psbt, seed=seed_12b)
 
 
-        # Wrap QRDisplayScreen's `render_brightness_tip` in a simple View + Screen so we
-        # can call it outside of its child thread and generate a screenshot.
-        class SeedExportXpubQR_ScreenBrightnessView(seed_views.SeedExportXpubQRDisplayView):
-            @dataclass
-            class QRDisplayScreenBrightnessTipScreen(BaseScreen):
-                qr_encoder: BaseQrEncoder = None
-
-                def _render(self):
-                    from seedsigner.gui.screens.screen import QRDisplayScreen
-                    image = self.qr_encoder.part_to_image(self.qr_encoder.cur_part(), 240, 240, border=2, background_color="white")
-                    QRDisplayScreen.QRDisplayThread.render_brightness_tip(None, image)
-                    self.renderer.show_image(image)
-
-            def run(self):
-                self.run_screen(
-                    SeedExportXpubQR_ScreenBrightnessView.QRDisplayScreenBrightnessTipScreen,
-                    qr_encoder=self.qr_encoder,  # initialized by SeedExportXpubQRDisplayView
-                )
-
-
         screenshot_sections = {
             "Main Menu Views": [
                 ScreenshotConfig(OpeningSplashView, dict(is_screenshot_renderer=True, force_partner_logos=True)),
@@ -322,7 +322,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedExportXpubCoordinatorView, dict(seed_num=0, sig_type="ss", script_type="nat")),
                 ScreenshotConfig(seed_views.SeedExportXpubWarningView, dict(seed_num=0, sig_type="msig", script_type="nes", coordinator="spd", custom_derivation="")),
                 ScreenshotConfig(seed_views.SeedExportXpubDetailsView, dict(seed_num=0, sig_type="ss", script_type="nat", coordinator="bw", custom_derivation="")),
-                ScreenshotConfig(SeedExportXpubQR_ScreenBrightnessView, dict(seed_num=0, coordinator="bw", derivation_path="m/84'/1'/0'")),
+                ScreenshotConfig(SeedExportXpubQR_ScreenBrightnessView, dict(seed_num=0, coordinator="bw", derivation_path="m/84'/0'/0'")),
 
                 ScreenshotConfig(seed_views.SeedWordsWarningView, dict(seed_num=0)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed_num=0)),

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import embit
 import pathlib
 import pytest
@@ -27,12 +28,14 @@ patch('PIL.ImageFont.core.HAVE_RAQM', False).start()
 from seedsigner.controller import Controller
 from seedsigner.gui.components import GUIConstants
 from seedsigner.gui.renderer import Renderer
+from seedsigner.gui.screens.screen import BaseScreen
 from seedsigner.gui.screens.seed_screens import SeedAddPassphraseScreen
 from seedsigner.gui.toast import RemoveSDCardToastManagerThread, SDCardStateChangeToastManagerThread
 from seedsigner.gui.toast import DefaultToast, InfoToast, SuccessToast, WarningToast, ErrorToast, DireWarningToast
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.helpers import embit_utils
 from seedsigner.models.decode_qr import DecodeQR
+from seedsigner.models.encode_qr import BaseQrEncoder
 from seedsigner.models.psbt_parser import OPCODES, PSBTParser
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed
@@ -41,7 +44,7 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
-from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView
+from seedsigner.views.view import NetworkMismatchErrorView, OptionDisabledView, PowerOffView, View
 
 from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
@@ -259,6 +262,26 @@ def generate_screenshots(locale):
             controller.psbt_parser = PSBTParser(p=controller.psbt, seed=seed_12b)
 
 
+        # Mimic SeedExportXpubQRDisplayView calls in a light View + Screen so we can call
+        # `render_brightness_tip`.
+        class SeedExportXpubQR_ScreenBrightnessView(seed_views.SeedExportXpubQRDisplayView):
+            @dataclass
+            class QRDisplayScreenBrightnessTipScreen(BaseScreen):
+                qr_encoder: BaseQrEncoder = None
+
+                def _render(self):
+                    from seedsigner.gui.screens.screen import QRDisplayScreen
+                    image = self.qr_encoder.part_to_image(self.qr_encoder.cur_part(), 240, 240, border=2, background_color="white")
+                    QRDisplayScreen.QRDisplayThread.render_brightness_tip(None, image)
+                    self.renderer.show_image(image)
+
+            def run(self):
+                self.run_screen(
+                    SeedExportXpubQR_ScreenBrightnessView.QRDisplayScreenBrightnessTipScreen,
+                    qr_encoder=self.qr_encoder,  # initialized by SeedExportXpubQRDisplayView
+                )
+
+
         screenshot_sections = {
             "Main Menu Views": [
                 ScreenshotConfig(OpeningSplashView, dict(is_screenshot_renderer=True, force_partner_logos=True)),
@@ -299,7 +322,8 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedExportXpubCoordinatorView, dict(seed_num=0, sig_type="ss", script_type="nat")),
                 ScreenshotConfig(seed_views.SeedExportXpubWarningView, dict(seed_num=0, sig_type="msig", script_type="nes", coordinator="spd", custom_derivation="")),
                 ScreenshotConfig(seed_views.SeedExportXpubDetailsView, dict(seed_num=0, sig_type="ss", script_type="nat", coordinator="bw", custom_derivation="")),
-                #ScreenshotConfig(SeedExportXpubQRDisplayView),
+                ScreenshotConfig(SeedExportXpubQR_ScreenBrightnessView, dict(seed_num=0, coordinator="bw", derivation_path="m/84'/1'/0'")),
+
                 ScreenshotConfig(seed_views.SeedWordsWarningView, dict(seed_num=0)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed_num=0)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed_num=0, page_index=2), screenshot_name="SeedWordsView_2"),


### PR DESCRIPTION
## Description

![SeedExportXpubQR_ScreenBrightnessView](https://github.com/user-attachments/assets/45b1327f-3ab5-41d1-b24c-9d8633884fa6) ![SeedExportXpubQR_ScreenBrightnessView](https://github.com/user-attachments/assets/0a5684b9-fbc5-454c-b63a-538fcbf639ee)

---

Adds a missing screenshot we couldn't previously generate because it ran in a child thread that the screenshot generator couldn't handle.

---

This pull request is categorized as a:
- [x] Other

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: test suite and screenshot generator are meant to run in local dev.