### PR TITLE
[Refactor] Enable auto-detection of screenshot generator renderer

### DIFF
--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -20,6 +20,11 @@ class Renderer(ConfigurableSingleton):
     lock = Lock()
 
 
+    @property
+    def is_screenshot_generator(self) -> bool:
+        return False
+
+
     @classmethod
     def configure_instance(cls):
         # Instantiate the one and only Renderer instance

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -43,21 +43,18 @@ class LogoScreen(BaseScreen):
 
 @dataclass
 class OpeningSplashView(View):
-    is_screenshot_renderer: bool = False
     force_partner_logos: bool|None = None
 
     def run(self):
         self.run_screen(
             OpeningSplashScreen,
-            is_screenshot_renderer=self.is_screenshot_renderer,
             force_partner_logos=self.force_partner_logos
         )
 
 
 
 class OpeningSplashScreen(LogoScreen):
-    def __init__(self, is_screenshot_renderer=False, force_partner_logos=None):
-        self.is_screenshot_renderer = is_screenshot_renderer
+    def __init__(self, force_partner_logos=None):
         self.force_partner_logos = force_partner_logos
         super().__init__()
 
@@ -85,7 +82,7 @@ class OpeningSplashScreen(LogoScreen):
             logo_offset_y = 0
 
         background = Image.new("RGBA", size=self.logo.size, color="black")
-        if not self.is_screenshot_renderer:
+        if not self.renderer.is_screenshot_generator:
             # Fade in alpha
             for i in range(250, -1, -25):
                 self.logo.putalpha(255 - i)
@@ -108,11 +105,11 @@ class OpeningSplashScreen(LogoScreen):
         version_y = int(self.canvas_height/2) + int(logo_height/2) + logo_offset_y + GUIConstants.COMPONENT_PADDING
         self.renderer.draw.text(xy=(version_x, version_y), text=version, font=font, fill=GUIConstants.ACCENT_COLOR, anchor="mt")
 
-        if not self.is_screenshot_renderer:
+        if not self.renderer.is_screenshot_generator:
             self.renderer.show_image()
 
         if show_partner_logos:
-            if not self.is_screenshot_renderer:
+            if not self.renderer.is_screenshot_generator:
                 # Hold on the version num for a moment
                 time.sleep(1)
 
@@ -136,7 +133,7 @@ class OpeningSplashScreen(LogoScreen):
 
             self.renderer.show_image()
 
-        if not self.is_screenshot_renderer:
+        if not self.renderer.is_screenshot_generator:
             # Hold on the splash screen for a moment
             time.sleep(2)
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -248,12 +248,11 @@ class PowerOptionsView(View):
 
 @dataclass
 class RestartView(View):
-    is_screenshot_renderer: bool = False
 
     def run(self):
         from seedsigner.gui.screens.screen import ResetScreen
 
-        if not self.is_screenshot_renderer:
+        if not self.renderer.is_screenshot_generator:
             # We don't want the screenshot generator to actually try to do the restart
             RestartView.DoResetThread().start()
 

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -275,7 +275,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(MainMenuView, screenshot_name='MainMenuView_DireWarningToast',                toast_thread=DireWarningToast("This is a dire warning toast!", activation_delay=0, duration=0)),
                 ScreenshotConfig(MainMenuView, screenshot_name='MainMenuView_ErrorToast',                      toast_thread=ErrorToast("This is an error toast!", activation_delay=0, duration=0)),
                 ScreenshotConfig(PowerOptionsView),
-                ScreenshotConfig(RestartView, dict(is_screenshot_renderer=True)),
+                ScreenshotConfig(RestartView),
                 ScreenshotConfig(PowerOffView),
             ],
             "Seed Views": [

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -262,8 +262,8 @@ def generate_screenshots(locale):
 
         screenshot_sections = {
             "Main Menu Views": [
-                ScreenshotConfig(OpeningSplashView, dict(is_screenshot_renderer=True, force_partner_logos=True)),
-                ScreenshotConfig(OpeningSplashView, dict(is_screenshot_renderer=True, force_partner_logos=False), screenshot_name="OpeningSplashView_no_partner_logos"),
+                ScreenshotConfig(OpeningSplashView, dict(force_partner_logos=True)),
+                ScreenshotConfig(OpeningSplashView, dict(force_partner_logos=False), screenshot_name="OpeningSplashView_no_partner_logos"),
                 ScreenshotConfig(MainMenuView),
                 ScreenshotConfig(MainMenuView, screenshot_name='MainMenuView_SDCardStateChangeToast_removed',  toast_thread=SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__REMOVED, activation_delay=0, duration=0)),
                 ScreenshotConfig(MainMenuView, screenshot_name='MainMenuView_SDCardStateChangeToast_inserted', toast_thread=SDCardStateChangeToastManagerThread(action=MicroSD.ACTION__INSERTED, activation_delay=0, duration=0)),

--- a/tests/screenshot_generator/utils.py
+++ b/tests/screenshot_generator/utils.py
@@ -22,6 +22,10 @@ class ScreenshotRenderer(Renderer):
     screenshot_path: str = None
     screenshot_filename: str = None
 
+    @property
+    def is_screenshot_generator(self) -> bool:
+        return True
+
     @classmethod
     def configure_instance(cls):
         # Instantiate the one and only Renderer instance


### PR DESCRIPTION
## Description

Fixes https://github.com/SeedSigner/seedsigner/issues/795. Changes made:

- Added `is_screenshot_generator` property to base `Renderer` class. Returns `False` by default
- Added `is_screenshot_generator` property to `ScreenshotRenderer` class. Returns `True` to identify it as the screenshot generator
- Removed the `is_screenshot_renderer` parameter from `OpeningSplashView` since it's no longer needed
- Modified `OpeningSplashScreen` to use `self.renderer.is_screenshot_generator` instead of the passed parameter
- Updated screenshot generator tests. Removed the `is_screenshot_renderer` parameter from the test configurations


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
