### PR TITLE
[Refactor] [l10n] Remove `TextArea.allow_text_overflow` for improved localization / screenshot usability

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -722,7 +722,6 @@ class PSBTOpReturnScreen(ButtonListScreen):
                 text=self.op_return_data.decode(errors="strict"),  # "strict" is a good enough heuristic to decide if it's human readable
                 font_size=GUIConstants.get_top_nav_title_font_size(),
                 is_text_centered=True,
-                allow_text_overflow=True,
                 screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
                 height=self.buttons[0].screen_y - self.top_nav.height - 2*GUIConstants.COMPONENT_PADDING,
             ))

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -804,7 +804,6 @@ class QRDisplayScreen(BaseScreen):
                 width=int(rectangle_width/2),
                 screen_x=chevron_up_icon.screen_x + GUIConstants.ICON_INLINE_FONT_SIZE,
                 screen_y=chevron_up_icon.screen_y - 2,  # -2 to account for Icon's positioning
-                allow_text_overflow=False
             ).render()
 
             # TRANSLATOR_NOTE: Decrease QR code screen brightness
@@ -822,7 +821,6 @@ class QRDisplayScreen(BaseScreen):
                 width=int(rectangle_width/2),
                 screen_x=chevron_down_icon.screen_x + GUIConstants.ICON_INLINE_FONT_SIZE,
                 screen_y=chevron_down_icon.screen_y - 2,  # -2 to account for Icon's positioning
-                allow_text_overflow=False
             ).render()
 
             # Write our temp Image onto the main image
@@ -924,7 +922,6 @@ class LargeIconStatusScreen(ButtonListScreen):
     text: str = ""                          # The body text of the screen
     text_edge_padding: int = GUIConstants.EDGE_PADDING
     button_data: list = None
-    allow_text_overflow: bool = False
 
 
     def __post_init__(self):

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1129,7 +1129,6 @@ class SeedReviewPassphraseScreen(ButtonListScreen):
                 font_color="orange",
                 is_text_centered=True,
                 screen_y=screen_y,
-                allow_text_overflow=True
             ))
             screen_y += char_height + 2
 
@@ -1641,7 +1640,6 @@ class SeedSignMessageConfirmMessageScreen(ButtonListScreen):
                 text=self.sign_message_data["message"],
                 width=renderer.canvas_width - 2*GUIConstants.EDGE_PADDING,
                 height=message_height,
-                allow_text_overflow=True,
             )
             self.sign_message_data["paged_message"] = paged
 
@@ -1660,7 +1658,6 @@ class SeedSignMessageConfirmMessageScreen(ButtonListScreen):
         message_display = TextArea(
             text=self.sign_message_data["paged_message"][self.page_num],
             is_text_centered=False,
-            allow_text_overflow=True,
             screen_y=start_y,
         )
         self.components.append(message_display)

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -45,7 +45,6 @@ class ToastOverlay(BaseComponent):
             auto_line_break=True,
             width=self.canvas_width - icon_delta_x - 2 * GUIConstants.COMPONENT_PADDING - 2 * self.outline_thickness,
             screen_x=icon_delta_x + GUIConstants.COMPONENT_PADDING,
-            allow_text_overflow=False,
             height_ignores_below_baseline=True,
         )
         

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -382,7 +382,6 @@ class UnhandledExceptionView(View):
             status_headline=self.error[0],
             text=self.error[1] + "\n" + self.error[2],
             button_data=[ButtonOption("Back to Main Menu")],
-            allow_text_overflow=True,  # Fit what we can, let the rest go off the edges
         )
         
         return Destination(MainMenuView, clear_history=True)
@@ -429,7 +428,6 @@ class OptionDisabledView(View):
             text=self.error_msg,
             button_data=button_data,
             show_back_button=False,
-            allow_text_overflow=True,  # Fit what we can, let the rest go off the edges
         )
 
         if button_data[selected_menu_num] == self.UPDATE_SETTING:

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -528,7 +528,6 @@ class TestMessageSigningFlows(FlowTest):
             text=self.controller.sign_message_data["message"],
             width=240 - 2*GUIConstants.EDGE_PADDING,
             height=240 - GUIConstants.TOP_NAV_HEIGHT - 3*GUIConstants.EDGE_PADDING - GUIConstants.BUTTON_HEIGHT,
-            allow_text_overflow=True,
         )
         self.controller.sign_message_data["paged_message"] = paged
 


### PR DESCRIPTION
## The problem / background

The `TextArea.allow_text_overflow` param will intentionally raise an exception if set to `False` when the provided text does not fit within the TextArea dimensions.

The original idea was to immediately bring this to a developer's attention when building a new Screen.

But now in the era of l10n support, we have to assume that any text could inadvertently overflow, no matter how strict we think a particular part of a screen might need to be.

For example, the current Norweigian translations are erroring out of the screenshot generator for this exact reason:

```
Running SettingsEntryUpdateSelectionView_coordinators

...

  File "/Users/kdmukai/dev/seedsigner/tests/screenshot_generator/generator.py", line 416, in screencap_view
    screenshot_config.View_cls(**screenshot_config.view_kwargs).run()
  File "/Users/kdmukai/dev/seedsigner/src/seedsigner/views/settings_views.py", line 182, in run
    ret_value = self.run_screen(
  File "/Users/kdmukai/dev/seedsigner/src/seedsigner/views/view.py", line 112, in run_screen
    self.screen = Screen_cls(**kwargs)
  File "<string>", line 23, in __init__
  File "/Users/kdmukai/dev/seedsigner/src/seedsigner/gui/screens/settings_screens.py", line 35, in __post_init__
    self.components.append(TextArea(
  File "<string>", line 26, in __init__
  File "/Users/kdmukai/dev/seedsigner/src/seedsigner/gui/components.py", line 457, in __post_init__
    self.text_lines = reflow_text_for_width(
  File "/Users/kdmukai/dev/seedsigner/src/seedsigner/gui/components.py", line 1909, in reflow_text_for_width
    raise TextDoesNotFitException("Text cannot fit in target rect with this font+size")
seedsigner.gui.components.TextDoesNotFitException: Text cannot fit in target rect with this font+size
```

---

## Solution / rationale
Removing `allow_text_overflow` allows the screenshot to always be rendered, even if the resulting text layout is bad. It is then up to the developer or, more likely, the translator to adjust the text to fit (or open an Issue to say that more room should be created for that text).

Removing it also gives us the freedom to launch a translation as-is, even if the text doesn't quite fit but the spacing is deemed to be acceptable enough.

Most importantly, if this param remained AND if such an overflow exception happened on one of the few screens that doesn't have a screenshot (and if hands-on testing misses it as well), we wouldn't know beforehand that the screen will fail. However unlikely that all might be, end users would experience the exception in the UX, resulting in a showstopper bug for them for that language.


## Testing / side-effects
Removing the `allow_text_overflow` attr is equivalent to changing all prior references to `True` (allow overflow in all cases). In the few cases where it was originally `False`, the exception noted above would be raised. So for any screen in a given language that did NOT raise that exception, we'd expect that it would still work completely fine after this change (i.e. no effect).

I re-ran the screenshot generator against the 14 languages that are the furthest along. I can't say that I inspected every last detail but a cursory spot check didn't reveal any unexpected side effects. And all 14 could now successfully complete (prior to this change, 13 would complete while Norweigian always failed).

If you'd like to play with all these translations, see my `max_locales` branch: https://github.com/kdmukai/seedsigner-translations/tree/max_locales

---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other: running the test suite and screenshot generator in local dev
