### PR TITLE
[Feature]: Predict Last Seed Word

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -121,3 +121,52 @@ def generate_mnemonic_from_image(image, wordlist_language_code: str = SettingsCo
 
     # Return as a list
     return bip39.mnemonic_from_bytes(hash.digest(), wordlist=Seed.get_wordlist(wordlist_language_code)).split()
+
+
+
+def get_valid_final_mnemonic_words(partial_mnemonic: list, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
+    """
+    Calculate all valid final words that would produce a valid checksum for the given partial mnemonic.
+
+    For 12-word seeds (7 bit entropy + 4 bit checksum): exactly 128 valid words out of 2048
+    For 24-word seeds (3 bit entropy + 8 bit checksum): exactly 8 valid words out of 2048
+    """
+    wordlist = Seed.get_wordlist(wordlist_language_code)
+    total_bits = 128 if len(partial_mnemonic) == 11 else 256
+    entropy_bits = 0
+
+    # convert partial mnemonic words to entropy bits.
+    # left shift the current entropy_bits by 11 and combine the shifted value with word index.
+    # this helps us calculate the correct checksum
+    for word in partial_mnemonic:
+        entropy_bits = (entropy_bits << 11) | wordlist.index(word)
+
+    final_entropy_bits = total_bits - len(partial_mnemonic) * 11 # each word has 11 bits of entropy
+    valid_indices = []
+
+    # brute force all possible final entropy values
+    # 12-word seeds: 2^7 = 128 iterations
+    # 24-word seeds: 2^3 = 8 iterations
+    for i in range(1 << final_entropy_bits):
+        # combine existing entropy with candidate final entropy bits
+        full_entropy = (entropy_bits << final_entropy_bits) | i
+        
+        # convert to bytes for SHA256 (crypto functions need byte input, not integers)
+        entropy_bytes = full_entropy.to_bytes(total_bits//8, 'big')
+        
+        # BIP-39 checksum: first byte of SHA256 hash contains the checksum bits
+        checksum = hashlib.sha256(entropy_bytes).digest()[0]
+        
+        # construct final word index from entropy + checksum bits
+        if len(partial_mnemonic) == 11:
+            # 12-word seed: use top 4 bits of checksum byte (>> 4 extracts bits 7-4)
+            checksum_bits = checksum >> 4
+            final_index = (i << 4) | checksum_bits
+        else:
+            # 24-word seed: use all 8 bits of checksum byte
+            # combine 3 entropy bits (shifted left) + 8 checksum bits
+            final_index = (i << 8) | checksum
+
+        valid_indices.append(final_index)
+
+    return [wordlist[i] for i in sorted(valid_indices)]

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -5,11 +5,15 @@ from seedsigner.models.settings_definition import SettingsConstants
 
 
 class SeedStorage:
+    PENDING_SEED_TYPE__BIP39 = "bip39"
+    PENDING_SEED_TYPE__ELECTRUM = "electrum"
+    # future TODO: PENDING_SEED_TYPE_SLIP39 = "slip39"
+    
     def __init__(self) -> None:
         self.seeds: List[Seed] = []
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
-        self._pending_is_electrum : bool = False
+        self._pending_seed_type: str = self.PENDING_SEED_TYPE__BIP39
 
 
     def set_pending_seed(self, seed: Seed):
@@ -58,10 +62,15 @@ class SeedStorage:
     def pending_mnemonic_length(self) -> int:
         return len(self._pending_mnemonic)
 
+    
+    @property 
+    def pending_is_bip39(self) -> bool:
+        return self._pending_seed_type == self.PENDING_SEED_TYPE__BIP39
+    
 
-    def init_pending_mnemonic(self, num_words:int = 12, is_electrum:bool = False):
+    def init_pending_mnemonic(self, num_words:int = 12, seed_type: str = PENDING_SEED_TYPE__BIP39):
         self._pending_mnemonic = [None] * num_words
-        self._pending_is_electrum = is_electrum
+        self._pending_seed_type = seed_type
 
 
     def update_pending_mnemonic(self, word: str, index: int):
@@ -83,7 +92,7 @@ class SeedStorage:
 
     def get_pending_mnemonic_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
         try:
-            if self._pending_is_electrum:
+            if self._pending_seed_type == self.PENDING_SEED_TYPE__ELECTRUM:
                 seed = ElectrumSeed(self._pending_mnemonic)
             else:
                 seed = Seed(self._pending_mnemonic)
@@ -93,7 +102,7 @@ class SeedStorage:
 
 
     def convert_pending_mnemonic_to_pending_seed(self):
-        if self._pending_is_electrum:
+        if self._pending_seed_type == self.PENDING_SEED_TYPE__ELECTRUM:
             self.pending_seed = ElectrumSeed(self._pending_mnemonic)
         else:
             self.pending_seed = Seed(self._pending_mnemonic)
@@ -102,4 +111,4 @@ class SeedStorage:
 
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
-        self._pending_is_electrum = False
+        self._pending_seed_type = self.PENDING_SEED_TYPE__BIP39

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -1,19 +1,15 @@
 from typing import List
-from seedsigner.models.seed import Seed, ElectrumSeed, InvalidSeedException
+from seedsigner.models.seed import Seed, InvalidSeedException
 from seedsigner.models.settings_definition import SettingsConstants
 
 
 
 class SeedStorage:
-    PENDING_SEED_TYPE__BIP39 = "bip39"
-    PENDING_SEED_TYPE__ELECTRUM = "electrum"
-    # future TODO: PENDING_SEED_TYPE_SLIP39 = "slip39"
-    
     def __init__(self) -> None:
         self.seeds: List[Seed] = []
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
-        self._pending_seed_type: str = self.PENDING_SEED_TYPE__BIP39
+        self._pending_Seed_cls = None
 
 
     def set_pending_seed(self, seed: Seed):
@@ -39,15 +35,6 @@ class SeedStorage:
         self.pending_seed = None
 
 
-    def validate_mnemonic(self, mnemonic: List[str]) -> bool:
-        try:
-            Seed(mnemonic=mnemonic)
-        except InvalidSeedException as e:
-            return False
-        
-        return True
-
-
     def num_seeds(self):
         return len(self.seeds)
     
@@ -62,15 +49,10 @@ class SeedStorage:
     def pending_mnemonic_length(self) -> int:
         return len(self._pending_mnemonic)
 
-    
-    @property 
-    def pending_is_bip39(self) -> bool:
-        return self._pending_seed_type == self.PENDING_SEED_TYPE__BIP39
-    
 
-    def init_pending_mnemonic(self, num_words:int = 12, seed_type: str = PENDING_SEED_TYPE__BIP39):
+    def init_pending_mnemonic(self, num_words:int = 12, seed_class = Seed):
         self._pending_mnemonic = [None] * num_words
-        self._pending_seed_type = seed_type
+        self._pending_Seed_cls = seed_class
 
 
     def update_pending_mnemonic(self, word: str, index: int):
@@ -92,23 +74,16 @@ class SeedStorage:
 
     def get_pending_mnemonic_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
         try:
-            if self._pending_seed_type == self.PENDING_SEED_TYPE__ELECTRUM:
-                seed = ElectrumSeed(self._pending_mnemonic)
-            else:
-                seed = Seed(self._pending_mnemonic)
+            seed = self._pending_Seed_cls(self._pending_mnemonic)
             return seed.get_fingerprint(network)
         except InvalidSeedException:
             return None
 
 
     def convert_pending_mnemonic_to_pending_seed(self):
-        if self._pending_seed_type == self.PENDING_SEED_TYPE__ELECTRUM:
-            self.pending_seed = ElectrumSeed(self._pending_mnemonic)
-        else:
-            self.pending_seed = Seed(self._pending_mnemonic)
+        self.pending_seed = self._pending_Seed_cls(self._pending_mnemonic)
         self.discard_pending_mnemonic()
     
 
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
-        self._pending_seed_type = self.PENDING_SEED_TYPE__BIP39

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -217,12 +217,32 @@ class SeedMnemonicEntryView(View):
 
 
     def run(self):
+        wordlist = Seed.get_wordlist(wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
+        is_last_word_index = self.cur_word_index == self.controller.storage.pending_mnemonic_length - 1
+        is_normal_seed_entry_mode = not self.is_calc_final_word
+        is_bip39_seed = self.controller.storage.pending_is_bip39
+        
+        predict_final_seed_word = (
+            is_last_word_index and 
+            is_normal_seed_entry_mode and 
+            is_bip39_seed
+        )
+        
+        # Filter wordlist for final word entry if needed
+        partial_mnemonic = None
+        if predict_final_seed_word:
+            partial_mnemonic = [word for word in self.controller.storage.pending_mnemonic if word is not None]
+            
+            from seedsigner.helpers.mnemonic_generation import get_valid_final_mnemonic_words
+            valid_final_words = get_valid_final_mnemonic_words(partial_mnemonic)
+            wordlist = valid_final_words
+        
         ret = self.run_screen(
             seed_screens.SeedMnemonicEntryScreen,
             # TRANSLATOR_NOTE: Inserts the word number (e.g. "Seed Word #6")
             title=_("Seed Word #{}").format(self.cur_word_index + 1),  # Human-readable 1-indexing!
             initial_letters=list(self.cur_word) if self.cur_word else ["a"],
-            wordlist=Seed.get_wordlist(wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE)),
+            wordlist=wordlist,
         )
 
         if ret == RET_CODE__BACK_BUTTON:
@@ -514,7 +534,7 @@ class SeedElectrumMnemonicStartView(View):
                 show_back_button=False,
         )
 
-        self.controller.storage.init_pending_mnemonic(num_words=12, is_electrum=True)
+        self.controller.storage.init_pending_mnemonic(num_words=12, seed_type=self.controller.storage.PENDING_SEED_TYPE__ELECTRUM)
 
         return Destination(SeedMnemonicEntryView)
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -13,7 +13,7 @@ from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import Seed, ElectrumSeed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
@@ -220,7 +220,7 @@ class SeedMnemonicEntryView(View):
         wordlist = Seed.get_wordlist(wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
         is_last_word_index = self.cur_word_index == self.controller.storage.pending_mnemonic_length - 1
         is_normal_seed_entry_mode = not self.is_calc_final_word
-        is_bip39_seed = self.controller.storage.pending_is_bip39
+        is_bip39_seed = self.controller.storage._pending_Seed_cls == Seed
         
         predict_final_seed_word = (
             is_last_word_index and 
@@ -534,7 +534,7 @@ class SeedElectrumMnemonicStartView(View):
                 show_back_button=False,
         )
 
-        self.controller.storage.init_pending_mnemonic(num_words=12, seed_type=self.controller.storage.PENDING_SEED_TYPE__ELECTRUM)
+        self.controller.storage.init_pending_mnemonic(num_words=12, seed_class=ElectrumSeed)
 
         return Destination(SeedMnemonicEntryView)
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -342,7 +342,7 @@ class TestSeedFlows(FlowTest):
             Electrum seeds should skip script type selection
         """            
         # Load a finalized Seed into the Controller
-        self.controller.storage.init_pending_mnemonic(num_words=12, seed_type=self.controller.storage.PENDING_SEED_TYPE__ELECTRUM)
+        self.controller.storage.init_pending_mnemonic(num_words=12, seed_class=ElectrumSeed)
         self.controller.storage.set_pending_seed(ElectrumSeed("regular reject rare profit once math fringe chase until ketchup century escape".split()))
         self.controller.storage.finalize_pending_seed()
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -90,36 +90,6 @@ class TestSeedFlows(FlowTest):
         test_with_mnemonic("cotton artefact spy mind wing there echo steak child oak awful host despair online bicycle divorce middle firm diamond rare execute chimney almost hollow".split())
 
 
-    def test_invalid_mnemonic(self):
-        """ Should be able to go back and edit or discard an invalid mnemonic """
-        # Test data from iancoleman.io
-        mnemonic = "blush twice taste dawn feed second opinion lazy thumb play neglect impact".split()
-        sequence = [
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-            FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # When no seeds are loaded it auto-redirects to LoadSeedView
-            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD if len(mnemonic) == 12 else seed_views.LoadSeedView.TYPE_24WORD),
-        ]
-        for word in mnemonic[:-1]:
-            sequence.append(FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=word))
-
-        sequence += [
-            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value="zoo"),  # But finish with an INVALID checksum word
-            FlowStep(seed_views.SeedMnemonicInvalidView, button_data_selection=seed_views.SeedMnemonicInvalidView.EDIT),
-        ]
-
-        # Restarts from first word
-        for word in mnemonic[:-1]:
-            sequence.append(FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=word))
-
-        sequence += [
-            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value="zebra"),  # provide yet another invalid checksum word
-            FlowStep(seed_views.SeedMnemonicInvalidView, button_data_selection=seed_views.SeedMnemonicInvalidView.DISCARD),
-            FlowStep(MainMenuView),
-        ]
-
-        self.run_sequence(sequence)
-
-
     def test_electrum_mnemonic_entry_flow(self):
         """
             Manually entering an Electrum mnemonic should land at the Finalize Seed flow and end at
@@ -372,7 +342,7 @@ class TestSeedFlows(FlowTest):
             Electrum seeds should skip script type selection
         """            
         # Load a finalized Seed into the Controller
-        self.controller.storage.init_pending_mnemonic(num_words=12, is_electrum=True)
+        self.controller.storage.init_pending_mnemonic(num_words=12, seed_type=self.controller.storage.PENDING_SEED_TYPE__ELECTRUM)
         self.controller.storage.set_pending_seed(ElectrumSeed("regular reject rare profit once math fringe chase until ketchup century escape".split()))
         self.controller.storage.finalize_pending_seed()
 

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -195,3 +195,36 @@ def test_50_dice_rolls():
     actual = " ".join(mnemonic)
     assert bip39.mnemonic_is_valid(actual)
     assert actual == expected
+
+
+def test_valid_final_mnemonic_words():
+    """ Test valid final words for 12-word and 24-word seeds. """
+    partial_11_words = [
+        "abandon", "abandon", "abandon", "abandon", "abandon", "abandon",
+        "abandon", "abandon", "abandon", "abandon", "abandon"
+    ]
+    
+    valid_words_12 = mnemonic_generation.get_valid_final_mnemonic_words(partial_11_words)
+    
+    # there should be exactly 128 valid final words for a 12-word seed
+    assert len(valid_words_12) == 128, f"Expected 128 valid words for 12-word seed, got {len(valid_words_12)}"
+    
+    for word in valid_words_12:
+        test_mnemonic = partial_11_words + [word]
+        assert bip39.mnemonic_is_valid(" ".join(test_mnemonic)), f"Word '{word}' should create valid mnemonic"
+    
+    partial_23_words = [
+        "abandon", "abandon", "abandon", "abandon", "abandon", "abandon",
+        "abandon", "abandon", "abandon", "abandon", "abandon", "abandon",
+        "abandon", "abandon", "abandon", "abandon", "abandon", "abandon",
+        "abandon", "abandon", "abandon", "abandon", "abandon"
+    ]
+    
+    valid_words_24 = mnemonic_generation.get_valid_final_mnemonic_words(partial_23_words)
+    
+    # there should be exactly 8 valid final words for a 24-word seed
+    assert len(valid_words_24) == 8, f"Expected 8 valid words for 24-word seed, got {len(valid_words_24)}"
+    
+    for word in valid_words_24:  # Test all since there should be only ~8
+        test_mnemonic = partial_23_words + [word]
+        assert bip39.mnemonic_is_valid(" ".join(test_mnemonic)), f"Word '{word}' should create valid mnemonic"


### PR DESCRIPTION
## Description

fixes #500 .
displays only checksum-valid words when manually entering the final word of a seed phrase.

### core implementation
- **added `get_valid_final_mnemonic_words()`** in `mnemonic_generation.py`
  - computes valid final words per bip-39 checksum
  - 12-word seeds: 128 valid words
  - 24-word seeds: 8 valid words (of 2048)

### technical details
- implements exact bip-39 spec
  - 12-word: 7-bit entropy + 4-bit checksum
  - 24-word: 3-bit entropy + 8-bit checksum
 
this enhances the UX by filtering out invalid words (which don’t meet the checksum criteria) and makes typing faster by showing fewer possible matches.

**EDIT:**
the test_invalid_mnemonic test was removed because it tests behavior that is no longer possible with the new seed word prediction feature.

this test was causing the entire test suite to hang indefinitely during execution. the issue occurred at the final word entry stage, where the test attempted to input invalid final words ("zoo" and "zebra"). these entries triggered the get_valid_final_mnemonic_words() function, but since neither word exists in the computed valid word set, the test framework became stuck in an infinite loop

This pull request is categorized as a:

- [X] New feature

## Checklist

- [X] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [X] Yes

I have tested this PR on the following platforms/os:

- [X] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
