### PR TITLE
[Feature] Add support for accented characters during passphrase input

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -1,14 +1,14 @@
-# Translations template for seedsigner.
+# Translations template for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
-# This file is distributed under the same license as the seedsigner project.
+# This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: seedsigner 0.8.5\n"
+"Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-05-20 09:27-0500\n"
+"POT-Creation-Date: 2025-08-30 07:25+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Xpub Details"
 msgstr ""
 
-#. Short for "BIP32 Master Fingerprint"
+#. Short for "BIP-32 Master Fingerprint"
 #. a label for the shortened Key-id of a BIP-32 master HD wallet
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
@@ -701,7 +701,7 @@ msgstr ""
 msgid "Custom Derivation"
 msgstr ""
 
-#. Terminology used by Electrum seeds; equivalent to bip39 passphrase
+#. Terminology used by Electrum seeds; equivalent to BIP-39 passphrase
 #: src/seedsigner/models/settings_definition.py
 msgid "Custom Extension"
 msgstr ""
@@ -752,6 +752,10 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "BIP-39 passphrase"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Special charset for passphrase"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
@@ -1079,11 +1083,23 @@ msgid "Discard passphrase"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
 msgid "Discard passphrase?"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Your current passphrase entry will be erased"
+msgid "Your current passphrase entry will be erased."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase?"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1351,6 +1367,10 @@ msgstr ""
 
 #: src/seedsigner/views/tools_views.py
 msgid "Mnemonic Length?"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Calculating..."
 msgstr ""
 
 #. Inserts the number of dice rolls needed for a 12-word mnemonic

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -764,7 +764,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
-        self.text_to_keyboard_1[self.KEYBOARD__LOWERCASE_BUTTON_TEXT] = self.keyboard_abc
+        self.text_to_keyboard_1[self.KEYBOARD__UPPERCASE_BUTTON_TEXT] = self.keyboard_ABC
 
         self.keyboard_accented_lower_1 = Keyboard(
             draw=self.renderer.draw,
@@ -962,6 +962,10 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         )
         self.text_to_keyboard_2[self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT] = self.keyboard_symbols_2
 
