### PR TITLE
[l10n] Remove libraqm workarounds and enforce libraqm dependency

### DIFF
--- a/docs/raspberry_pi_os_build_instructions.md
+++ b/docs/raspberry_pi_os_build_instructions.md
@@ -77,7 +77,7 @@ You will be prompted to enter the current password ("raspberry") and then to ent
 # * libsqlite3-dev: required by `coverage`
 sudo apt update && sudo apt install -y build-essential zlib1g-dev \
     libncurses5-dev libgdbm-dev libnss3-dev openssl libssl-dev \
-    libreadline-dev libffi-dev wget libsqlite3-dev
+    libreadline-dev libffi-dev wget libsqlite3-dev libraqm-dev
 
 # Grab the python3.10 source
 wget https://www.python.org/ftp/python/3.10.10/Python-3.10.10.tgz

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -432,10 +432,6 @@ class TextArea(BaseComponent):
         self.text_y = self.text_height_above_baseline
 
         self.visible_width = self.width - max(self.edge_padding, self.min_text_x) - self.edge_padding
-        if not ImageFont.core.HAVE_RAQM:
-            # Fudge factor for imprecise width calcs w/out libraqm
-            full_text_width = int(full_text_width * 1.05)
-            self.visible_width = int(self.visible_width * 1.05)
 
         if self.is_horizontal_scrolling_enabled or not self.auto_line_break:
             # Guaranteed to be a single line of text, possibly wider than self.width
@@ -588,10 +584,6 @@ class TextArea(BaseComponent):
             img = sharpened.crop((0, resample_padding, image_width, resample_padding + total_text_height))
         
         self.rendered_text_img = img
-
-        if not ImageFont.core.HAVE_RAQM:
-            # At this point we need the visible_width to be the "actual" (yet still incorrect) width
-            self.visible_width = int(self.visible_width * 0.95)
 
         self.horizontal_text_scroll_thread: TextArea.HorizontalTextScrollThread = None
         if self.is_horizontal_scrolling_enabled:
@@ -1843,10 +1835,6 @@ def reflow_text_for_width(text: str,
     # Measure from left baseline ("ls")
     (left, top, full_text_width, px_below_baseline) = font.getbbox(text, anchor="ls")
 
-    if not ImageFont.core.HAVE_RAQM:
-        # Fudge factor for imprecise width calcs w/out libraqm
-        full_text_width = int(full_text_width * 1.05)
-
     # Assume we can break Asian text on any character
     treat_chars_as_words = Settings.get_instance().get_value(SettingsConstants.SETTING__LOCALE) in [
         SettingsConstants.LOCALE__CHINESE_SIMPLIFIED,
@@ -1879,10 +1867,6 @@ def reflow_text_for_width(text: str,
             # Measure rendered width from "left" anchor (anchor="l_")
             (left, top, right, px_below_baseline) = font.getbbox(word_spacer.join(words[0:index]), anchor="ls")
             line_width = right - left
-
-            if not ImageFont.core.HAVE_RAQM:
-                # Fudge factor for imprecise width calcs w/out libraqm
-                line_width = int(line_width * 1.05)
 
             if line_width >= width:
                 # Candidate line is still too long. Restrict search range down.

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -6,6 +6,7 @@ import random
 import sys
 import time
 from unittest.mock import Mock, patch, MagicMock
+from PIL import ImageFont
 
 from embit import compact
 from embit.psbt import PSBT, OutputScope
@@ -20,9 +21,6 @@ sys.modules['RPi'] = MagicMock()
 sys.modules['RPi.GPIO'] = MagicMock()
 sys.modules['seedsigner.hardware.camera'] = MagicMock()
 sys.modules['seedsigner.hardware.microsd'] = MagicMock()
-
-# Force the screenshots to mimic Pi Zero's output without libraqm
-patch('PIL.ImageFont.core.HAVE_RAQM', False).start()
 
 from seedsigner.controller import Controller
 from seedsigner.gui.components import GUIConstants
@@ -47,8 +45,6 @@ from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
 import warnings; warnings.warn = lambda *args, **kwargs: None
 
-
-
 # Dynamically generate a pytest test run for each locale
 @pytest.mark.parametrize("locale", [x for x, y in SettingsConstants.get_detected_languages()])
 def test_generate_all(locale, target_locale):
@@ -59,6 +55,11 @@ def test_generate_all(locale, target_locale):
     """
     if target_locale and locale != target_locale:
         pytest.skip(f"Skipping {locale}")
+    
+    if not ImageFont.core.HAVE_RAQM:
+        # We can't generate pixel-perfect screenshots that match what gets rendered on
+        # the device if we don't have libraqm.
+        pytest.fail("libraqm is not installed.")
     
     generate_screenshots(locale)
 


### PR DESCRIPTION
## Description

This PR implements the clean up of libraqm-related code by removing workarounds and ensuring proper libraqm support is enforced.

## Changes Made

### Add libraqm in dev build instructions (https://github.com/SeedSigner/seedsigner/commit/b24ca4b1304b0c3303a81074c0e069be5fdabc56)
Modified `raspberry_pi_os_build_instructions.md` to include libraqm-dev in the required system packages
Changed the apt install command from:
```
sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev openssl libssl-dev libreadline-dev libffi-dev wget libsqlite3-dev
```
to:
```
sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev openssl libssl-dev libreadline-dev libffi-dev wget libsqlite3-dev libraqm-dev
```
This ensures Raspberry Pi OS dev environment have the necessary libraqm support.

### Remove "libraqm not supported" tweaks (https://github.com/SeedSigner/seedsigner/commit/430f0cbee1ce00111e4580e613f11f4100b13dc3)
Cleaned up text measurement workarounds in `components.py`:
- Removing fudge factor adjustments that compensated for imprecise text width calculations without libraqm.
- Removing compensating adjustment later in the code.

Fixed screenshot generator in `generator.py`:
- Removed the libraqm disable patch.
- Added libraqm validation check in `test_generate_all`.



This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


### Bonus track!!

It seems the OP_RETURN problem from https://github.com/SeedSigner/seedsigner/pull/762 gets solved with this modifications, although still with a bigger font size.

![PSBTOpReturnView_raw_hex_data](https://github.com/user-attachments/assets/4c5d4b6f-49b7-4e60-9ee1-311c32951369)  ![PSBTOpReturnView_raw_hex_data](https://github.com/user-attachments/assets/61746a96-cf00-4143-81e3-d160a8a0a51c)

