### PR TITLE
Add taproot tapleaf signing

### DIFF
--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -234,6 +234,7 @@ class PSBTParser():
                 trimmed_psbt.inputs[i].final_scriptwitness = inp.final_scriptwitness
             else:
                 trimmed_psbt.inputs[i].partial_sigs = inp.partial_sigs
+                trimmed_psbt.inputs[i].taproot_sigs = inp.taproot_sigs
 
         return trimmed_psbt
 
@@ -247,6 +248,7 @@ class PSBTParser():
                 cnt += 1
             else:
                 cnt += len(list(inp.partial_sigs.keys()))
+                cnt += len(list(inp.taproot_sigs.keys()))
 
         return cnt
 


### PR DESCRIPTION
## Description

embit library already is able to sign tapleaves, but they are discarded.
This pr simply adds those signed signatures to the psbt.
AFAIK currently supported wallets don't support tapleafs but a seedsigner can be used with a Bitcoin Core wallet.
Here i created a helper tool to be able to use it with Bitocin Core: https://github.com/ekrembal/psbtqr

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other