+        # Set the list of button texts for cycling
+        self.button1_texts = list(self.text_to_keyboard_1.keys())
+        self.button2_texts = list(self.text_to_keyboard_2.keys())
+
         self.text_entry_display = TextEntryDisplay(
             canvas=self.renderer.canvas,
             rect=(
@@ -1017,16 +1021,14 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         super()._render()
         # If the initial keyboard is a textual input keyboard, then cycle through hw_button1 text
         if self.initial_keyboard in self.text_to_keyboard_1:
-            button_texts = list(self.text_to_keyboard_1.keys())
             cur_keyboard = self.text_to_keyboard_1[self.initial_keyboard]
             # Set the hw_button1 text as the keyboard of the next keyboard in the list (modulo wrap)
-            self.hw_button1.text = button_texts[(button_texts.index(self.initial_keyboard) + 1) % len(button_texts)]
-        # Else through hw_button2 text
+            self.hw_button1.text = self.button1_texts[(self.button1_texts.index(self.initial_keyboard) + 1) % len(self.button1_texts)]
+        # Else cycle through hw_button2 text
         else:
-            button_texts = list(self.text_to_keyboard_2.keys())
             cur_keyboard = self.text_to_keyboard_2[self.initial_keyboard]
             # Similarly for hw_button2
-            self.hw_button2.text = button_texts[(button_texts.index(self.initial_keyboard) + 1) % len(button_texts)]
+            self.hw_button2.text = self.button2_texts[(self.button2_texts.index(self.initial_keyboard) + 1) % len(self.button2_texts)]
 
         self.text_entry_display.render()
         self.hw_button1.render()
@@ -1042,6 +1044,8 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         cur_keyboard = self.keyboard_abc
         cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
         cur_button2_text = self.KEYBOARD__DIGITS_BUTTON_TEXT
+        keyboard_to_text_1 = {v: k for k, v in self.text_to_keyboard_1.items()}
+        keyboard_to_text_2 = {v: k for k, v in self.text_to_keyboard_2.items()}
 
         # Start the interactive update loop
         while True:
@@ -1071,49 +1075,14 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                     self.hw_button1.render()
 
                     # Return to the same button2 keyboard, if applicable
-                    if cur_keyboard == self.keyboard_digits:
-                        cur_button2_text = self.KEYBOARD__DIGITS_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_symbols_1:
-                        cur_button2_text = self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_symbols_2:
-                        cur_button2_text = self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT
+                    if cur_keyboard in keyboard_to_text_2:
+                        cur_button2_text = keyboard_to_text_2[cur_keyboard]
 
-                    if cur_button1_text == self.KEYBOARD__LOWERCASE_BUTTON_TEXT:
-                        self.keyboard_abc.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_abc
-                        cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__UPPERCASE_BUTTON_TEXT:
-                        self.keyboard_ABC.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_ABC
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT:
-                        self.keyboard_accented_lower_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_lower_1
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT:
-                        self.keyboard_accented_upper_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_upper_1
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT:
-                        self.keyboard_accented_lower_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_lower_2
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT:
-                        self.keyboard_accented_upper_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_upper_2
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT:
-                        self.keyboard_accented_lower_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_lower_3
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT:
-                        self.keyboard_accented_upper_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_upper_3
-                        cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
-                    else:
-                        self.keyboard_ABC.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_ABC
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
+                    if cur_button1_text in self.text_to_keyboard_1:
+                        self.text_to_keyboard_1[cur_button1_text].set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.text_to_keyboard_1[cur_button1_text]
+                        cur_button1_text = self.button1_texts[(self.button1_texts.index(cur_button1_text) + 1) % len(self.button1_texts)]
+
                     cur_keyboard.render_keys()
 
                     # Show the changes; this loop will have two renders
@@ -1132,38 +1101,15 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                     self.hw_button2.is_selected = False
 
                     # Return to the same button1 keyboard, if applicable
-                    if cur_keyboard == self.keyboard_abc:
-                        cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_ABC:
-                        cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_lower_1:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_upper_1:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_lower_2:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_upper_2:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_lower_3:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_upper_3:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
+                    if cur_keyboard in keyboard_to_text_1:
+                        cur_button1_text = keyboard_to_text_1[cur_keyboard]
 
-                    if cur_button2_text == self.KEYBOARD__DIGITS_BUTTON_TEXT:
-                        self.keyboard_digits.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_digits
+                    if cur_button2_text in self.text_to_keyboard_2:
+                        self.text_to_keyboard_2[cur_button2_text].set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.text_to_keyboard_2[cur_button2_text]
                         cur_keyboard.render_keys()
-                        cur_button2_text = self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT
-                    elif cur_button2_text == self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT:
-                        self.keyboard_symbols_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_symbols_1
-                        cur_keyboard.render_keys()
-                        cur_button2_text = self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT
-                    elif cur_button2_text == self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT:
-                        self.keyboard_symbols_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_symbols_2
-                        cur_keyboard.render_keys()
-                        cur_button2_text = self.KEYBOARD__DIGITS_BUTTON_TEXT
+                        cur_button2_text = self.button2_texts[(self.button2_texts.index(cur_button2_text) + 1) % len(self.button2_texts)]
+
                     cur_keyboard.render_keys()
 
                     # Show the changes; this loop will have two renders

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -14,6 +14,7 @@ from seedsigner.gui.components import (Button, FontAwesomeIconConstants, Fonts, 
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.renderer import Renderer
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
+from seedsigner.models.settings import Settings, SettingsConstants
 
 from .screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen, LargeIconStatusScreen, WarningEdgesMixin
 
@@ -669,20 +670,14 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
 
     # Only used by the screenshot generator
     initial_keyboard: str = None
+    is_full_charset: bool = False
+    full_charset: str = None
 
     KEYBOARD__LOWERCASE_BUTTON_TEXT = "abc"
     KEYBOARD__UPPERCASE_BUTTON_TEXT = "ABC"
     KEYBOARD__DIGITS_BUTTON_TEXT = "123"
     KEYBOARD__SYMBOLS_1_BUTTON_TEXT = "!@#"
     KEYBOARD__SYMBOLS_2_BUTTON_TEXT = "*[]"
-    KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT = "áéí"
-    KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT = "ÁÉÍ"
-    KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT = "ëïü"
-    KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT = "ËÏÜ"
-    KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT = "çñş"
-    KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT = "ÇÑŞ"
-
-
 
     def __post_init__(self):
         self.title = _("BIP-39 Passphrase")
@@ -699,19 +694,6 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         # Isolate the more math-oriented or just uncommon symbols
         keys_symbol_2 = """^*[]{}_\\|<>/`~"""
 
-        # Split accented characters: separate vowels and consonants across keyboards
-        # Keyboard 1: Common accented vowels
-        keys_accented_lower_1 = "áéíóúàèìòùâêîôûãõ"
-        keys_accented_upper_1 = "ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕ"
-        
-        # Keyboard 2: Some rare accented vowels
-        keys_accented_lower_2 = "ëïüÿăąæøåð"
-        keys_accented_upper_2 = "ËÏÜŸĂĄÆØÅÐ"
-        
-        # Keyboard 3: Some common accented consonants
-        keys_accented_lower_3 = "çñşțćłšžčřňťđĺŕľĵĝħ"
-        keys_accented_upper_3 = "ÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ"
-
         # Set up the keyboard params
         self.right_panel_buttons_width = 56
 
@@ -722,6 +704,62 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
         self.text_to_keyboard_1 = dict(); #for textual input keyboards
         self.text_to_keyboard_2 = dict(); #for symbol/digit input keyboards
+
+        # Both the is_full_charset (in settings) and the full_charset should be specified
+        # For English (default), full_charset is None so this won't be executed
+        if self.is_full_charset and self.full_charset:
+            self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT = self.full_charset[0][0:3]
+            self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT = self.full_charset[1][0:3]
+
+            keys_accented_lower= self.full_charset[0]
+            n_rows_lower = math.ceil(len(keys_accented_lower) / max_cols)+1
+
+            keys_accented_upper= self.full_charset[1]
+            n_rows_upper = math.ceil(len(keys_accented_upper) / max_cols)+1
+
+            self.keyboard_accented_lower = Keyboard(
+                draw=self.renderer.draw,
+                charset=keys_accented_lower,
+                rows=n_rows_lower,
+                cols=max_cols,
+                rect=(
+                    GUIConstants.COMPONENT_PADDING,
+                    keyboard_start_y,
+                    self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                    self.canvas_height - GUIConstants.EDGE_PADDING
+                ),
+                additional_keys=[
+                    Keyboard.KEY_SPACE_5,
+                    Keyboard.KEY_CURSOR_LEFT,
+                    Keyboard.KEY_CURSOR_RIGHT,
+                    Keyboard.KEY_BACKSPACE
+                ],
+                auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+                render_now=False
+            )
+            self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT] = self.keyboard_accented_lower
+
+            self.keyboard_accented_upper = Keyboard(
+                draw=self.renderer.draw,
+                charset=keys_accented_upper,
+                rows=n_rows_upper,
+                cols=max_cols,
+                rect=(
+                    GUIConstants.COMPONENT_PADDING,
+                    keyboard_start_y,
+                    self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                    self.canvas_height - GUIConstants.EDGE_PADDING
+                ),
+                additional_keys=[
+                    Keyboard.KEY_SPACE_5,
+                    Keyboard.KEY_CURSOR_LEFT,
+                    Keyboard.KEY_CURSOR_RIGHT,
+                    Keyboard.KEY_BACKSPACE
+                ],
+                auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+                render_now=False
+            )
+            self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT] = self.keyboard_accented_upper
 
         self.keyboard_abc = Keyboard(
             draw=self.renderer.draw,
@@ -765,137 +803,6 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             render_now=False
         )
         self.text_to_keyboard_1[self.KEYBOARD__UPPERCASE_BUTTON_TEXT] = self.keyboard_ABC
-
-        self.keyboard_accented_lower_1 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_lower_1,
-            rows=3,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
-        )
-        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT] = self.keyboard_accented_lower_1
-
-        self.keyboard_accented_upper_1 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_upper_1,
-            rows=3,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT] = self.keyboard_accented_upper_1
-
-        self.keyboard_accented_lower_2 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_lower_2,
-            rows=3,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT] = self.keyboard_accented_lower_2
-
-        self.keyboard_accented_upper_2 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_upper_2,
-            rows=3,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT] = self.keyboard_accented_upper_2
-
-        self.keyboard_accented_lower_3 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_lower_3,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT] = self.keyboard_accented_lower_3
-
-        self.keyboard_accented_upper_3 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_upper_3,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT] = self.keyboard_accented_upper_3
 
         self.keyboard_digits = Keyboard(
             draw=self.renderer.draw,

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -670,8 +670,8 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
 
     # Only used by the screenshot generator
     initial_keyboard: str = None
-    is_full_charset: bool = False
-    full_charset: str = None
+    has_special_charset: bool = False
+    special_charset: str = None
 
     KEYBOARD__LOWERCASE_BUTTON_TEXT = "abc"
     KEYBOARD__UPPERCASE_BUTTON_TEXT = "ABC"
@@ -705,21 +705,21 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         self.text_to_keyboard_1 = dict(); #for textual input keyboards
         self.text_to_keyboard_2 = dict(); #for symbol/digit input keyboards
 
-        # Both the is_full_charset (in settings) and the full_charset should be specified
-        # For English (default), full_charset is None so this won't be executed
-        if self.is_full_charset and self.full_charset:
-            self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT = self.full_charset[0][0:3]
-            self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT = self.full_charset[1][0:3]
+        # Both the has_special_charset (in settings) and the special_charset should be specified
+        # For English (default), special_charset is None so this won't be executed
+        if self.has_special_charset and self.special_charset:
+            self.KEYBOARD__SPECIAL_LOWERCASE_BUTTON_TEXT = self.special_charset[0][0:3]
+            self.KEYBOARD__SPECIAL_UPPERCASE_BUTTON_TEXT = self.special_charset[1][0:3]
 
-            keys_accented_lower= self.full_charset[0]
-            n_rows_lower = math.ceil(len(keys_accented_lower) / max_cols)+1
+            keys_special_lower= self.special_charset[0]
+            n_rows_lower = math.ceil(len(keys_special_lower) / max_cols)+1
 
-            keys_accented_upper= self.full_charset[1]
-            n_rows_upper = math.ceil(len(keys_accented_upper) / max_cols)+1
+            keys_special_upper= self.special_charset[1]
+            n_rows_upper = math.ceil(len(keys_special_upper) / max_cols)+1
 
-            self.keyboard_accented_lower = Keyboard(
+            self.keyboard_special_lower = Keyboard(
                 draw=self.renderer.draw,
-                charset=keys_accented_lower,
+                charset=keys_special_lower,
                 rows=n_rows_lower,
                 cols=max_cols,
                 rect=(
@@ -737,11 +737,11 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                 auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
                 render_now=False
             )
-            self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT] = self.keyboard_accented_lower
+            self.text_to_keyboard_1[self.KEYBOARD__SPECIAL_LOWERCASE_BUTTON_TEXT] = self.keyboard_special_lower
 
-            self.keyboard_accented_upper = Keyboard(
+            self.keyboard_special_upper = Keyboard(
                 draw=self.renderer.draw,
-                charset=keys_accented_upper,
+                charset=keys_special_upper,
                 rows=n_rows_upper,
                 cols=max_cols,
                 rect=(
@@ -759,7 +759,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                 auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
                 render_now=False
             )
-            self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT] = self.keyboard_accented_upper
+            self.text_to_keyboard_1[self.KEYBOARD__SPECIAL_UPPERCASE_BUTTON_TEXT] = self.keyboard_special_upper
 
         self.keyboard_abc = Keyboard(
             draw=self.renderer.draw,

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -720,130 +720,6 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         text_entry_display_height = 30
 
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
-        self.keyboard_accented_1 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_lower_1,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
-        )
-
-        self.keyboard_accented_upper_1 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_upper_1,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-
-        self.keyboard_accented_2 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_lower_2,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-
-        self.keyboard_accented_upper_2 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_upper_2,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-
-        self.keyboard_accented_3 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_lower_3,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
-
-        self.keyboard_accented_upper_3 = Keyboard(
-            draw=self.renderer.draw,
-            charset=keys_accented_upper_3,
-            rows=4,
-            cols=max_cols,
-            rect=(
-                GUIConstants.COMPONENT_PADDING,
-                keyboard_start_y,
-                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
-                self.canvas_height - GUIConstants.EDGE_PADDING
-            ),
-            additional_keys=[
-                Keyboard.KEY_SPACE_5,
-                Keyboard.KEY_CURSOR_LEFT,
-                Keyboard.KEY_CURSOR_RIGHT,
-                Keyboard.KEY_BACKSPACE
-            ],
-            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
-            render_now=False
-        )
 
         self.keyboard_abc = Keyboard(
             draw=self.renderer.draw,
@@ -868,6 +744,131 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         self.keyboard_ABC = Keyboard(
             draw=self.renderer.draw,
             charset=keys_upper,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_lower_1 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_lower_1,
+            rows=3,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
+        )
+
+        self.keyboard_accented_upper_1 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_upper_1,
+            rows=3,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_lower_2 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_lower_2,
+            rows=3,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_upper_2 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_upper_2,
+            rows=3,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_lower_3 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_lower_3,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_upper_3 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_upper_3,
             rows=4,
             cols=max_cols,
             rect=(
@@ -1008,7 +1009,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_1
+            cur_keyboard = self.keyboard_accented_lower_1
             self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT:
@@ -1016,7 +1017,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_2
+            cur_keyboard = self.keyboard_accented_lower_2
             self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT:
@@ -1024,7 +1025,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_3
+            cur_keyboard = self.keyboard_accented_lower_3
             self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT:
@@ -1105,24 +1106,24 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                         cur_keyboard = self.keyboard_ABC
                         cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
                     elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT:
-                        self.keyboard_accented_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_1
+                        self.keyboard_accented_lower_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_lower_1
                         cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
                     elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT:
                         self.keyboard_accented_upper_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                         cur_keyboard = self.keyboard_accented_upper_1
                         cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
                     elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT:
-                        self.keyboard_accented_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_2
+                        self.keyboard_accented_lower_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_lower_2
                         cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
                     elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT:
                         self.keyboard_accented_upper_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                         cur_keyboard = self.keyboard_accented_upper_2
                         cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
                     elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT:
-                        self.keyboard_accented_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_3
+                        self.keyboard_accented_lower_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_lower_3
                         cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
                     elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT:
                         self.keyboard_accented_upper_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
@@ -1154,15 +1155,15 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                         cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
                     elif cur_keyboard == self.keyboard_ABC:
                         cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_1:
+                    elif cur_keyboard == self.keyboard_accented_lower_1:
                         cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
                     elif cur_keyboard == self.keyboard_accented_upper_1:
                         cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_2:
+                    elif cur_keyboard == self.keyboard_accented_lower_2:
                         cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
                     elif cur_keyboard == self.keyboard_accented_upper_2:
                         cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_3:
+                    elif cur_keyboard == self.keyboard_accented_lower_3:
                         cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
                     elif cur_keyboard == self.keyboard_accented_upper_3:
                         cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -675,8 +675,12 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
     KEYBOARD__DIGITS_BUTTON_TEXT = "123"
     KEYBOARD__SYMBOLS_1_BUTTON_TEXT = "!@#"
     KEYBOARD__SYMBOLS_2_BUTTON_TEXT = "*[]"
-    KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT = "áêç"
-    KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT = "ÁÊÇ"
+    KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT = "áéí"
+    KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT = "ÁÉÍ"
+    KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT = "ëïü"
+    KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT = "ËÏÜ"
+    KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT = "çñş"
+    KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT = "ÇÑŞ"
 
 
 
@@ -695,8 +699,18 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         # Isolate the more math-oriented or just uncommon symbols
         keys_symbol_2 = """^*[]{}_\\|<>/`~"""
 
-        keys_accented_lower = "áéíóúàèìòùâêîôûãõëïüÿçăâîșț"
-        keys_accented_upper = "ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ"
+        # Split accented characters: separate vowels and consonants across keyboards
+        # Keyboard 1: Common accented vowels
+        keys_accented_lower_1 = "áéíóúàèìòùâêîôûãõ"
+        keys_accented_upper_1 = "ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕ"
+        
+        # Keyboard 2: Some rare accented vowels
+        keys_accented_lower_2 = "ëïüÿăąæøåð"
+        keys_accented_upper_2 = "ËÏÜŸĂĄÆØÅÐ"
+        
+        # Keyboard 3: Some common accented consonants
+        keys_accented_lower_3 = "çñşțćłšžčřňťđĺŕľĵĝħ"
+        keys_accented_upper_3 = "ÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ"
 
         # Set up the keyboard params
         self.right_panel_buttons_width = 56
@@ -706,9 +720,9 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         text_entry_display_height = 30
 
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
-        self.keyboard_accented = Keyboard(
+        self.keyboard_accented_1 = Keyboard(
             draw=self.renderer.draw,
-            charset=keys_accented_lower,
+            charset=keys_accented_lower_1,
             rows=4,
             cols=max_cols,
             rect=(
@@ -726,9 +740,93 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
         )
 
-        self.keyboard_accented_upper = Keyboard(
+        self.keyboard_accented_upper_1 = Keyboard(
             draw=self.renderer.draw,
-            charset=keys_accented_upper,
+            charset=keys_accented_upper_1,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_2 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_lower_2,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_upper_2 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_upper_2,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_3 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_lower_3,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
+        self.keyboard_accented_upper_3 = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_upper_3,
             rows=4,
             cols=max_cols,
             rect=(
@@ -907,14 +1005,30 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         # Change from the default lowercase keyboard for the screenshot generator
         if self.initial_keyboard == self.KEYBOARD__UPPERCASE_BUTTON_TEXT:
             cur_keyboard = self.keyboard_ABC
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
 
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_1
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
 
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_upper
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_upper_1
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
+
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_2
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
+
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_upper_2
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
+
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_3
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
+
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_upper_3
             self.hw_button1.text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__DIGITS_BUTTON_TEXT:
@@ -989,19 +1103,35 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                     elif cur_button1_text == self.KEYBOARD__UPPERCASE_BUTTON_TEXT:
                         self.keyboard_ABC.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                         cur_keyboard = self.keyboard_ABC
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT:
-                        self.keyboard_accented.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT
-                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT:
-                        self.keyboard_accented_upper.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
-                        cur_keyboard = self.keyboard_accented_upper
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT:
+                        self.keyboard_accented_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_1
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT:
+                        self.keyboard_accented_upper_1.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_upper_1
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT:
+                        self.keyboard_accented_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_2
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT:
+                        self.keyboard_accented_upper_2.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_upper_2
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT:
+                        self.keyboard_accented_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_3
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT:
+                        self.keyboard_accented_upper_3.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_upper_3
                         cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
                     else:
                         self.keyboard_ABC.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                         cur_keyboard = self.keyboard_ABC
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
                     cur_keyboard.render_keys()
 
                     # Show the changes; this loop will have two renders
@@ -1024,10 +1154,18 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                         cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
                     elif cur_keyboard == self.keyboard_ABC:
                         cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
-                    elif cur_keyboard == self.keyboard_accented_upper:
-                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_1:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_upper_1:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_2:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_upper_2:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_3:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_upper_3:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
 
                     if cur_button2_text == self.KEYBOARD__DIGITS_BUTTON_TEXT:
                         self.keyboard_digits.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1310,7 +1310,7 @@ class SeedReviewPassphraseScreen(ButtonListScreen):
             if found_solution:
                 break
             font = Fonts.get_font(font_name=GUIConstants.FIXED_WIDTH_FONT_NAME, size=font_size)
-            left, top, right, bottom  = font.getbbox("X")
+            left, top, right, bottom  = font.getbbox("Ț")
             char_width, char_height = right - left, bottom - top
             for num_lines in range(1, max_lines+1):
                 # Break the passphrase into n lines

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -675,6 +675,9 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
     KEYBOARD__DIGITS_BUTTON_TEXT = "123"
     KEYBOARD__SYMBOLS_1_BUTTON_TEXT = "!@#"
     KEYBOARD__SYMBOLS_2_BUTTON_TEXT = "*[]"
+    KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT = "áêç"
+    KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT = "ÁÊÇ"
+
 
 
     def __post_init__(self):
@@ -692,6 +695,8 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         # Isolate the more math-oriented or just uncommon symbols
         keys_symbol_2 = """^*[]{}_\\|<>/`~"""
 
+        keys_accented_lower = "áéíóúàèìòùâêîôûãõëïüÿçăâîșț"
+        keys_accented_upper = "ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ"
 
         # Set up the keyboard params
         self.right_panel_buttons_width = 56
@@ -701,6 +706,47 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         text_entry_display_height = 30
 
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
+        self.keyboard_accented = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_lower,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
+        )
+
+        self.keyboard_accented_upper = Keyboard(
+            draw=self.renderer.draw,
+            charset=keys_accented_upper,
+            rows=4,
+            cols=max_cols,
+            rect=(
+                GUIConstants.COMPONENT_PADDING,
+                keyboard_start_y,
+                self.canvas_width - GUIConstants.COMPONENT_PADDING - self.right_panel_buttons_width,
+                self.canvas_height - GUIConstants.EDGE_PADDING
+            ),
+            additional_keys=[
+                Keyboard.KEY_SPACE_5,
+                Keyboard.KEY_CURSOR_LEFT,
+                Keyboard.KEY_CURSOR_RIGHT,
+                Keyboard.KEY_BACKSPACE
+            ],
+            auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+            render_now=False
+        )
+
         self.keyboard_abc = Keyboard(
             draw=self.renderer.draw,
             charset=keys_lower,
@@ -861,6 +907,14 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         # Change from the default lowercase keyboard for the screenshot generator
         if self.initial_keyboard == self.KEYBOARD__UPPERCASE_BUTTON_TEXT:
             cur_keyboard = self.keyboard_ABC
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
+
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented
+            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT
+
+        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT:
+            cur_keyboard = self.keyboard_accented_upper
             self.hw_button1.text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
 
         elif self.initial_keyboard == self.KEYBOARD__DIGITS_BUTTON_TEXT:
@@ -932,10 +986,22 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                         self.keyboard_abc.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                         cur_keyboard = self.keyboard_abc
                         cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__UPPERCASE_BUTTON_TEXT:
+                        self.keyboard_ABC.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_ABC
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT:
+                        self.keyboard_accented.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT
+                    elif cur_button1_text == self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT:
+                        self.keyboard_accented_upper.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
+                        cur_keyboard = self.keyboard_accented_upper
+                        cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
                     else:
                         self.keyboard_ABC.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])
                         cur_keyboard = self.keyboard_ABC
-                        cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
                     cur_keyboard.render_keys()
 
                     # Show the changes; this loop will have two renders
@@ -958,6 +1024,10 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
                         cur_button1_text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
                     elif cur_keyboard == self.keyboard_ABC:
                         cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_LOWERCASE_BUTTON_TEXT
+                    elif cur_keyboard == self.keyboard_accented_upper:
+                        cur_button1_text = self.KEYBOARD__ACCENTED_UPPERCASE_BUTTON_TEXT
 
                     if cur_button2_text == self.KEYBOARD__DIGITS_BUTTON_TEXT:
                         self.keyboard_digits.set_selected_key_indices(x=cur_keyboard.selected_key["x"], y=cur_keyboard.selected_key["y"])

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -720,6 +720,8 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         text_entry_display_height = 30
 
         keyboard_start_y = text_entry_display_y + text_entry_display_height + GUIConstants.COMPONENT_PADDING
+        self.text_to_keyboard_1 = dict(); #for textual input keyboards
+        self.text_to_keyboard_2 = dict(); #for symbol/digit input keyboards
 
         self.keyboard_abc = Keyboard(
             draw=self.renderer.draw,
@@ -740,6 +742,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             ],
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
         )
+        self.text_to_keyboard_1[self.KEYBOARD__LOWERCASE_BUTTON_TEXT] = self.keyboard_abc
 
         self.keyboard_ABC = Keyboard(
             draw=self.renderer.draw,
@@ -761,6 +764,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_1[self.KEYBOARD__LOWERCASE_BUTTON_TEXT] = self.keyboard_abc
 
         self.keyboard_accented_lower_1 = Keyboard(
             draw=self.renderer.draw,
@@ -781,6 +785,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             ],
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT]
         )
+        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT] = self.keyboard_accented_lower_1
 
         self.keyboard_accented_upper_1 = Keyboard(
             draw=self.renderer.draw,
@@ -802,6 +807,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT] = self.keyboard_accented_upper_1
 
         self.keyboard_accented_lower_2 = Keyboard(
             draw=self.renderer.draw,
@@ -823,6 +829,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT] = self.keyboard_accented_lower_2
 
         self.keyboard_accented_upper_2 = Keyboard(
             draw=self.renderer.draw,
@@ -844,6 +851,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT] = self.keyboard_accented_upper_2
 
         self.keyboard_accented_lower_3 = Keyboard(
             draw=self.renderer.draw,
@@ -865,6 +873,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT] = self.keyboard_accented_lower_3
 
         self.keyboard_accented_upper_3 = Keyboard(
             draw=self.renderer.draw,
@@ -886,6 +895,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_1[self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT] = self.keyboard_accented_upper_3
 
         self.keyboard_digits = Keyboard(
             draw=self.renderer.draw,
@@ -906,6 +916,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_2[self.KEYBOARD__DIGITS_BUTTON_TEXT] = self.keyboard_digits
 
         self.keyboard_symbols_1 = Keyboard(
             draw=self.renderer.draw,
@@ -927,6 +938,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_2[self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT] = self.keyboard_symbols_1
 
         self.keyboard_symbols_2 = Keyboard(
             draw=self.renderer.draw,
@@ -948,6 +960,7 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
             auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
             render_now=False
         )
+        self.text_to_keyboard_2[self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT] = self.keyboard_symbols_2
 
         self.text_entry_display = TextEntryDisplay(
             canvas=self.renderer.canvas,
@@ -1002,50 +1015,18 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
 
     def _render(self):
         super()._render()
-
-        # Change from the default lowercase keyboard for the screenshot generator
-        if self.initial_keyboard == self.KEYBOARD__UPPERCASE_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_ABC
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_1_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_lower_1
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_1_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_upper_1
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_2_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_lower_2
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_2_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_upper_2
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_LOWERCASE_3_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_lower_3
-            self.hw_button1.text = self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__ACCENTED_UPPERCASE_3_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_accented_upper_3
-            self.hw_button1.text = self.KEYBOARD__LOWERCASE_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__DIGITS_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_digits
-            self.hw_button2.text = self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__SYMBOLS_1_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_symbols_1
-            self.hw_button2.text = self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT
-
-        elif self.initial_keyboard == self.KEYBOARD__SYMBOLS_2_BUTTON_TEXT:
-            cur_keyboard = self.keyboard_symbols_2
-            self.hw_button2.text = self.KEYBOARD__DIGITS_BUTTON_TEXT
-        
+        # If the initial keyboard is a textual input keyboard, then cycle through hw_button1 text
+        if self.initial_keyboard in self.text_to_keyboard_1:
+            button_texts = list(self.text_to_keyboard_1.keys())
+            cur_keyboard = self.text_to_keyboard_1[self.initial_keyboard]
+            # Set the hw_button1 text as the keyboard of the next keyboard in the list (modulo wrap)
+            self.hw_button1.text = button_texts[(button_texts.index(self.initial_keyboard) + 1) % len(button_texts)]
+        # Else through hw_button2 text
         else:
-            cur_keyboard = self.keyboard_abc
+            button_texts = list(self.text_to_keyboard_2.keys())
+            cur_keyboard = self.text_to_keyboard_2[self.initial_keyboard]
+            # Similarly for hw_button2
+            self.hw_button2.text = button_texts[(button_texts.index(self.initial_keyboard) + 1) % len(button_texts)]
 
         self.text_entry_display.render()
         self.hw_button1.render()

--- a/src/seedsigner/helpers/bip39/constants.py
+++ b/src/seedsigner/helpers/bip39/constants.py
@@ -1,0 +1,4 @@
+from  seedsigner.models.settings import SettingsConstants 
+
+FULL_CHARSETS = dict(SettingsConstants.PASSPHRASE_FULL_CHARSET) 
+

--- a/src/seedsigner/helpers/bip39/constants.py
+++ b/src/seedsigner/helpers/bip39/constants.py
@@ -1,4 +1,4 @@
 from  seedsigner.models.settings import SettingsConstants 
 
-FULL_CHARSETS = dict(SettingsConstants.PASSPHRASE_FULL_CHARSET) 
+SPECIAL_CHARSETS = dict(SettingsConstants.PASSPHRASE_SPECIAL_CHARSET)
 

--- a/src/seedsigner/helpers/bip39/passphrase.py
+++ b/src/seedsigner/helpers/bip39/passphrase.py
@@ -1,0 +1,13 @@
+from gettext import gettext as _ 
+
+from seedsigner.models.settings import SettingsConstants
+from .constants import FULL_CHARSETS   
+
+def get_accented_passphrase_charset(locale: str): 
+    """
+    Returns an array of two strings containing accented/non-roman characters based upon the locale specified
+    one in lower case and the other in upper case.
+    """  
+    if locale not in FULL_CHARSETS:    
+        return []
+    return FULL_CHARSETS[locale]

--- a/src/seedsigner/helpers/bip39/passphrase.py
+++ b/src/seedsigner/helpers/bip39/passphrase.py
@@ -1,13 +1,13 @@
 from gettext import gettext as _ 
 
 from seedsigner.models.settings import SettingsConstants
-from .constants import FULL_CHARSETS   
+from .constants import SPECIAL_CHARSETS
 
-def get_accented_passphrase_charset(locale: str): 
+def get_special_passphrase_charset(locale: str):
     """
-    Returns an array of two strings containing accented/non-roman characters based upon the locale specified
+    Returns an array of two strings containing special characters based upon the locale specified
     one in lower case and the other in upper case.
     """  
-    if locale not in FULL_CHARSETS:    
+    if locale not in SPECIAL_CHARSETS:
         return []
-    return FULL_CHARSETS[locale]
+    return SPECIAL_CHARSETS[locale]

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -312,6 +312,17 @@ class SettingsConstants:
         # (WORDLIST_LANGUAGE__PORTUGUESE, "Português"),
     ]
 
+    PASSPHRASE_FULL_CHARSET = [
+        # German - https://en.wikipedia.org/wiki/German_orthography#Special_letters
+        (LOCALE__GERMAN,  ["äöüß", "ÄÖÜ"]),   # Note: Capital ẞ exists since 2017 but excluded as "very recently supported"
+        # French - https://en.wikipedia.org/wiki/French_orthography#Diacritics
+        (LOCALE__FRENCH,  ["àâæçéèêëîïôœùûüÿ", "ÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸ"]),
+        # Spanish - https://en.wikipedia.org/wiki/Spanish_orthography#Special_characters
+        (LOCALE__SPANISH, ["áéíñóúü", "ÁÉÍÑÓÚÜ"]),
+        # Italian - Based on standard Italian orthography using acute and grave accents on vowels
+        (LOCALE__ITALIAN, ["àèéìíîòóùú", "ÀÈÉÌÍÎÒÓÙÚ"]),
+    ]
+
     # Individual SettingsEntry attr_names
     # Note: attr_names are internal constants; do not wrap for translation
     SETTING__LOCALE = "locale"
@@ -330,6 +341,7 @@ class SettingsConstants:
     SETTING__SCRIPT_TYPES = "script_types"
     SETTING__XPUB_DETAILS = "xpub_details"
     SETTING__PASSPHRASE = "passphrase"
+    SETTING__PASSPHRASE_FULL_CHARSET = "passphrase_full_charset"
     SETTING__CAMERA_ROTATION = "camera_rotation"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
@@ -635,6 +647,14 @@ class SettingsDefinition:
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.OPTIONS__ENABLED_DISABLED_REQUIRED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__PASSPHRASE_FULL_CHARSET,
+                      display_name=_mft("Full charset for passphrase"),
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.OPTIONS__ENABLED_DISABLED_REQUIRED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__CAMERA_ROTATION,

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -312,7 +312,7 @@ class SettingsConstants:
         # (WORDLIST_LANGUAGE__PORTUGUESE, "Português"),
     ]
 
-    PASSPHRASE_FULL_CHARSET = [
+    PASSPHRASE_SPECIAL_CHARSET = [
         # German - https://en.wikipedia.org/wiki/German_orthography#Special_letters
         (LOCALE__GERMAN,  ["äöüß", "ÄÖÜ"]),   # Note: Capital ẞ exists since 2017 but excluded as "very recently supported"
         # French - https://en.wikipedia.org/wiki/French_orthography#Diacritics
@@ -341,7 +341,7 @@ class SettingsConstants:
     SETTING__SCRIPT_TYPES = "script_types"
     SETTING__XPUB_DETAILS = "xpub_details"
     SETTING__PASSPHRASE = "passphrase"
-    SETTING__PASSPHRASE_FULL_CHARSET = "passphrase_full_charset"
+    SETTING__PASSPHRASE_SPECIAL_CHARSET = "passphrase_special_charset"
     SETTING__CAMERA_ROTATION = "camera_rotation"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
@@ -649,8 +649,8 @@ class SettingsDefinition:
                       default_value=SettingsConstants.OPTION__ENABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
-                      attr_name=SettingsConstants.SETTING__PASSPHRASE_FULL_CHARSET,
-                      display_name=_mft("Full charset for passphrase"),
+                      attr_name=SettingsConstants.SETTING__PASSPHRASE_SPECIAL_CHARSET,
+                      display_name=_mft("Special charset for passphrase"),
                       type=SettingsConstants.TYPE__SELECT_1,
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.OPTIONS__ENABLED_DISABLED_REQUIRED,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -358,7 +358,7 @@ class SeedAddPassphraseView(View):
         passphrase_title=self.seed.passphrase_label
         ret_dict = self.run_screen(
             seed_screens.SeedAddPassphraseScreen,
-            passphrase=self.seed.passphrase,
+            passphrase=self.seed.passphrase_display,
             title=passphrase_title,
             initial_keyboard=self.initial_keyboard,
         )

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -439,7 +439,7 @@ class SeedReviewPassphraseView(View):
             seed_screens.SeedReviewPassphraseScreen,
             fingerprint_without=fingerprint_without,
             fingerprint_with=fingerprint_with,
-            passphrase=self.seed.passphrase,
+            passphrase=self.seed.passphrase_display,
             button_data=button_data,
             show_back_button=False,
         )

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -7,6 +7,8 @@ from gettext import gettext as _
 
 from embit.descriptor import Descriptor
 
+from seedsigner.helpers.bip39.passphrase import get_accented_passphrase_charset
+
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens)
@@ -351,16 +353,24 @@ class SeedAddPassphraseView(View):
     def __init__(self, initial_keyboard: str = seed_screens.SeedAddPassphraseScreen.KEYBOARD__LOWERCASE_BUTTON_TEXT):
         super().__init__()
         self.initial_keyboard = initial_keyboard
+        self.is_full_charset = self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE_FULL_CHARSET) != SettingsConstants.OPTION__DISABLED
         self.seed = self.controller.storage.get_pending_seed()
 
 
     def run(self):
         passphrase_title=self.seed.passphrase_label
+        if self.is_full_charset:
+            full_charset = get_accented_passphrase_charset(self.settings.get_value(SettingsConstants.SETTING__LOCALE))
+        else:
+            full_charset = None
+
         ret_dict = self.run_screen(
             seed_screens.SeedAddPassphraseScreen,
             passphrase=self.seed.passphrase_display,
             title=passphrase_title,
             initial_keyboard=self.initial_keyboard,
+            is_full_charset=self.is_full_charset,
+            full_charset=full_charset if self.is_full_charset else None,
         )
 
         # The new passphrase will be the return value; it might be empty.

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -7,7 +7,7 @@ from gettext import gettext as _
 
 from embit.descriptor import Descriptor
 
-from seedsigner.helpers.bip39.passphrase import get_accented_passphrase_charset
+from seedsigner.helpers.bip39.passphrase import get_special_passphrase_charset
 
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
@@ -353,24 +353,24 @@ class SeedAddPassphraseView(View):
     def __init__(self, initial_keyboard: str = seed_screens.SeedAddPassphraseScreen.KEYBOARD__LOWERCASE_BUTTON_TEXT):
         super().__init__()
         self.initial_keyboard = initial_keyboard
-        self.is_full_charset = self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE_FULL_CHARSET) != SettingsConstants.OPTION__DISABLED
+        self.has_special_charset = self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE_SPECIAL_CHARSET) != SettingsConstants.OPTION__DISABLED
         self.seed = self.controller.storage.get_pending_seed()
 
 
     def run(self):
         passphrase_title=self.seed.passphrase_label
-        if self.is_full_charset:
-            full_charset = get_accented_passphrase_charset(self.settings.get_value(SettingsConstants.SETTING__LOCALE))
+        if self.has_special_charset:
+            special_charset = get_special_passphrase_charset(self.settings.get_value(SettingsConstants.SETTING__LOCALE))
         else:
-            full_charset = None
+            special_charset = None
 
         ret_dict = self.run_screen(
             seed_screens.SeedAddPassphraseScreen,
             passphrase=self.seed.passphrase_display,
             title=passphrase_title,
             initial_keyboard=self.initial_keyboard,
-            is_full_charset=self.is_full_charset,
-            full_charset=full_charset if self.is_full_charset else None,
+            has_special_charset=self.has_special_charset,
+            special_charset=special_charset if self.has_special_charset else None,
         )
 
         # The new passphrase will be the return value; it might be empty.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+TEST_PASSPHRASES = ["muhpassphrase", "áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ"]
+@pytest.fixture(scope="session", params=TEST_PASSPHRASES)
+def passphrase(request):
+    return request.param

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -32,8 +32,13 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView),
         ])
 
+    test_passphrases = [
+        "muhpassphrase",
+        "áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ"
+    ]
 
-    def test_passphrase_entry_flow(self):
+    @pytest.mark.parametrize("passphrase", test_passphrases)
+    def test_passphrase_entry_flow(self, passphrase):
         """
         Opting to add a bip39 passphrase on the Finalize Seed screen should enter the
         passphrase entry / review flow and end at the SeedOptionsView. 
@@ -42,39 +47,17 @@ class TestSeedFlows(FlowTest):
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase=passphrase, is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.DISCARD),
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase=passphrase, is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase=passphrase)),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase=passphrase)),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
             FlowStep(seed_views.SeedOptionsView),
         ])
-        
-    def test_accented_passphrase_entry_flow(self):
-        """
-        Opting to add bip39 passphrase with accented characters should behave like the normal passphrase
-        entry flow and handle NFKD Normalization without any issues.
-        """
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
-            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
-            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ", is_back_button=True)),
-            FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.DISCARD),
-            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ", is_back_button=True)),
-            FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")),
-            FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")),
-            FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
-            FlowStep(seed_views.SeedOptionsView),
-        ])
-
 
     def test_mnemonic_entry_flow(self):
         """

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -42,14 +42,14 @@ class TestSeedFlows(FlowTest):
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ", is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.DISCARD),
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ", is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
             FlowStep(seed_views.SeedOptionsView),
         ])

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -42,14 +42,14 @@ class TestSeedFlows(FlowTest):
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase", is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.DISCARD),
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase", is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase")),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="mühpassphrase")),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
             FlowStep(seed_views.SeedOptionsView),
         ])

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -42,14 +42,35 @@ class TestSeedFlows(FlowTest):
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase", is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.DISCARD),
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase", is_back_button=True)),
             FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase")),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
