### PR TITLE
[Feature] Load BIP-85 Child Seeds

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -217,10 +217,6 @@ class Controller(Singleton):
         return self._storage
 
 
-    def discard_seed(self, seed: Seed):
-        self.storage.seeds.remove(seed)
-
-
     def pop_prev_from_back_stack(self):
         if len(self.back_stack) > 0:
             # Pop the top View (which is the current View_cls)

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -184,7 +184,8 @@ class FontAwesomeIconConstants:
     KEYBOARD = "\uf11c"
     MAP = "\uf279"
     X = "\u0058"
-    INDEX = "\u0023"
+    HASHTAG = "\u0023"
+    ARROW_RIGHT = "\uf061"
 
 
 

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -184,6 +184,7 @@ class FontAwesomeIconConstants:
     KEYBOARD = "\uf11c"
     MAP = "\uf279"
     X = "\u0058"
+    INDEX = "\u0023"
 
 
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -15,9 +15,37 @@ from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.renderer import Renderer
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 
-from .screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen, LargeIconStatusScreen, WarningEdgesMixin
+from .screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, ButtonOptionWithoutTranslation, KeyboardScreen, LargeIconStatusScreen, WarningEdgesMixin
 
 logger = logging.getLogger(__name__)
+
+
+
+@dataclass
+class SeedButtonOption(ButtonOptionWithoutTranslation):
+    """
+    ButtonOption for an in-memory seed in the various seed list Screens.
+
+    Renders the seed's fingerprint alongside the fingerprint icon. BIP-85 child seeds
+    (`child_index` is not None) are instead prefixed with their child index and indented
+    to convey the parent/child hierarchy.
+
+    Note: the labels are dynamic (a fingerprint), so they must NOT be run through `_()`
+    again when the buttons are rendered; hence `ButtonOptionWithoutTranslation`.
+    """
+    child_index: int = None
+
+    def __post_init__(self):
+        # Note: `ButtonOption` is a plain dataclass with no `__post_init__` to chain to.
+        if self.child_index is None:
+            self.icon_name = SeedSignerIconConstants.FINGERPRINT
+
+        else:
+            # TRANSLATOR_NOTE: Inserts BIP-85 child index and its fingerprint, e.g. "#3: abcd1234"
+            self.button_label = _("#{}: {}").format(self.child_index, self.button_label)
+
+            # Indent the child seed for a better hierarchical view
+            self.icon_name = " " * (GUIConstants.EDGE_PADDING // 4) + FontAwesomeIconConstants.ARROW_RIGHT
 
 
 
@@ -417,18 +445,24 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
 @dataclass
 class SeedFinalizeScreen(ButtonListScreen):
     fingerprint: str = None
+    is_bip85_child_seed: bool = False
     is_bottom_list: bool = True
     button_data: list = None
 
     def __post_init__(self):
         self.show_back_button = False
-        self.title = _("Finalize Seed")
+        if self.is_bip85_child_seed:
+            self.title = _("Finalize Child Seed")
+            icon_color=GUIConstants.DIRE_WARNING_COLOR
+        else:
+            self.title = _("Finalize Seed")
+            icon_color=GUIConstants.INFO_COLOR
         super().__post_init__()
 
         self.fingerprint_icontl = IconTextLine(
             icon_name=SeedSignerIconConstants.FINGERPRINT,
-            icon_color=GUIConstants.INFO_COLOR,
-            icon_size=GUIConstants.ICON_FONT_SIZE + 12,
+            icon_color=icon_color,
+            icon_size=int(GUIConstants.ICON_FONT_SIZE * 1.5),
             label_text=_("fingerprint"),
             value_text=self.fingerprint,
             font_size=GUIConstants.get_body_font_size() + 2,
@@ -453,23 +487,23 @@ class SeedBIP85FinalizeScreen(ButtonListScreen):
         self.child_fingerprint_icontl = IconTextLine(
             icon_name=SeedSignerIconConstants.FINGERPRINT,
             icon_color=GUIConstants.INFO_COLOR,
-            icon_size=GUIConstants.ICON_FONT_SIZE + 12,
+            icon_size=int(GUIConstants.ICON_FONT_SIZE * 1.5),
             label_text=_("child fingerprint"),
             value_text=self.child_fingerprint,
             font_size=GUIConstants.get_body_font_size(),
-            screen_x=GUIConstants.LIST_ITEM_PADDING,
+            screen_x=GUIConstants.EDGE_PADDING // 2,
             screen_y=self.top_nav.height + int((self.buttons[0].screen_y - self.top_nav.height) / 2) - 40
         )
         self.components.append(self.child_fingerprint_icontl)
 
         self.bip85_index_icontl = IconTextLine(
-            icon_name=FontAwesomeIconConstants.INDEX,
+            icon_name=FontAwesomeIconConstants.HASHTAG,
             icon_color=GUIConstants.INFO_COLOR,
-            icon_size=GUIConstants.ICON_FONT_SIZE + 12,
+            icon_size=int(GUIConstants.ICON_FONT_SIZE * 1.5),
             label_text=_("BIP-85 Index"),
             value_text=str(self.bip85_index),
             font_size=GUIConstants.get_body_font_size(),
-            screen_x=GUIConstants.COMPONENT_PADDING,
+            screen_x=GUIConstants.EDGE_PADDING,
             screen_y=self.top_nav.height + int((self.buttons[0].screen_y - self.top_nav.height) / 2)
         )
         self.components.append(self.bip85_index_icontl)
@@ -480,14 +514,16 @@ class SeedBIP85FinalizeScreen(ButtonListScreen):
 class SeedOptionsScreen(ButtonListScreen):
     fingerprint: str = None
     is_bip85_child_seed: bool = False
+    bip85_index: int = None
 
     def __post_init__(self):
-        self.top_nav_icon_name = SeedSignerIconConstants.FINGERPRINT
+        self.top_nav_icon_color = GUIConstants.INFO_COLOR
         if self.is_bip85_child_seed:
-            self.top_nav_icon_color = GUIConstants.DIRE_WARNING_COLOR
+            self.top_nav_icon_name = FontAwesomeIconConstants.HASHTAG
+            self.title = f"{self.bip85_index}: {self.fingerprint}"
         else:
-            self.top_nav_icon_color = GUIConstants.INFO_COLOR
-        self.title = self.fingerprint
+            self.top_nav_icon_name = SeedSignerIconConstants.FINGERPRINT
+            self.title = self.fingerprint
         self.is_button_text_centered = False
         self.is_bottom_list = True
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -440,12 +440,53 @@ class SeedFinalizeScreen(ButtonListScreen):
 
 
 @dataclass
+class SeedBIP85FinalizeScreen(ButtonListScreen):
+    child_fingerprint: str = None
+    bip85_index: int = None
+    is_bottom_list: bool = True
+    button_data: list = None
+
+    def __post_init__(self):
+        self.title = _("BIP-85 Child Seed")
+        super().__post_init__()
+
+        self.child_fingerprint_icontl = IconTextLine(
+            icon_name=SeedSignerIconConstants.FINGERPRINT,
+            icon_color=GUIConstants.INFO_COLOR,
+            icon_size=GUIConstants.ICON_FONT_SIZE + 12,
+            label_text=_("child fingerprint"),
+            value_text=self.child_fingerprint,
+            font_size=GUIConstants.get_body_font_size(),
+            screen_x=GUIConstants.LIST_ITEM_PADDING,
+            screen_y=self.top_nav.height + int((self.buttons[0].screen_y - self.top_nav.height) / 2) - 40
+        )
+        self.components.append(self.child_fingerprint_icontl)
+
+        self.bip85_index_icontl = IconTextLine(
+            icon_name=FontAwesomeIconConstants.INDEX,
+            icon_color=GUIConstants.INFO_COLOR,
+            icon_size=GUIConstants.ICON_FONT_SIZE + 12,
+            label_text=_("BIP-85 Index"),
+            value_text=str(self.bip85_index),
+            font_size=GUIConstants.get_body_font_size(),
+            screen_x=GUIConstants.COMPONENT_PADDING,
+            screen_y=self.top_nav.height + int((self.buttons[0].screen_y - self.top_nav.height) / 2)
+        )
+        self.components.append(self.bip85_index_icontl)
+
+
+
+@dataclass
 class SeedOptionsScreen(ButtonListScreen):
     fingerprint: str = None
+    is_bip85_child_seed: bool = False
 
     def __post_init__(self):
         self.top_nav_icon_name = SeedSignerIconConstants.FINGERPRINT
-        self.top_nav_icon_color = GUIConstants.INFO_COLOR
+        if self.is_bip85_child_seed:
+            self.top_nav_icon_color = GUIConstants.DIRE_WARNING_COLOR
+        else:
+            self.top_nav_icon_color = GUIConstants.INFO_COLOR
         self.title = self.fingerprint
         self.is_button_text_centered = False
         self.is_bottom_list = True
@@ -459,13 +500,18 @@ class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
     words: List[str] = None
     page_index: int = 0
     num_pages: int = 3
+    bip85_child_index: int = None
     is_bottom_list: bool = True
     status_color: str = GUIConstants.DIRE_WARNING_COLOR
 
 
     def __post_init__(self):
-        # TRANSLATOR_NOTE: Displays the page number and total: (e.g. page 1 of 6)
-        self.title = _("Seed Words: {}/{}").format(self.page_index + 1, self.num_pages)
+        if self.bip85_child_index is not None:
+            # TRANSLATOR_NOTE: Inserts the BIP-85 child index, the page number and the total (e.g. "Child #3: 1/6")
+            self.title = _("Child #{}: {}/{}").format(self.bip85_child_index, self.page_index + 1, self.num_pages)
+        else:
+            # TRANSLATOR_NOTE: Displays the page number and total: (e.g. page 1 of 6)
+            self.title = _("Seed Words: {}/{}").format(self.page_index + 1, self.num_pages)
         super().__post_init__()
 
         words_per_page = len(self.words)

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -164,11 +164,17 @@ class Seed:
         return bip85.derive_mnemonic(root, bip85_num_words, bip85_index)
         
 
-    ### override operators    
+    ### override operators
     def __eq__(self, other):
-        if isinstance(other, Seed):
-            return self.seed_bytes == other.seed_bytes
-        return False
+        if not isinstance(other, Seed):
+            return False
+
+        if isinstance(self, BIP85ChildSeed) != isinstance(other, BIP85ChildSeed):
+            # A BIP-85 child seed carries parent/index provenance, so it is a distinct
+            # in-memory entry even when the underlying seed bytes match.
+            return False
+
+        return self.seed_bytes == other.seed_bytes
 
 
 
@@ -239,3 +245,27 @@ class ElectrumSeed(Seed):
     @property
     def bip85_supported(self) -> bool:
         return False
+
+
+
+class BIP85GrandchildNotAllowedException(Exception):
+    pass
+
+
+
+class BIP85ChildSeed(Seed):
+    def __init__(self, parent_seed: Seed, child_index: int, num_words: int, **kwargs):
+        self.parent_seed = parent_seed
+        self.child_index = child_index
+        self.num_words = num_words
+        super().__init__(**kwargs)
+
+
+    @property
+    def bip85_supported(self) -> bool:
+        # Do not allow further BIP-85 child derivation from a BIP-85 child seed
+        return False
+
+
+    def get_bip85_child_mnemonic(self, *args, **kwargs):
+        raise BIP85GrandchildNotAllowedException("Further BIP-85 child derivation is not allowed.")

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -1,5 +1,5 @@
 from typing import List
-from seedsigner.models.seed import Seed, ElectrumSeed, InvalidSeedException
+from seedsigner.models.seed import Seed, BIP85ChildSeed, ElectrumSeed, InvalidSeedException
 from seedsigner.models.settings_definition import SettingsConstants
 
 
@@ -24,9 +24,30 @@ class SeedStorage:
         # Store the pending seed and return it
         seed = self.pending_seed
         if seed not in self.seeds:
-            self.seeds.append(seed)
+            if isinstance(seed, BIP85ChildSeed):
+                # Insert child seeds adjacent to parent, sorted by child index, then by number of words
+                # Required to list seeds in a presentable order
+                existing_siblings = self.get_bip85_child_seeds(seed.parent_seed)
+                index = self.seeds.index(seed.parent_seed) + 1
+                for sibling in existing_siblings:
+                    if (sibling.child_index, sibling.num_words) < (seed.child_index, seed.num_words):
+                        index += 1
+                    else:
+                        break
+                self.seeds.insert(index, seed)
+            else:
+                self.seeds.append(seed)
         self.pending_seed = None
         return seed
+
+
+    def discard_seed(self, seed: Seed):
+        bip85_child_seeds = self.get_bip85_child_seeds(seed)
+
+        self.seeds.remove(seed)
+
+        for child_seed in bip85_child_seeds:
+            self.seeds.remove(child_seed)
 
 
     def clear_pending_seed(self):
@@ -101,3 +122,8 @@ class SeedStorage:
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
         self._pending_is_electrum = False
+
+
+    def get_bip85_child_seeds(self, parent_seed: Seed) -> list[BIP85ChildSeed]:
+        """Returns the list of BIP-85 child seeds derived from the specified seed."""
+        return [seed for seed in self.seeds if isinstance(seed, BIP85ChildSeed) and seed.parent_seed == parent_seed]

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -53,6 +53,14 @@ class SettingsConstants:
         (XPUB_QR_FORMAT__SPECTER_LEGACY, _mft("Specter legacy")),
     ]
 
+    BIP85__VIEW_ONLY = "V"
+    BIP85__LOADABLE = "L"
+    ALL_BIP85_OPTIONS = [
+        (OPTION__DISABLED, _mft("Disabled")),
+        (BIP85__VIEW_ONLY, _mft("View-only child seeds")),
+        (BIP85__LOADABLE, _mft("Loadable child seeds")),
+    ]
+
     # Over-specifying current and possible future locales to reduce/eliminate main repo
     # changes when adding/testing new languages.
     LOCALE__ARABIC = "ar"
@@ -664,6 +672,8 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,
                       abbreviated_name="bip85",
                       display_name=_mft("BIP-85 child seeds"),
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      selection_options=SettingsConstants.ALL_BIP85_OPTIONS,
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -2,8 +2,10 @@ from gettext import gettext as _
 
 from seedsigner.models.psbt_parser import (PSBTInputOwnershipClaimError,
     PSBTOutputOwnershipClaimError, PSBTParser, PSBTSeedCannotSignError)
+from seedsigner.models.seed import BIP85ChildSeed
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants
+from seedsigner.gui.screens import seed_screens
 from seedsigner.gui.screens.screen import (RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption, LargeIconStatusScreen, WarningScreen, DireWarningScreen, QRDisplayScreen)
 from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination
 
@@ -33,13 +35,17 @@ class PSBTSelectSeedView(View):
         seeds = self.controller.storage.seeds
         button_data = []
         for seed in seeds:
-            button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+            button_option = seed_screens.SeedButtonOption(
+                button_label=seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+                child_index=seed.child_index if isinstance(seed, BIP85ChildSeed) else None,
+            )
+
             if not PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
                 # Doesn't look like this seed can sign the current PSBT
                 # TRANSLATOR_NOTE: Inserts fingerprint w/"?" to indicate that this seed can't sign the current PSBT
-                button_str = _("{} (?)").format(button_str)
+                button_option.button_label = _("{} (?)").format(button_option.button_label)
 
-            button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT))
+            button_data.append(button_option)
 
         button_data.append(self.SCAN_SEED)
         button_data.append(self.TYPE_12WORD)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -13,7 +13,7 @@ from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
 from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import BIP85ChildSeed, Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
