### PR TITLE
[FIX] generate png for restart view

### DIFF
--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -266,9 +266,9 @@ class RestartView(View):
             import sys
             import time
 
+            logger.info("Restarting SeedSigner")
             # Give the screen just enough time to display the reset message before
             # exiting.
-            logger.info("Restarting SeedSigner")
             time.sleep(0.25)
 
             # Flush any buffered data.

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -255,8 +255,6 @@ class RestartView(View):
         self.thread = self.DoResetThread()
 
     def run(self):
-        logger.info("Restarting SeedSigner")
-
         from seedsigner.gui.screens.screen import ResetScreen
 
         if not self.is_screenshot_renderer:
@@ -274,6 +272,7 @@ class RestartView(View):
 
             # Give the screen just enough time to display the reset message before
             # exiting.
+            logger.info("Restarting SeedSigner")
             time.sleep(0.25)
 
             # Flush any buffered data.

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -250,16 +250,12 @@ class PowerOptionsView(View):
 class RestartView(View):
     is_screenshot_renderer: bool = False
 
-    def __post_init__(self):
-        super().__post_init__()
-        self.thread = self.DoResetThread()
-
     def run(self):
         from seedsigner.gui.screens.screen import ResetScreen
 
         if not self.is_screenshot_renderer:
-            # For the screenshot generator, we don't actually want to restart
-            self.thread.start()
+            # We don't want the screenshot generator to actually try to do the restart
+            RestartView.DoResetThread().start()
 
         self.run_screen(ResetScreen)
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -255,15 +255,14 @@ class RestartView(View):
         self.thread = self.DoResetThread()
 
     def run(self):
-        if self.is_screenshot_renderer:
-            # For the screenshot generator, we don't actually want to restart
-            return
-        
         logger.info("Restarting SeedSigner")
 
         from seedsigner.gui.screens.screen import ResetScreen
 
-        self.thread.start()
+        if not self.is_screenshot_renderer:
+            # For the screenshot generator, we don't actually want to restart
+            self.thread.start()
+
         self.run_screen(ResetScreen)
 
 

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -479,13 +479,26 @@ def generate_screenshots(locale):
 
     for section_name, screenshot_list in setup_screenshots(locale).items():
         subdir = section_name.lower().replace(" ", "_")
-        screenshot_renderer.set_screenshot_path(os.path.join(screenshot_root, locale, subdir))
+        screenshot_section_path = os.path.join(screenshot_root, locale, subdir)
+        screenshot_renderer.set_screenshot_path(screenshot_section_path)
         locale_readme += "\n\n---\n\n"
         locale_readme += f"## {section_name}\n\n"
         locale_readme += """<table style="border: 0;">"""
         locale_readme += f"""<tr><td align="center">"""
         for screenshot_config in screenshot_list:
+            screenshot_filename = f"{screenshot_config.screenshot_name}.png"
+            screenshot_filepath = os.path.join(screenshot_section_path, screenshot_filename)
+
+            # Ensure a clean slate. This guarantees we're testing file creation,
+            # not just the existence of a stale file from a previous run.
+            if os.path.exists(screenshot_filepath):
+                os.remove(screenshot_filepath)
+
             screencap_view(screenshot_config)
+
+            if not os.path.exists(screenshot_filepath):
+                raise Exception(f"Failed to generate screenshot for '{screenshot_config.screenshot_name}' in section '{section_name}'.")
+
             locale_readme += """  <table align="left" style="border: 1px solid gray;">"""
             locale_readme += f"""<tr><td align="center">{screenshot_config.screenshot_name}<br/><br/><img src="{subdir}/{screenshot_config.screenshot_name}.png"></td></tr>"""
             locale_readme += """</table>\n"""

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -479,26 +479,13 @@ def generate_screenshots(locale):
 
     for section_name, screenshot_list in setup_screenshots(locale).items():
         subdir = section_name.lower().replace(" ", "_")
-        screenshot_section_path = os.path.join(screenshot_root, locale, subdir)
-        screenshot_renderer.set_screenshot_path(screenshot_section_path)
+        screenshot_renderer.set_screenshot_path(os.path.join(screenshot_root, locale, subdir))
         locale_readme += "\n\n---\n\n"
         locale_readme += f"## {section_name}\n\n"
         locale_readme += """<table style="border: 0;">"""
         locale_readme += f"""<tr><td align="center">"""
         for screenshot_config in screenshot_list:
-            screenshot_filename = f"{screenshot_config.screenshot_name}.png"
-            screenshot_filepath = os.path.join(screenshot_section_path, screenshot_filename)
-
-            # Ensure a clean slate. This guarantees we're testing file creation,
-            # not just the existence of a stale file from a previous run.
-            if os.path.exists(screenshot_filepath):
-                os.remove(screenshot_filepath)
-
             screencap_view(screenshot_config)
-
-            if not os.path.exists(screenshot_filepath):
-                raise Exception(f"Failed to generate screenshot for '{screenshot_config.screenshot_name}' in section '{section_name}'.")
-
             locale_readme += """  <table align="left" style="border: 1px solid gray;">"""
             locale_readme += f"""<tr><td align="center">{screenshot_config.screenshot_name}<br/><br/><img src="{subdir}/{screenshot_config.screenshot_name}.png"></td></tr>"""
             locale_readme += """</table>\n"""


### PR DESCRIPTION
## Description

**_run_screen_** need to be executed by screenshot generator test to generate _png_ for restart view. But we don't want to restart in case of **_ScreenshotRenderer_**. So, only running the **_DoResetThread_** when **_is_screenshot_renderer_** is false should be enough. The png file is saved in the intended destination in the _show_image_ method of _ScreenshotRenderer_ class which get executed by _run_screen_. Before this pr the the _run_ method of **_RestartView_** was being returned before **_run_screen_** method could be executed as a result the png was not being generated. 

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other

