### PR TITLE
BIP references cleanup to read like "BIP-XX"

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -31,7 +31,7 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
 
         self.possible_alphabet = "abcdefghijklmnopqrstuvwxyz"
 
-        # Measure the width required to display the longest word in the English bip39
+        # Measure the width required to display the longest word in the English BIP-39
         # wordlist.
         # TODO: If we ever support other wordlist languages, adjust accordingly.
         matches_list_highlight_font_name = GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME
@@ -48,7 +48,7 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
         self.arrow_up_is_active = False
         self.arrow_down_is_active = False
 
-        # TODO: support other BIP39 languages/charsets
+        # TODO: support other BIP-39 languages/charsets
         self.keyboard = Keyboard(
             draw=self.image_draw,
             charset=self.possible_alphabet,
@@ -624,7 +624,7 @@ class SeedExportXpubDetailsScreen(WarningEdgesMixin, ButtonListScreen):
         self.fingerprint_line = IconTextLine(
             icon_name=SeedSignerIconConstants.FINGERPRINT,
             icon_color=GUIConstants.INFO_COLOR,
-            # TRANSLATOR_NOTE: Short for "BIP32 Master Fingerprint"
+            # TRANSLATOR_NOTE: Short for "BIP-32 Master Fingerprint"
             label_text=_("Fingerprint"),
             value_text=self.fingerprint,
             screen_x=GUIConstants.COMPONENT_PADDING,

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -44,7 +44,7 @@ def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, walle
 
     elif wallet_type == SettingsConstants.MULTISIG:
         if script_type == SettingsConstants.LEGACY_P2PKH:
-            return f"m/45'" #BIP45
+            return f"m/45'" #BIP-45
         elif script_type == SettingsConstants.NESTED_SEGWIT:
             return f"m/48'/{network_path}/0'/1'"
         elif script_type == SettingsConstants.NATIVE_SEGWIT:

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -398,11 +398,11 @@ class DecodeQR:
                 _4LETTER_WORDLIST = []
 
             if all(x in wordlist for x in s.strip().split(" ")):
-                # checks if all words in list are in bip39 word list
+                # checks if all words in list are in BIP-39 word list
                 return QRType.SEED__MNEMONIC
 
             elif all(x in _4LETTER_WORDLIST for x in s.strip().split(" ")):
-                # checks if all 4 letter words are in list are in 4 letter bip39 word list
+                # checks if all 4 letter words are in list are in 4 letter BIP-39 word list
                 return QRType.SEED__FOUR_LETTER_MNEMONIC
 
             elif DecodeQR.is_base43_psbt(s):

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -395,7 +395,7 @@ class SettingsConstants:
 
     # Label strings
     LABEL__BIP39_PASSPHRASE = _mft("BIP-39 Passphrase")
-    # TRANSLATOR_NOTE: Terminology used by Electrum seeds; equivalent to bip39 passphrase
+    # TRANSLATOR_NOTE: Terminology used by Electrum seeds; equivalent to BIP-39 passphrase
     custom_extension = _mft("Custom Extension")
     LABEL__CUSTOM_EXTENSION = custom_extension
 
@@ -542,7 +542,7 @@ class SettingsDefinition:
                       selection_options=SettingsConstants.get_detected_languages(),
                       default_value=SettingsConstants.LOCALE__ENGLISH),
 
-        # TODO: Support other bip-39 wordlist languages! Until then, type == HIDDEN
+        # TODO: Support other BIP-39 wordlist languages! Until then, type == HIDDEN
         SettingsEntry(category=SettingsConstants.CATEGORY__SYSTEM,
                       attr_name=SettingsConstants.SETTING__WORDLIST_LANGUAGE,
                       abbreviated_name="wordlist_lang",

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1117,17 +1117,17 @@ class SeedWordsView(View):
 
 
 """****************************************************************************
-    BIP85 - Derive child mnemonic (seed) flow
+    BIP-85 - Derive child mnemonic (seed) flow
 ****************************************************************************"""
 class SeedBIP85ApplicationModeView(View):
     """
-        * Ask the user the application type as defined in the BIP0085 spec.
+        * Ask the user the application type as defined in the BIP-85 spec.
         * Currently only Word mode of 12, 24 words (Application number: 39')
         * Possible future additions are
         *  WIF (HDSEED)
-        *  XPRV (BIP32)
+        *  XPRV (BIP-32)
     """
-    # TODO: Future enhancement to display WIF (HD-SEED) and XPRV (Bip32)?
+    # TODO: Future enhancement to display WIF (HD-SEED) and XPRV (BIP-32)?
     WORDS_12 = ButtonOption("12 Words")
     WORDS_24 = ButtonOption("24 Words")
 

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -283,7 +283,7 @@ def test_get_multisig_address():
 
     from embit.descriptor import Descriptor
 
-    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39 and BIP32 standard-path wallets
+    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39 and BIP-32 standard-path wallets
     #    keystore1 = 0x00*16 = 73c5da0a = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
     #    keystore2 = 0x11*16 = 0be174ee = 'baby mass dust captain baby mass dust captain baby mass dust casino'
     #    keystore3 = 0x22*16 = 8d55ff0d = 'captain baby mass dust captain baby mass dust captain baby mass dutch'

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -283,7 +283,7 @@ def test_get_multisig_address():
 
     from embit.descriptor import Descriptor
 
-    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39 and BIP32-standard-path wallets
+    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39 and BIP32 standard-path wallets
     #    keystore1 = 0x00*16 = 73c5da0a = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
     #    keystore2 = 0x11*16 = 0be174ee = 'baby mass dust captain baby mass dust captain baby mass dust casino'
     #    keystore3 = 0x22*16 = 8d55ff0d = 'captain baby mass dust captain baby mass dust captain baby mass dutch'

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -283,7 +283,7 @@ def test_get_multisig_address():
 
     from embit.descriptor import Descriptor
 
-    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on bip39-bip32-standard-path wallets
+    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39-BIP32-standard-path wallets
     #    keystore1 = 0x00*16 = 73c5da0a = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
     #    keystore2 = 0x11*16 = 0be174ee = 'baby mass dust captain baby mass dust captain baby mass dust casino'
     #    keystore3 = 0x22*16 = 8d55ff0d = 'captain baby mass dust captain baby mass dust captain baby mass dutch'

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -283,7 +283,7 @@ def test_get_multisig_address():
 
     from embit.descriptor import Descriptor
 
-    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39-BIP32-standard-path wallets
+    # jdlcdl: these vectors created with electrum & sparrow as a 2 of 3 multisig based on BIP-39 and BIP32-standard-path wallets
     #    keystore1 = 0x00*16 = 73c5da0a = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
     #    keystore2 = 0x11*16 = 0be174ee = 'baby mass dust captain baby mass dust captain baby mass dust casino'
     #    keystore3 = 0x22*16 = 8d55ff0d = 'captain baby mass dust captain baby mass dust captain baby mass dutch'

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -35,7 +35,7 @@ class TestSeedFlows(FlowTest):
 
     def test_passphrase_entry_flow(self):
         """
-        Opting to add a bip39 passphrase on the Finalize Seed screen should enter the
+        Opting to add a BIP-39 passphrase on the Finalize Seed screen should enter the
         passphrase entry / review flow and end at the SeedOptionsView. 
         """
         self.run_sequence([


### PR DESCRIPTION
## Description

This PR updates all BIP references to follow a consistent format: BIP-XX (e.g., BIP-39, BIP-85).

Fixes #304 

NOTE: I have NOT touched constants, variables and classes to create any code changes which would lead to issues.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other