@@ -468,6 +468,7 @@ class SeedDiscardView(View):
         else:
             self.is_pending_seed = False
             self.seed = seed
+        self.has_bip85_child_seeds = not self.is_pending_seed and len(self.controller.storage.get_bip85_child_seeds(self.seed)) > 0
 
 
     def run(self):
@@ -475,7 +476,12 @@ class SeedDiscardView(View):
 
         fingerprint = self.seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
         # TRANSLATOR_NOTE: Inserts the seed fingerprint
-        text = _("Wipe seed {} from the device?").format(fingerprint)
+        text = _("Discard seed {} from the device?").format(fingerprint)
+
+        if self.has_bip85_child_seeds:
+            # TRANSLATOR_NOTE: Inserts the seed fingerprint
+            text = _("Discard seed {} and its child seeds from the device?").format(fingerprint)
+
         selected_menu_num = self.run_screen(
             WarningScreen,
             title=_("Discard Seed?"),
@@ -496,7 +502,7 @@ class SeedDiscardView(View):
             if self.is_pending_seed:
                 self.controller.storage.clear_pending_seed()
             else:
-                self.controller.discard_seed(self.seed)
+                self.controller.storage.discard_seed(self.seed)
             return Destination(MainMenuView, clear_history=True)
 
 
@@ -581,7 +587,7 @@ class SeedOptionsView(View):
         if self.settings.get_value(SettingsConstants.SETTING__MESSAGE_SIGNING) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.SIGN_MESSAGE)
         