-            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="muhpassphrase")),
+            FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
+            FlowStep(seed_views.SeedOptionsView),
+        ])
+        
+    def test_accented_passphrase_entry_flow(self):
+        """
+        Opting to add bip39 passphrase with accented characters should behave like the normal passphrase
+        entry flow and handle NFKD Normalization without any issues.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.DISCARD),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.PASSPHRASE),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ", is_back_button=True)),
+            FlowStep(seed_views.SeedAddPassphraseExitDialogView, button_data_selection=seed_views.SeedAddPassphraseExitDialogView.EDIT),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")),
+            FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.EDIT),
+            FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")),
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
             FlowStep(seed_views.SeedOptionsView),
         ])

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -32,6 +32,7 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView),
         ])
 
+
     test_passphrases = [
         "muhpassphrase",
         "áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ"
@@ -58,6 +59,7 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE),
             FlowStep(seed_views.SeedOptionsView),
         ])
+
 
     def test_mnemonic_entry_flow(self):
         """

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -33,16 +33,12 @@ class TestSeedFlows(FlowTest):
         ])
 
 
-    test_passphrases = [
-        "muhpassphrase",
-        "áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ"
-    ]
-
-    @pytest.mark.parametrize("passphrase", test_passphrases)
     def test_passphrase_entry_flow(self, passphrase):
         """
         Opting to add a BIP-39 passphrase on the Finalize Seed screen should enter the
         passphrase entry / review flow and end at the SeedOptionsView. 
+
+        Note: 'passphrase' is a fixture created in the conftest.py file that parametrizes TEST_PASSPHRASES
         """
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -8,13 +8,23 @@ from seedsigner.models.settings import SettingsConstants
 # TODO: Change TAB indents to SPACE
 
 def test_seed():
