### PR TITLE
[Testing] Exclude hardware drivers from `coverage`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ exclude_lines = [
 # Omit; need a different approach to test modules with hardware dependencies
 omit = [
   "*/__init__.py",
+  "*/seedsigner/hardware/camera.py",
+  "*/seedsigner/hardware/pivideostream.py",
+  "*/seedsigner/hardware/displays/ST7789.py",
+  "*/seedsigner/hardware/displays/st7789_mpy.py",
+  "*/seedsigner/hardware/displays/ili9341.py",
   "*/tests/*",
 ]
 skip_covered = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ exclude_lines = [
 # Omit; need a different approach to test modules with hardware dependencies
 omit = [
   "*/__init__.py",
-  "*/seedsigner/hardware/camera.py",
-  "*/seedsigner/hardware/pivideostream.py",
-  "*/seedsigner/hardware/displays/ST7789.py",
-  "*/seedsigner/hardware/displays/st7789_mpy.py",
-  "*/seedsigner/hardware/displays/ili9341.py",
+  "src/seedsigner/hardware/camera.py",
+  "src/seedsigner/hardware/pivideostream.py",
+  "src/seedsigner/hardware/displays/ST7789.py",
+  "src/seedsigner/hardware/displays/st7789_mpy.py",
+  "src/seedsigner/hardware/displays/ili9341.py",
   "*/tests/*",
 ]
 skip_covered = true


### PR DESCRIPTION
## Description

The five python files that this PR adds to the `coverage` exclusion list are all hardware drivers that are mocked out when we run the test suite, so they will always yield 0% coverage.

So just due to these new exclusions, this PR changes our test coverage (when running the `run_full_coverage.sh` script) from 65.79% to 70.84%.

Note: It's a separate discussion topic to think about how much direct hardware + driver testing might make sense. So far the approach has just been: "if the camera, display, and buttons work as expected, we're good!"

---

This pull request is categorized as a:
- [x] Other

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: test suite running in local dev