-        if self.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS) == SettingsConstants.OPTION__ENABLED and self.seed.bip85_supported:
+        if self.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS) in [SettingsConstants.BIP85__VIEW_ONLY, SettingsConstants.BIP85__LOADABLE] and self.seed.bip85_supported:
             button_data.append(self.BIP85_CHILD_SEED)
 
         button_data.append(self.DISCARD)
@@ -590,6 +596,7 @@ class SeedOptionsView(View):
             seed_screens.SeedOptionsScreen,
             button_data=button_data,
             fingerprint=self.seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+            is_bip85_child_seed=isinstance(self.seed, BIP85ChildSeed),
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
@@ -1000,10 +1007,9 @@ class SeedExportXpubQRDisplayView(View):
     View Seed Words flow
 ****************************************************************************"""
 class SeedWordsWarningView(View):
-    def __init__(self, seed: Seed, bip85_data: dict = None):
+    def __init__(self, seed: Seed):
         super().__init__()
         self.seed = seed
-        self.bip85_data = bip85_data
 
 
     def run(self):
@@ -1012,7 +1018,6 @@ class SeedWordsWarningView(View):
             view_args=dict(
                 seed=self.seed,
                 page_index=0,
-                bip85_data=self.bip85_data
             ),
             skip_current_view=True,  # Prevent going BACK to WarningViews
         )
@@ -1038,7 +1043,7 @@ class SeedWordsView(View):
     NEXT = ButtonOption("Next")
     DONE = ButtonOption("Done")
 
-    def __init__(self, seed: Seed, bip85_data: dict = None, page_index: int = 0):
+    def __init__(self, seed: Seed, page_index: int = 0):
         super().__init__()
         if seed is None:
             self.is_pending_seed = True
@@ -1046,7 +1051,6 @@ class SeedWordsView(View):
         else:
             self.is_pending_seed = False
             self.seed = seed
-        self.bip85_data = bip85_data
         self.page_index = page_index
 
 
@@ -1054,13 +1058,7 @@ class SeedWordsView(View):
         # Slice the mnemonic to our current 4-word section
         words_per_page = 4  # TODO: eventually make this configurable for bigger screens?
 
-        if self.bip85_data is not None:
-            mnemonic = self.seed.get_bip85_child_mnemonic(self.bip85_data["child_index"], self.bip85_data["num_words"]).split()
-            # TRANSLATOR_NOTE: Inserts the child index (e.g. "Child #0")
-            title = _("Child #{}").format(self.bip85_data["child_index"])
-        else:
-            mnemonic = self.seed.mnemonic_display_list
-            title = _("Seed Words")
+        mnemonic = self.seed.mnemonic_display_list
         words = mnemonic[self.page_index*words_per_page:(self.page_index + 1)*words_per_page]
 
         button_data = []
@@ -1072,10 +1070,10 @@ class SeedWordsView(View):
 
         selected_menu_num = self.run_screen(
             seed_screens.SeedWordsScreen,
-            title=f"{title}: {self.page_index+1}/{num_pages}",
             words=words,
             page_index=self.page_index,
             num_pages=num_pages,
+            bip85_child_index=self.seed.child_index if isinstance(self.seed, BIP85ChildSeed) else None,
             button_data=button_data,
         )
 
@@ -1089,19 +1087,19 @@ class SeedWordsView(View):
             if self.is_pending_seed and self.page_index == num_pages - 1:
                 return Destination(
                     SeedWordsBackupTestPromptView,
-                    view_args=dict(seed=self.seed, bip85_data=self.bip85_data),
+                    view_args=dict(seed=self.seed),
                 )
             else:
                 return Destination(
                     SeedWordsView,
-                    view_args=dict(seed=self.seed, page_index=self.page_index + 1, bip85_data=self.bip85_data)
+                    view_args=dict(seed=self.seed, page_index=self.page_index + 1)
                 )
 
         elif button_data[selected_menu_num] == self.DONE:
             # Must clear history to avoid BACK button returning to private info
             return Destination(
                 SeedWordsBackupTestPromptView,
-                view_args=dict(seed=self.seed, bip85_data=self.bip85_data),
+                view_args=dict(seed=self.seed),
             )
 
 
@@ -1152,7 +1150,6 @@ class SeedBIP85SelectChildIndexView(View):
 
 
     def run(self):
-        # TODO: Change this later to use the generic Screen input keyboard
         ret = self.run_screen(seed_screens.SeedBIP85SelectChildIndexScreen)
 
         if ret == RET_CODE__BACK_BUTTON:
@@ -1168,13 +1165,19 @@ class SeedBIP85SelectChildIndexView(View):
                 skip_current_view=True
             )
 
-        return Destination(
-            SeedWordsWarningView,
-            view_args=dict(
-                seed=self.seed,
-                bip85_data=dict(child_index=int(ret), num_words=self.num_words),
+        child_index = int(ret)
+        child_mnemonic = self.seed.get_bip85_child_mnemonic(child_index, self.num_words, self.settings.get_value(SettingsConstants.SETTING__NETWORK)).split()
+        child_seed = BIP85ChildSeed(
+                parent_seed=self.seed,
+                child_index=child_index,
+                num_words=self.num_words,
+                mnemonic=child_mnemonic,
+                wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE)
             )
-        )
+
+        self.controller.storage.set_pending_seed(child_seed)
+
+        return Destination(SeedBIP85FinalizeView)
 
 
 
@@ -1207,6 +1210,47 @@ class SeedBIP85InvalidChildIndexView(View):
 
 
 
+class SeedBIP85FinalizeView(View):
+    LOAD = ButtonOption("Load child")
+    VIEW_MNEMONIC = ButtonOption("View mnemonic")
+    DONE = ButtonOption("Done")
+
+    def __init__(self):
+        super().__init__()
+        self.seed: BIP85ChildSeed = self.controller.storage.get_pending_seed()
+
+        if not isinstance(self.seed, BIP85ChildSeed):
+            raise ValueError("SeedBIP85FinalizeView requires the pending seed to be a BIP85ChildSeed instance.")
+
+        self.is_loadable_mode = self.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS) == SettingsConstants.BIP85__LOADABLE
+
+
+    def run(self):
+        if self.is_loadable_mode:
+            button_data = [self.LOAD, self.VIEW_MNEMONIC]
+        else:
+            button_data = [self.VIEW_MNEMONIC, self.DONE]
+
+        selected_menu_num = self.run_screen(
+            seed_screens.SeedBIP85FinalizeScreen,
+            child_fingerprint=self.seed.get_fingerprint(network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+            bip85_index=self.seed.child_index,
+            button_data=button_data,
+            show_back_button=self.is_loadable_mode,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON or button_data[selected_menu_num] == self.DONE:
+            self.controller.storage.clear_pending_seed()
+            return Destination(SeedOptionsView, view_args=dict(seed=self.seed.parent_seed), clear_history=True)
+
+        if button_data[selected_menu_num] == self.VIEW_MNEMONIC:
+            return Destination(SeedWordsWarningView, view_args=dict(seed=None))
+
+        if button_data[selected_menu_num] == self.LOAD:
+            return Destination(SeedFinalizeView)
+
+
+
 """****************************************************************************
     Seed Words Backup Test
 ****************************************************************************"""
@@ -1214,10 +1258,9 @@ class SeedWordsBackupTestPromptView(View):
     VERIFY = ButtonOption("Verify")
     SKIP = ButtonOption("Skip")
 
-    def __init__(self, seed: Seed, bip85_data: dict = None):
+    def __init__(self, seed: Seed):
         super().__init__()
         self.seed = seed
-        self.bip85_data = bip85_data
 
 
     def run(self):
@@ -1230,11 +1273,13 @@ class SeedWordsBackupTestPromptView(View):
         if button_data[selected_menu_num] == self.VERIFY:
             return Destination(
                 SeedWordsBackupTestView,
-                view_args=dict(seed=self.seed, bip85_data=self.bip85_data),
+                view_args=dict(seed=self.seed),
             )
 
         elif button_data[selected_menu_num] == self.SKIP:
             if self.seed is None:
+                if isinstance(self.controller.storage.get_pending_seed(), BIP85ChildSeed):
+                    return Destination(SeedBIP85FinalizeView)
                 return Destination(SeedFinalizeView)
             else:
                 return Destination(SeedOptionsView, view_args=dict(seed=self.seed))
@@ -1242,7 +1287,7 @@ class SeedWordsBackupTestPromptView(View):
 
 
 class SeedWordsBackupTestView(View):
-    def __init__(self, seed: Seed, bip85_data: dict = None, confirmed_list: list[bool] = None, cur_index: int = None, rand_seed: int = None):
+    def __init__(self, seed: Seed, confirmed_list: list[bool] = None, cur_index: int = None, rand_seed: int = None):
         """
         Note: `rand_seed` is ONLY USED BY THE SCREENSHOT GENERATOR!!! (to ensure
         consistent screenshot results).