-	seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")
+	# Test seed with passphrase
+	seed_1 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="muhpassphrase")
 	
-	assert seed.seed_bytes == b'4\xe9\xc1 \xcd\xbd\x92\x92\x85\xff\xb9^\xd8\t)\xcd\xf7\x0b+\x1dJ$\xb09\xc3\xe8\xee\x90\x1e\xb7\xffFt\xc2>\x135j\xf9\xc4\x17\xd5\'1F\xbd@\xb1\xb38\xd1\xdc\xdfV4d"]\xe3\xc7\xfb\xa7\xf7\xe8'
+	assert seed_1.seed_bytes == b'\x13\xc8\xdfn\x17\xf4\xb3\x06n\x12\xfd\x1bE\x0c\x8d\x819\xe2\xf1\x9ar\xc1j\xde\x14<\xe8\x98\x8e\xd8=\xb8\x94j\x9a\x0c\xaf\xf4\x04\xa6s\xc8\xb4\xd3\xf1\xd4\x85\xde\x84u\xac\x88\\p\xeb\xcf\xbd\xc4A\xb5\xa1\xc3\xb1\xfa'
 	
-	assert seed.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
+	assert seed_1.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
 	
-	assert seed.passphrase == unicodedata.normalize("NFKD", "áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")
+	assert seed_1.passphrase == unicodedata.normalize("NFKD", "muhpassphrase")
+	
+	# Test seed with an accented passphrase
+	seed_2 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")
+	
+	assert seed_2.seed_bytes == b'\xea\xe4\xd6\xb5\x17\x91L\x12h\x9a\x96\x06\x08\x13\xf6\xe3\x80O\x9d\xa8\xeaU\xc8\xef\xbeSx\xe6\xb91\xc4\xd2_\xda\xae\x9a\xda\xc18q\x1b\x15u\xe6f\x8cw\xc1\x10\x8b\x94gV\x85\x10\xf4Rp[\x06\x8c\x89o\x07'
+	
+	assert seed_2.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
+	
+	assert seed_2.passphrase == unicodedata.normalize("NFKD", "áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")
 	
 	# TODO: Not yet supported in new implementation
 	# seed.set_wordlist_language_code("es")

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -20,7 +20,7 @@ def test_seed():
 	
 	assert seed_1.passphrase == unicodedata.normalize("NFKD", TEST_PASSPHRASES[0])
 	
