### PR TITLE
[l10n] Add logger message in Controller if libraqm not supported

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -174,8 +174,7 @@ class Controller(Singleton):
 
         # Check for libraqm support and log the status if not supported
         from PIL import features
-        has_libraqm = features.check('raqm')
-        if not has_libraqm:
+        if not features.check('raqm'):
             logger.warning("libraqm support: NOT AVAILABLE - Complex text rendering may be limited")
 
         # models

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -172,6 +172,12 @@ class Controller(Singleton):
         controller = cls.__new__(cls)
         cls._instance = controller
 
+        # Check for libraqm support and log the status if not supported
+        from PIL import features
+        has_libraqm = features.check('raqm')
+        if not has_libraqm:
+            logger.warning("libraqm support: NOT AVAILABLE - Complex text rendering may be limited")
+
         # models
         controller.settings = Settings.get_instance()
         


### PR DESCRIPTION
## Description

Adds logging to detect and report if libraqm is not supported during Controller initialization. This change helps developers identify when the optional libraqm dependency is missing, which can cause limitations in complex text rendering capabilities, specially for Right-to-Left (RTL) languages.

When the Controller is first initialized, it now checks for libraqm support using `PIL.features.check('raqm')` and logs a WARNING message when `libraqm` is not available.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