@@ -1254,12 +1299,8 @@ class SeedWordsBackupTestView(View):
         else:
             self.is_pending_seed = False
             self.seed = seed
-        self.bip85_data = bip85_data
 
-        if self.bip85_data is not None:
-            self.mnemonic_list = self.seed.get_bip85_child_mnemonic(self.bip85_data["child_index"], self.bip85_data["num_words"]).split()
-        else:
-            self.mnemonic_list = self.seed.mnemonic_display_list
+        self.mnemonic_list = self.seed.mnemonic_display_list
 
         self.confirmed_list = confirmed_list
         if not self.confirmed_list:
@@ -1314,7 +1355,7 @@ class SeedWordsBackupTestView(View):
                 # Continue testing the remaining words
                 return Destination(
                     SeedWordsBackupTestView,
-                    view_args=dict(seed=self.seed, confirmed_list=self.confirmed_list, bip85_data=self.bip85_data),
+                    view_args=dict(seed=self.seed, confirmed_list=self.confirmed_list),
                 )
 
         else:
@@ -1323,7 +1364,6 @@ class SeedWordsBackupTestView(View):
                 SeedWordsBackupTestMistakeView,
                 view_args=dict(
                     seed=self.seed,
-                    bip85_data=self.bip85_data,
                     cur_index=self.cur_index,
                     wrong_word=button_data[selected_menu_num].button_label,
                     confirmed_list=self.confirmed_list,
@@ -1336,10 +1376,9 @@ class SeedWordsBackupTestMistakeView(View):
     REVIEW = ButtonOption("Review seed words")
     RETRY = ButtonOption("Try again")
 
-    def __init__(self, seed: Seed, bip85_data: dict = None, cur_index: int = None, wrong_word: str = None, confirmed_list: list[bool] = None):
+    def __init__(self, seed: Seed, cur_index: int = None, wrong_word: str = None, confirmed_list: list[bool] = None):
         super().__init__()
         self.seed = seed
-        self.bip85_data = bip85_data
         self.cur_index = cur_index
         self.wrong_word = wrong_word
         self.confirmed_list = confirmed_list
@@ -1367,7 +1406,7 @@ class SeedWordsBackupTestMistakeView(View):
         if button_data[selected_menu_num] == self.REVIEW:
             return Destination(
                 SeedWordsView,
-                view_args=dict(seed=self.seed, bip85_data=self.bip85_data),
+                view_args=dict(seed=self.seed),
             )
 
         elif button_data[selected_menu_num] == self.RETRY:
@@ -1377,7 +1416,6 @@ class SeedWordsBackupTestMistakeView(View):
                     seed=self.seed,
                     confirmed_list=self.confirmed_list,
                     cur_index=self.cur_index,
-                    bip85_data=self.bip85_data,
                 )
             )
 