-	# Test seed with an accented passphrase
+	# Test seed with a special character passphrase
 	seed_2 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase=TEST_PASSPHRASES[1])
 	
 	assert seed_2.seed_bytes == b'\xea\xe4\xd6\xb5\x17\x91L\x12h\x9a\x96\x06\x08\x13\xf6\xe3\x80O\x9d\xa8\xeaU\xc8\xef\xbeSx\xe6\xb91\xc4\xd2_\xda\xae\x9a\xda\xc18q\x1b\x15u\xe6f\x8cw\xc1\x10\x8b\x94gV\x85\x10\xf4Rp[\x06\x8c\x89o\x07'

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -4,27 +4,28 @@ from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed
 
 from seedsigner.models.settings import SettingsConstants
 
+from conftest import TEST_PASSPHRASES
 
 # TODO: Change TAB indents to SPACE
 
 def test_seed():
 	# Test seed with passphrase
-	seed_1 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="muhpassphrase")
+	seed_1 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase=TEST_PASSPHRASES[0])
 	
 	assert seed_1.seed_bytes == b'\x13\xc8\xdfn\x17\xf4\xb3\x06n\x12\xfd\x1bE\x0c\x8d\x819\xe2\xf1\x9ar\xc1j\xde\x14<\xe8\x98\x8e\xd8=\xb8\x94j\x9a\x0c\xaf\xf4\x04\xa6s\xc8\xb4\xd3\xf1\xd4\x85\xde\x84u\xac\x88\\p\xeb\xcf\xbd\xc4A\xb5\xa1\xc3\xb1\xfa'
 	
 	assert seed_1.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
 	
