### PR TITLE
[Bugfix] Solve raw hex display of OP_RETURN for non-latin alphabets

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -731,14 +731,24 @@ class PSBTOpReturnScreen(ButtonListScreen):
             # Contains data that can't be converted to UTF-8; probably encoded and not
             # meant to be human readable.
             font = Fonts.get_font(GUIConstants.FIXED_WIDTH_FONT_NAME, size=GUIConstants.get_body_font_size())
-            (left, top, right, bottom) = font.getbbox("X", anchor="ls")
-            chars_per_line = int((self.canvas_width - 2*GUIConstants.EDGE_PADDING) / (right - left))
             decoded_str = self.op_return_data.hex()
-            num_lines = math.ceil(len(decoded_str) / chars_per_line)
             text = ""
-            for i in range(num_lines):
-                text += (decoded_str[i*chars_per_line:(i+1)*chars_per_line]) + "\n"
-            text = text[:-1]
+            current_line = ""
+            max_width = self.canvas_width - 4 * GUIConstants.EDGE_PADDING
+
+            # Calculate average character width
+            avg_char_width = font.getbbox("0", anchor="ls")[2] - font.getbbox("0", anchor="ls")[0]
+            chars_per_line = max_width // avg_char_width
+
+            for i, char in enumerate(decoded_str):
+                current_line += char
+                if len(current_line) >= chars_per_line:
+                    text += current_line + "\n"
+                    current_line = ""
+
+            # Add the remaining text
+            if current_line:
+                text += current_line
 
             # TRANSLATOR_NOTE: Shown when displaying OP_RETURN as non-human-readable hexadecimal data
             hex_label = _("raw hex data")

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -763,7 +763,7 @@ class PSBTOpReturnScreen(ButtonListScreen):
             self.components.append(TextArea(
                 text=text,
                 font_name=GUIConstants.FIXED_WIDTH_FONT_NAME,
-                font_size=GUIConstants.get_body_font_size(),
+                font_size=GUIConstants.BODY_FONT_SIZE["default"],
                 screen_y=label.screen_y + label.height + GUIConstants.COMPONENT_PADDING,
             ))
 


### PR DESCRIPTION
## Description

This PR solves the wrong display of the raw hex OP_RETURN for non-latin alphabets.

### Before:
![PSBTOpReturnView_raw_hex_data](https://github.com/user-attachments/assets/939bc98c-e201-4204-be4e-4c6396301184)

### After:

Two options here:

Commit https://github.com/SeedSigner/seedsigner/pull/762/commits/cfb5a5c91d1157ad9b20c957cb942c11416d4f66: (this one may be just right if the TextArea is scrollable)
![PSBTOpReturnView_raw_hex_data_1](https://github.com/user-attachments/assets/e8a3da43-708c-458c-9509-dd6dbdb2616b)

Commit https://github.com/SeedSigner/seedsigner/commit/2f1094e4b97af728f759472723bf2d5dc50d5cb1:
This one makes the screen to use always the default font size for the hex content.
![PSBTOpReturnView_raw_hex_data](https://github.com/user-attachments/assets/69173b98-55c6-4c18-b44a-cf1b7a93ff47)



_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Screenshots


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