@@ -1400,6 +1438,8 @@ class SeedWordsBackupTestSuccessView(View):
         )
 
         if self.seed is None:
+            if isinstance(self.controller.storage.get_pending_seed(), BIP85ChildSeed):
+                return Destination(SeedBIP85FinalizeView)
             return Destination(SeedFinalizeView)
         else:
             return Destination(SeedOptionsView, view_args=dict(seed=self.seed), clear_history=True)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -26,23 +26,20 @@ logger = logging.getLogger(__name__)
 class SeedsMenuView(View):
     LOAD = ButtonOption("Load a seed")
 
-    def __init__(self):
-        super().__init__()
-        self.seeds = []
-        for seed in self.controller.storage.seeds:
-            self.seeds.append({
-                "fingerprint": seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            })
-
-
     def run(self):
-        if not self.seeds:
+        seeds = self.controller.storage.seeds
+
+        if not seeds:
             # Nothing to do here unless we have a seed loaded
             return Destination(LoadSeedView, clear_history=True)
 
         button_data = []
-        for seed in self.seeds:
-            button_data.append(ButtonOption(seed["fingerprint"], SeedSignerIconConstants.FINGERPRINT))
+        for seed in seeds:
+            button_data.append(seed_screens.SeedButtonOption(
+                button_label=seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+                child_index=seed.child_index if isinstance(seed, BIP85ChildSeed) else None,
+            ))
+
         button_data.append(self.LOAD)
 
         selected_menu_num = self.run_screen(
@@ -55,9 +52,8 @@ class SeedsMenuView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        elif len(self.seeds) > 0 and selected_menu_num < len(self.seeds):
-            selected_seed = self.controller.storage.seeds[selected_menu_num]
-            return Destination(SeedOptionsView, view_args={"seed": selected_seed})
+        elif len(seeds) > 0 and selected_menu_num < len(seeds):
+            return Destination(SeedOptionsView, view_args={"seed": seeds[selected_menu_num]})
 
         elif button_data[selected_menu_num] == self.LOAD:
             return Destination(LoadSeedView)
@@ -106,9 +102,11 @@ class SeedSelectSeedView(View):
 
         button_data = []
         for seed in seeds:
-            button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT, icon_color="blue"))
-        
+            button_data.append(seed_screens.SeedButtonOption(
+                button_label=seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+                child_index=seed.child_index if isinstance(seed, BIP85ChildSeed) else None,
+            ))
+
         button_data.append(self.SCAN_SEED)
         button_data.append(self.TYPE_12WORD)
         button_data.append(self.TYPE_24WORD)
@@ -334,6 +332,7 @@ class SeedFinalizeView(View):
             seed_screens.SeedFinalizeScreen,
             fingerprint=self.fingerprint,
             button_data=button_data,
+            is_bip85_child_seed=isinstance(self.seed, BIP85ChildSeed),
         )
 
         if button_data[selected_menu_num] == self.FINALIZE:
@@ -591,12 +590,14 @@ class SeedOptionsView(View):
             button_data.append(self.BIP85_CHILD_SEED)
 
         button_data.append(self.DISCARD)
-        
+
+        is_bip85_child_seed = isinstance(self.seed, BIP85ChildSeed)
         selected_menu_num = self.run_screen(
             seed_screens.SeedOptionsScreen,
             button_data=button_data,
             fingerprint=self.seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
-            is_bip85_child_seed=isinstance(self.seed, BIP85ChildSeed),
+            is_bip85_child_seed=is_bip85_child_seed,
+            bip85_index=self.seed.child_index if is_bip85_child_seed else None,
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5,10 +5,10 @@ import time
 from gettext import gettext as _
 
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants, resize_image_to_fill
-from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen
+from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen, seed_screens
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.helpers import mnemonic_generation
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import BIP85ChildSeed, Seed
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.views.seed_views import SeedDiscardView, SeedFinalizeView, SeedMnemonicEntryView, SeedOptionsView, SeedWordsWarningView, SeedExportXpubScriptTypeView
 
@@ -514,8 +514,11 @@ class ToolsAddressExplorerSelectSourceView(View):
         seeds = self.controller.storage.seeds
         button_data = []
         for seed in seeds:
-            button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT))
+            button_data.append(seed_screens.SeedButtonOption(
+                button_label=seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+                child_index=seed.child_index if isinstance(seed, BIP85ChildSeed) else None,
+            ))
+
         button_data = button_data + [self.SCAN_SEED, self.SCAN_DESCRIPTOR, self.TYPE_12WORD, self.TYPE_24WORD]
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -39,7 +39,7 @@ from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.encode_qr import BaseQrEncoder
 from seedsigner.models.psbt_parser import OPCODES, PSBTParser
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import BIP85ChildSeed, Seed
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, RemoveMicroSDWarningView, NotYetImplementedView, UnhandledExceptionView, 
@@ -114,7 +114,7 @@ mnemonic_24 = "attack pizza motion avocado network gather crop fresh patrol unus
 seed_12 = Seed(mnemonic=mnemonic_12, passphrase="cap*BRACKET3stove", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
 seed_24 = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
 seed_24_w_passphrase = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
-
+bip85_child_seed = BIP85ChildSeed(parent_seed=seed_24, child_index=0, num_words=12, mnemonic=seed_24.get_bip85_child_mnemonic(0, 12).split())
 MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFfsBrmpj226ZYiRszYi2qK6iGvh2vkkghfGB2YiRUVY4rqqedHCFEgw12FwDkm7rUoVtq9wLTKc6BN2sxswvQeQgp7m8st4FP8WtP8go76/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*))#3jhtf6yx"""
 
 # Grab the most recent release version info for the "release build" splash screenshots.
@@ -348,6 +348,52 @@ def generate_screenshots(locale):
                     yield
 
 