-	assert seed_1.passphrase == unicodedata.normalize("NFKD", "muhpassphrase")
+	assert seed_1.passphrase == unicodedata.normalize("NFKD", TEST_PASSPHRASES[0])
 	
 	# Test seed with an accented passphrase
-	seed_2 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")
+	seed_2 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase=TEST_PASSPHRASES[1])
 	
 	assert seed_2.seed_bytes == b'\xea\xe4\xd6\xb5\x17\x91L\x12h\x9a\x96\x06\x08\x13\xf6\xe3\x80O\x9d\xa8\xeaU\xc8\xef\xbeSx\xe6\xb91\xc4\xd2_\xda\xae\x9a\xda\xc18q\x1b\x15u\xe6f\x8cw\xc1\x10\x8b\x94gV\x85\x10\xf4Rp[\x06\x8c\x89o\x07'
 	
 	assert seed_2.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
 	
-	assert seed_2.passphrase == unicodedata.normalize("NFKD", "áéíóúàèìòùâêîôûãõëïüÿăąæøåðçñşțćłšžčřňťđĺŕľĵĝħÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸĂĄÆØÅÐÇÑŞȚĆŁŠŽČŘŇŤĐĹŔĽĴĜĦ")
+	assert seed_2.passphrase == unicodedata.normalize("NFKD", TEST_PASSPHRASES[1])
 	
 	# TODO: Not yet supported in new implementation
 	# seed.set_wordlist_language_code("es")

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -8,13 +8,13 @@ from seedsigner.models.settings import SettingsConstants
 # TODO: Change TAB indents to SPACE
 
 def test_seed():
