### PR TITLE
[FIX]: Empty Passphrase Handling

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -390,7 +390,7 @@ class SeedAddPassphraseExitDialogView(View):
             message = _("Your current passphrase entry will be erased.")
             button_data = [self.EDIT, self.DISCARD]
         else:
-            title = _("Skip Passphrase?")
+            title = _("Skip passphrase?")
             message = _("You have not entered a passphrase yet.")
             button_data = [self.EDIT, self.SKIP]
         

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -367,16 +367,13 @@ class SeedAddPassphraseView(View):
         self.seed.set_passphrase(ret_dict["passphrase"])
 
         if "is_back_button" in ret_dict:
-            if len(self.seed.passphrase) >= 0:
-                return Destination(SeedAddPassphraseExitDialogView)
-            else:
-                return Destination(BackStackView)
+            return Destination(SeedAddPassphraseExitDialogView)
             
         elif len(self.seed.passphrase) > 0:
             return Destination(SeedReviewPassphraseView)
         
         else:
-            return Destination(SeedFinalizeView)
+            return Destination(SeedAddPassphraseExitDialogView)
 
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -367,7 +367,7 @@ class SeedAddPassphraseView(View):
         self.seed.set_passphrase(ret_dict["passphrase"])
 
         if "is_back_button" in ret_dict:
-            if len(self.seed.passphrase) > 0:
+            if len(self.seed.passphrase) >= 0:
                 return Destination(SeedAddPassphraseExitDialogView)
             else:
                 return Destination(BackStackView)
@@ -396,7 +396,7 @@ class SeedAddPassphraseExitDialogView(View):
             WarningScreen,
             title=_("Discard passphrase?"),
             status_headline=None,
-            text=_("Your current passphrase entry will be erased"),
+            text=_("Your current passphrase entry will be erased") if self.seed.passphrase else _("You have not entered a passphrase yet"),
             show_back_button=False,
             button_data=button_data,
         )

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -366,14 +366,11 @@ class SeedAddPassphraseView(View):
         # The new passphrase will be the return value; it might be empty.
         self.seed.set_passphrase(ret_dict["passphrase"])
 
-        if "is_back_button" in ret_dict:
+        if "is_back_button" in ret_dict or len(self.seed.passphrase) == 0:
             return Destination(SeedAddPassphraseExitDialogView)
-            
-        elif len(self.seed.passphrase) > 0:
-            return Destination(SeedReviewPassphraseView)
-        
+                    
         else:
-            return Destination(SeedAddPassphraseExitDialogView)
+            return Destination(SeedReviewPassphraseView)
 
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -380,6 +380,7 @@ class SeedAddPassphraseView(View):
 class SeedAddPassphraseExitDialogView(View):
     EDIT = ButtonOption("Edit passphrase")
     DISCARD = ButtonOption("Discard passphrase", button_label_color="red")
+    SKIP = ButtonOption("Skip passphrase")  # NOT red since we're not throwing anything away
 
     def __init__(self):
         super().__init__()
@@ -387,13 +388,20 @@ class SeedAddPassphraseExitDialogView(View):
 
 
     def run(self):
-        button_data = [self.EDIT, self.DISCARD]
+        if self.seed.passphrase:
+            title = _("Discard passphrase?")
+            message = _("Your current passphrase entry will be erased.")
+            button_data = [self.EDIT, self.DISCARD]
+        else:
+            title = _("Skip Passphrase?")
+            message = _("You have not entered a passphrase yet.")
+            button_data = [self.EDIT, self.SKIP]
         
         selected_menu_num = self.run_screen(
             WarningScreen,
-            title=_("Discard passphrase?"),
+            title=title,
             status_headline=None,
-            text=_("Your current passphrase entry will be erased") if self.seed.passphrase else _("You have not entered a passphrase yet"),
+            text=message,
             show_back_button=False,
             button_data=button_data,
         )
@@ -401,7 +409,7 @@ class SeedAddPassphraseExitDialogView(View):
         if button_data[selected_menu_num] == self.EDIT:
             return Destination(SeedAddPassphraseView)
 
-        elif button_data[selected_menu_num] == self.DISCARD:
+        elif button_data[selected_menu_num] in [self.DISCARD, self.SKIP]:
             self.seed.set_passphrase("")
             return Destination(SeedFinalizeView)
         


### PR DESCRIPTION
## Description

When users navigate through the BIP-39 passphrase flow and edit their passphrase to be empty, the application crashes, not the first time but happens the second time when you try to go back with an empty input. with a `ValueError: range() arg 3 must not be zero error. This occurs in the SeedReviewPassphraseScreen.__post_init__()` method when trying to calculate character layout for an empty passphrase.

### Steps to Reproduce

- Navigate to the BIP-39 passphrase option
- Enter any non-empty passphrase (e.g., "test")
- Click "OK" to proceed to the review passphrase screen
- Click "Edit passphrase" to go back to the passphrase input screen
- Clear the passphrase input field (leave it empty)
- Click "<-" (go back)
Error occurs: ValueError: range() arg 3 must not be zero in the SeedReviewPassphraseScreen.__post_init__() method

## Changes

- Modified the `SeedAddPassphraseView.run()` method — to check for empty passphrases before rendering the `SeedAddPassphraseExitDialogView`. Now, when an empty passphrase is detected, the user is now redirected to the `SeedAddPassphraseExitDialogView` with a new warning message "You have not entered a passphrase yet".
- cleaned up the back button logic — now all exit routes (even empty passphrase) go through SeedAddPassphraseExitDialogView.

This pull request is categorized as a:

- [x] Bug fix

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)