+        @contextmanager
+        def mock_bip85_child_seed_pending():
+            original_pending_seed = controller.storage.get_pending_seed()
+            controller.storage.set_pending_seed(bip85_child_seed)
+            try:
+                yield
+            finally:
+                controller.storage.set_pending_seed(original_pending_seed)
+
+
+        @contextmanager
+        def mock_bip85_setting_loadable():
+            """Temporarily enables the BIP85 loadable child seeds setting."""
+            original = controller.settings.get_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS)
+            controller.settings.set_value(
+                attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,
+                value=SettingsConstants.BIP85__LOADABLE,
+            )
+            try:
+                yield
+            finally:
+                controller.settings.set_value(
+                    attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,
+                    value=original,
+                )
+
+
+        @contextmanager
+        def mock_bip85_child_seed_pending_and_loadable():
+            with mock_bip85_child_seed_pending():
+                with mock_bip85_setting_loadable():
+                    yield
+
+
+        @contextmanager
+        def mock_bip85_child_seed_loaded():
+            with mock_bip85_child_seed_pending():
+                with mock_bip85_setting_loadable():
+                    seed = controller.storage.get_pending_seed()
+                    controller.storage.finalize_pending_seed()
+                    try:
+                        yield
+                    finally:
+                        controller.storage.discard_seed(seed)
+
+
         screenshot_sections = {
             "Main Menu Views": [
                 ScreenshotConfig(OpeningSplashView, dict(force_partner_logos=True), mock_context_manager=mock_version_to_most_recent_release),
@@ -395,9 +441,15 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedWordsWarningView, dict(seed=seed_12)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed=seed_12)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed=seed_12, page_index=2), screenshot_name="SeedWordsView_2"),
-                ScreenshotConfig(seed_views.SeedBIP85SelectNumWordsView,     dict(seed=seed_12)),
-                ScreenshotConfig(seed_views.SeedBIP85SelectChildIndexView,   dict(seed=seed_12, num_words=24)),
-                ScreenshotConfig(seed_views.SeedBIP85InvalidChildIndexView,  dict(seed=seed_12, num_words=12)), 
+                ScreenshotConfig(seed_views.SeedWordsView, dict(seed=bip85_child_seed), screenshot_name="SeedWordsView_bip85_child_seed"),
+                ScreenshotConfig(seed_views.SeedBIP85SelectNumWordsView,     dict(seed=seed_24)),
+                ScreenshotConfig(seed_views.SeedBIP85SelectChildIndexView,   dict(seed=seed_24, num_words=24)),
+                ScreenshotConfig(seed_views.SeedBIP85InvalidChildIndexView,  dict(seed=seed_24, num_words=12)),
+                ScreenshotConfig(seed_views.SeedBIP85FinalizeView, screenshot_name="SeedBIP85FinalizeView_view_only", mock_context_manager=mock_bip85_child_seed_pending),
+                ScreenshotConfig(seed_views.SeedBIP85FinalizeView, screenshot_name="SeedBIP85FinalizeView_loadable",  mock_context_manager=mock_bip85_child_seed_pending_and_loadable),
+                ScreenshotConfig(seed_views.SeedFinalizeView, screenshot_name="SeedFinalizeView_bip85_child_seed", mock_context_manager=mock_bip85_child_seed_pending_and_loadable),
+                ScreenshotConfig(seed_views.SeedOptionsView, dict(seed=bip85_child_seed), screenshot_name="SeedOptionsView_bip85_child_seed", mock_context_manager=mock_bip85_child_seed_loaded),
+                ScreenshotConfig(seed_views.SeedsMenuView, screenshot_name="SeedsMenuView_bip85_child_seed", mock_context_manager=mock_bip85_child_seed_loaded),
                 ScreenshotConfig(seed_views.SeedWordsBackupTestPromptView,   dict(seed=seed_12)),
                 ScreenshotConfig(seed_views.SeedWordsBackupTestView,         dict(seed=seed_12, rand_seed=6102)),
                 ScreenshotConfig(seed_views.SeedWordsBackupTestMistakeView,  dict(seed=seed_12, cur_index=7, wrong_word="satoshi")),

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -8,7 +8,7 @@ from base import FlowTestInvalidButtonDataSelectionException
 
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
 from seedsigner.models.settings import Settings, SettingsConstants
-from seedsigner.models.seed import ElectrumSeed, Seed
+from seedsigner.models.seed import BIP85ChildSeed, ElectrumSeed, Seed
 from seedsigner.views.view import MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
 from seedsigner.views import seed_views, scan_views, settings_views
 
@@ -494,6 +494,87 @@ class TestSeedFlows(FlowTest):
         ])
 
         assert self.controller.is_screensaver_start_allowed == False
+
+
+    def test_bip85_load_child_flow(self):
+        """
+            Selecting "BIP-85 Child Seed" from the SeedOptionsView should enter the BIP-85 flow and
+            end at the SeedOptionsView of the Child Seed when the load child seed setting is enabled
+        """
+        # Ensure the settings is enabled with loading
+        self.settings.set_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS, SettingsConstants.BIP85__LOADABLE)
+
+        # Load a finalized Seed into the Controller
+        mnemonic = "blush twice taste dawn feed second opinion lazy thumb play neglect impact".split()
+        self.controller.storage.set_pending_seed(Seed(mnemonic=mnemonic))
+        seed = self.controller.storage.finalize_pending_seed()
+
+        self.run_sequence(
+            initial_destination_view_args=dict(seed=seed),
+            sequence=[
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BIP85_CHILD_SEED),
+                FlowStep(seed_views.SeedBIP85SelectNumWordsView, button_data_selection=seed_views.SeedBIP85SelectNumWordsView.WORDS_12),
+                FlowStep(seed_views.SeedBIP85SelectChildIndexView, screen_return_value=0),
+                FlowStep(seed_views.SeedBIP85FinalizeView, button_data_selection=seed_views.SeedBIP85FinalizeView.LOAD),
+                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+                FlowStep(seed_views.SeedOptionsView),
+            ]
+        )
+
+        # Discarding the parent seed should also discard the child seed
+        # Verify by going to the SeedsMenuView and seeing that no seeds are loaded
+        self.run_sequence(
+            initial_destination_view_args=dict(seed=seed),
+            sequence=[
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.DISCARD),
+                FlowStep(seed_views.SeedDiscardView, button_data_selection=seed_views.SeedDiscardView.DISCARD),
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # When no seeds are loaded it auto-redirects to LoadSeedView
+                FlowStep(seed_views.LoadSeedView),
+            ]
+        )
+
+
+    def test_bip85_backup_test_success_returns_to_bip85_finalize(self):
+        """
+            After a successful backup test on a pending BIP-85 child seed, the flow must
+            return to SeedBIP85FinalizeView (NOT SeedFinalizeView, which would load the
+            child seed even in view-only mode).
+        """
+        self.settings.set_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS, SettingsConstants.BIP85__VIEW_ONLY)
+
+        # Load a finalized Seed into the Controller
+        mnemonic = "blush twice taste dawn feed second opinion lazy thumb play neglect impact".split()
+        self.controller.storage.set_pending_seed(Seed(mnemonic=mnemonic))
+        parent_seed = self.controller.storage.finalize_pending_seed()
+
+        # Set a derived child seed as the pending seed, as SeedBIP85SelectChildIndexView would
+        child_seed = BIP85ChildSeed(
+            parent_seed=parent_seed,
+            child_index=0,
+            num_words=12,
+            mnemonic=parent_seed.get_bip85_child_mnemonic(0, 12).split(),
+        )
+        self.controller.storage.set_pending_seed(child_seed)
+
+        self.run_sequence(
+            initial_destination_view_args=dict(seed=None),
+            sequence=[
+                FlowStep(seed_views.SeedWordsBackupTestSuccessView, screen_return_value=0),
+                FlowStep(seed_views.SeedBIP85FinalizeView),
+            ]
+        )
+
+        # Sanity check: a regular pending seed still routes to SeedFinalizeView
+        self.controller.storage.clear_pending_seed()
+        self.controller.storage.set_pending_seed(Seed(mnemonic=mnemonic))
+        self.run_sequence(
+            initial_destination_view_args=dict(seed=None),
+            sequence=[
+                FlowStep(seed_views.SeedWordsBackupTestSuccessView, screen_return_value=0),
+                FlowStep(seed_views.SeedFinalizeView),
+            ]
+        )
 
 
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -648,7 +648,7 @@ class TestMessageSigningFlows(FlowTest):
         ])
 
         # Scenario 2: Scan the seed first, then select Sign Message