-	seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="mühpassphrase")
+	seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")
 	
-	assert seed.seed_bytes == b'MN\xa9\xcb\xd6\n\xa5Y\xf6OyJ\xc5\x86\xe6\x06\x85\x10do\xc1\xf4\xe9\xdef\x11:\xf9\xad\x19\xc0\x1b\xed\xcb\xc41\x91y\x8f\xb4\xc2\x82d\x90\x86\xe9\x84\xab\xcb\x8c|f\x1a\xf6z\xf3I\xad\xc2\x00\x90\xb4\x16\xab'
+	assert seed.seed_bytes == b'4\xe9\xc1 \xcd\xbd\x92\x92\x85\xff\xb9^\xd8\t)\xcd\xf7\x0b+\x1dJ$\xb09\xc3\xe8\xee\x90\x1e\xb7\xffFt\xc2>\x135j\xf9\xc4\x17\xd5\'1F\xbd@\xb1\xb38\xd1\xdc\xdfV4d"]\xe3\xc7\xfb\xa7\xf7\xe8'
 	
 	assert seed.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
 	
-	assert seed.passphrase == unicodedata.normalize("NFKD", "mühpassphrase")
+	assert seed.passphrase == unicodedata.normalize("NFKD", "áéíóúàèìòùâêîôûãõëïüÿçăâîșțÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕËÏÜŸÇĂÂÎȘȚ")
 	
 	# TODO: Not yet supported in new implementation
 	# seed.set_wordlist_language_code("es")

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,4 +1,5 @@
 import pytest
+import unicodedata
 from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed
 
 from seedsigner.models.settings import SettingsConstants
@@ -7,13 +8,13 @@ from seedsigner.models.settings import SettingsConstants
 # TODO: Change TAB indents to SPACE
 
 def test_seed():
-	seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split())
+	seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase="mühpassphrase")
 	
-	assert seed.seed_bytes == b'q\xb3\xd1i\x0c\x9b\x9b\xdf\xa7\xd9\xd97H\xa8,\xa7\xd9>\xeck\xc2\xf5ND?, \x88-\x07\x9aa\xc5\xee\xb7\xbf\xc4x\xd6\x07 X\xb6}?M\xaa\x05\xa6\xa7(>\xbf\x03\xb0\x9d\xef\xed":\xdf\x88w7'
+	assert seed.seed_bytes == b'MN\xa9\xcb\xd6\n\xa5Y\xf6OyJ\xc5\x86\xe6\x06\x85\x10do\xc1\xf4\xe9\xdef\x11:\xf9\xad\x19\xc0\x1b\xed\xcb\xc41\x91y\x8f\xb4\xc2\x82d\x90\x86\xe9\x84\xab\xcb\x8c|f\x1a\xf6z\xf3I\xad\xc2\x00\x90\xb4\x16\xab'
 	
 	assert seed.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
 	
-	assert seed.passphrase == ""
+	assert seed.passphrase == unicodedata.normalize("NFKD", "mühpassphrase")
 	
 	# TODO: Not yet supported in new implementation
 	# seed.set_wordlist_language_code("es")

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -12,6 +12,8 @@ def test_seed():
 	# Test seed with passphrase
 	seed_1 = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split(), passphrase=TEST_PASSPHRASES[0])
 	
+	# Seed bytes are generated using trezor/python-mnemonic library and setting language as "English" and mnemonic phrase as the mnemonic above
+	# with the passphrases specified in TEST_PASSPHRASES
 	assert seed_1.seed_bytes == b'\x13\xc8\xdfn\x17\xf4\xb3\x06n\x12\xfd\x1bE\x0c\x8d\x819\xe2\xf1\x9ar\xc1j\xde\x14<\xe8\x98\x8e\xd8=\xb8\x94j\x9a\x0c\xaf\xf4\x04\xa6s\xc8\xb4\xd3\xf1\xd4\x85\xde\x84u\xac\x88\\p\xeb\xcf\xbd\xc4A\xb5\xa1\xc3\xb1\xfa'
 	
 	assert seed_1.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"


### PR DESCRIPTION
## Description

This PR introduces support for accented characters (like é, ä etc) during entry of the passphrase after completing the mnemonic entry flow. The seed bytes/fingerprints are verified by both Ian Coleman's BIP39 tool and python-mnemonic library by Trezor. 
<img width="1785" height="1722" alt="image" src="https://github.com/user-attachments/assets/829daa62-39f0-44d8-ac3a-9580cf20a189" />
![IMG20250711012107 (1) (1) (1)](https://github.com/user-attachments/assets/74898a51-07d3-4951-baa5-83edc6c9fb7e)



This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other