-        self.controller.discard_seed(self.controller.storage.seeds[0])
+        self.controller.storage.discard_seed(self.controller.storage.seeds[0])
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
@@ -696,7 +696,7 @@ class TestMessageSigningFlows(FlowTest):
         ])
 
         # Scenario 4: Load a long message without whitespace
-        self.controller.discard_seed(self.controller.storage.seeds[0])
+        self.controller.storage.discard_seed(self.controller.storage.seeds[0])
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -177,7 +177,7 @@ class TestToolsFlows(FlowTest):
 
         # Scenario 4: No seed onboard, one script type enabled, started from Tools, BACK
         # can only go to MainMenu because of mid-flow seed load.
-        controller.discard_seed(seed)
+        controller.storage.discard_seed(seed)
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
             FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,5 +1,5 @@
 import pytest
-from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed
+from seedsigner.models.seed import BIP85ChildSeed, InvalidSeedException, Seed, ElectrumSeed
 
 from seedsigner.models.settings import SettingsConstants
 
@@ -83,3 +83,48 @@ def test_electrum_seed_rejects_most_bip39_mnemonics():
 	mnemonic = "only gain spot output unknown craft simple cram absorb suggest ridge famous".split()
 	Seed(mnemonic)
 	ElectrumSeed(mnemonic)
+
+
+def test_bip85_child_seed_is_not_equal_to_the_same_seed_loaded_directly():
+	"""
+	A BIP85ChildSeed and a plain Seed must never compare equal, even when their
+	seed_bytes match.
+
+	A BIP85ChildSeed carries parent/index provenance and participates in the parent/child
+	display and discard behavior, so it is a distinct in-memory entry. Treating them as
+	equal would let SeedStorage silently skip storing the child while still returning it
+	to the UI.
+	"""
+	parent_seed = Seed(mnemonic=["abandon"] * 11 + ["about"])
+	child_mnemonic = parent_seed.get_bip85_child_mnemonic(0, 12).split()
+
+	child_seed = BIP85ChildSeed(
+		parent_seed=parent_seed,
+		child_index=0,
+		num_words=12,
+		mnemonic=child_mnemonic,
+	)
+
+	# The same mnemonic, but loaded directly as a normal Seed
+	standalone_seed = Seed(mnemonic=child_mnemonic)
+
+	# Sanity check: these really do share the same underlying seed bytes
+	assert child_seed.seed_bytes == standalone_seed.seed_bytes
+
+	# ...but they must not be considered the same entry, in either direction
+	assert child_seed != standalone_seed
+	assert standalone_seed != child_seed
+
+	# ...including when the standalone Seed is on the left of an `in` check
+	assert standalone_seed not in [child_seed]
+	assert child_seed not in [standalone_seed]
+
+
+def test_bip85_child_seeds_with_matching_seed_bytes_are_equal():
+	"""Two BIP85ChildSeeds that derive to the same seed_bytes are still equal."""
+	parent_seed = Seed(mnemonic=["abandon"] * 11 + ["about"])
+	child_mnemonic = parent_seed.get_bip85_child_mnemonic(0, 12).split()
+
+	kwargs = dict(parent_seed=parent_seed, child_index=0, num_words=12, mnemonic=child_mnemonic)
+
+	assert BIP85ChildSeed(**kwargs) == BIP85ChildSeed(**kwargs)

--- a/tests/test_seed_storage.py
+++ b/tests/test_seed_storage.py
@@ -1,0 +1,136 @@
+import pytest
+
+# Must import this before the Controller
+from base import BaseTest
+
+from seedsigner.controller import Controller
+from seedsigner.models.seed import BIP85ChildSeed, Seed
+
+
+class TestSeedStorage(BaseTest):
+
+    @pytest.mark.parametrize("children_specs", [
+        # Format: [(parent_idx, child_idx, num_words), ...]
+        [(0, 0, 12)],  # Single child for first parent
+        [(0, 8, 12), (0, 1, 12), (0, 5, 12), (0, 2, 12)],  # Multiple children with different child_index values
+        [(0, 2, 24), (0, 1, 12), (0, 2, 12), (0, 1, 24)],  # Multiple children with same child_index but different num_words
+        [(1, 3, 24)],  # Single child for second parent only
+        [(1, 5, 12), (0, 1, 12), (0, 0, 24)],  # Both parents have children
+        [(1, 1, 24), (0, 3, 12), (1, 1, 12), (0, 1, 12)],  # Interleaved insertion across both parents
+        [],  # No children for either parent
+    ])
+    def test_finalize_pending_seed(self, children_specs):
+        """
+        Test that finalize_pending_seed properly orders seeds in storage.
+
+        BIP-85 child seeds should be inserted adjacent to parent, sorted by:
+        1. child_index (ascending)
+        2. num_words (12 before 24) when child_index is the same
+        """
+        storage = Controller.get_instance().storage
+
+        # Add 2 parent seeds
+        parent_mnemonics = [["abandon"] * 11 + ["about"], ["baby"] * 11 + ["away"]]
+        parent_seeds = []
+        for mnemonic in parent_mnemonics:
+            parent_seed = Seed(mnemonic=mnemonic)
+            storage.set_pending_seed(parent_seed)
+            storage.finalize_pending_seed()
+            parent_seeds.append(parent_seed)
+
+        # Create and add child seeds to storage
+        child_seeds = {0: {}, 1: {}}
+
+        for parent_idx, child_idx, num_words in children_specs:
+            parent_seed = parent_seeds[parent_idx]
+
+            child_seed = BIP85ChildSeed(
+                parent_seed=parent_seed,
+                child_index=child_idx,
+                num_words=num_words,
+                mnemonic=parent_seed.get_bip85_child_mnemonic(child_idx, num_words).split(),
+            )
+            child_seeds[parent_idx][(child_idx, num_words)] = child_seed
+            storage.set_pending_seed(child_seed)
+            storage.finalize_pending_seed()
+
+        # Build expected order: parent0, sorted children0, parent1, sorted children1
+        expected_seeds = []
+        for parent_idx in [0, 1]:
+            expected_seeds.append(parent_seeds[parent_idx])
+
+            # Add this parent's children sorted by (child_index, num_words)
+            parent_children = sorted(child_seeds[parent_idx].keys(), key=lambda x: (x[0], x[1]))
+
+            for child_idx, num_words in parent_children:
+                expected_seeds.append(child_seeds[parent_idx][(child_idx, num_words)])
+
+        assert storage.seeds == expected_seeds
+
+
+    @pytest.mark.parametrize("child_indices", [
+        [],  # No child seeds
+        [0],  # Single child
+        [5, 1, 10, 3],  # Four children with various indices
+    ])
+    def test_discard_seed(self, child_indices):
+        """
+        Discarding a seed should remove it from storage along with any of its BIP-85 child seeds.
+        """
+        storage = Controller.get_instance().storage
+
+        # Add a seed to storage
+        parent_seed = Seed(mnemonic=["abandon"] * 11 + ["about"])
+        storage.seeds.append(parent_seed)
+
+        # Add a second seed to ensure only the intended seed is removed
+        storage.seeds.append(Seed(mnemonic=["baby"] * 11 + ["away"]))
+
+        # Add child seeds to storage
+        for child_index in child_indices:
+            child_seed = BIP85ChildSeed(
+                parent_seed=parent_seed,
+                child_index=child_index,
+                num_words=12,
+                mnemonic=parent_seed.get_bip85_child_mnemonic(child_index, 12).split(),
+            )
+            storage.seeds.append(child_seed)
+
+        storage.discard_seed(parent_seed)
+        assert len(storage.seeds) == 1  # Only the second seed should remain
+
+
+    def test_child_seed_is_stored_alongside_the_same_seed_loaded_directly(self):
+        """
+        A BIP-85 child seed and the same mnemonic loaded directly as a normal Seed are
+        distinct in-memory entries; both must be stored.
+        """
+        storage = Controller.get_instance().storage
+
+        parent_seed = Seed(mnemonic=["abandon"] * 11 + ["about"])
+        child_mnemonic = parent_seed.get_bip85_child_mnemonic(0, 12).split()
+
+        # Load the child's mnemonic directly as a normal seed, before the parent exists
+        standalone_seed = Seed(mnemonic=child_mnemonic)
+        storage.set_pending_seed(standalone_seed)
+        storage.finalize_pending_seed()
+
+        storage.set_pending_seed(parent_seed)
+        storage.finalize_pending_seed()
+
+        # Now derive + load that same seed as a BIP-85 child
+        child_seed = BIP85ChildSeed(
+            parent_seed=parent_seed,
+            child_index=0,
+            num_words=12,
+            mnemonic=child_mnemonic,
+        )
+        storage.set_pending_seed(child_seed)
+        storage.finalize_pending_seed()
+
+        # Both representations are present, with the child adjacent to its parent
+        assert storage.seeds == [standalone_seed, parent_seed, child_seed]
+
+        # Discarding the parent removes only the child; the standalone seed survives
+        storage.discard_seed(parent_seed)
+        assert storage.seeds == [standalone_seed]


### PR DESCRIPTION
## Description

Closes #354.

This PR introduces support for directly loading BIP-85 generated seeds into the UX.

- Adds `SeedBIP85FinalizeView`, with [this flow](https://excalidraw.com/#json=tbXTKuqraFUOCbBPMh9xj,LERaz9c9GSGufgOKdkPQCg) in mind.
- Adds `BIP85ChildSeed` and refactors codebase to eliminate the need of passing around `bip85_data`.
- Discards child seeds if parent is discarded.
- Adds visual indicators on all list views to differentiate child seeds and understand hierarchy.
	> Note: I initially wanted to use [this icon](https://fontawesome.com/icons/arrow-turn-down-right?f=classic&s=solid) instead of the plain arrow, but unfortunately it's a _pro_ icon. Perhaps we could make a custom icon for this in the SeedSigner Font?
- Adds child seed info in `SeedOptionsView`.
- Adds a new setting option for BIP-85.

### New Screenshots

<img width="240" height="240" alt="SettingsEntryUpdateSelectionView_bip85_child_seeds" src="https://github.com/user-attachments/assets/ffff70da-bf41-4d98-b460-52ecfb42d54c" /> <img width="240" height="240" alt="SeedBIP85FinalizeView_loadable" src="https://github.com/user-attachments/assets/acad4839-5d55-403f-8b56-824ad86e8d09" /> <img width="240" height="240" alt="SeedFinalizeView_bip85_child_seed" src="https://github.com/user-attachments/assets/69eb8224-a499-4a67-b179-7e0af5a82a21" /> <img width="240" height="240" alt="SeedOptionsView_bip85_child_seed" src="https://github.com/user-attachments/assets/05cc7f6c-6b2d-4a80-b565-826fb127a2c6" /> <img width="240" height="240" alt="SeedsMenuView_bip85_child_seed" src="https://github.com/user-attachments/assets/4434eacf-dbae-4753-b7f9-d4c3f4bcfefc" /> <img width="240" height="240" alt="SeedDiscardView" src="https://github.com/user-attachments/assets/ba1dc4fc-79ef-4dd0-bc6e-1e6cac04f80b" /> <img width="240" height="240" alt="SeedWordsView_bip85_child_seed" src="https://github.com/user-attachments/assets/07746c9f-49c9-4566-a8f9-dfacba06fc32" />


### Other minor changes:
- Rewords "Wipe" to "Discard" in `SeedDiscardView`.
- Makes the following `SelectSeedViews` consistent with other In-Memory Seeds views and use white for the fingerprint icon instead of blue.

<img width="240" height="240" alt="SeedDiscardView" src="https://github.com/user-attachments/assets/18afa8b5-8d59-4d2c-ac03-dc50d2d982af" /> <img width="240" height="240" alt="SeedSelectSeedView_address_verification" src="https://github.com/user-attachments/assets/bf974e21-abc9-4469-825d-166b32e11b0a" /> <img width="240" height="240" alt="SeedSelectSeedView_sign_message" src="https://github.com/user-attachments/assets/5ee7c5bc-2e31-4caf-a0af-26b881545d08" />


## TODO
- [x] Settings Menu: Add a third option to enable BIP-85 seed generation and loading.
	- Note: The BIP-85 setting changed from enabled/disabled to a three-option select (Disabled / View-only / Loadable), so users who previously enabled it will find it effectively disabled until they re-select a mode.
- [x] Visual Indicators: Add metadata (e.g., parent fingerprint, child index) in `SeedOptionsView` and differentiate child seeds/show parent relationship in Seeds List Views.
- [x] Tests, Screenshot Generator: Implement appropriate unit and integration tests, add screenshots.

---

This pull request is categorized as a:

- [x] New feature

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] Yes

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
