### PR TITLE
[REF] replace PSBT text in codebase with Proposed transaction or Transaction

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -29,7 +29,7 @@ class PSBTOverviewScreen(ButtonListScreen):
 
     def __post_init__(self):
         # Customize defaults
-        self.title = _("Review PSBT")
+        self.title = _("Review Transaction")
         self.is_bottom_list = True
         self.button_data = [ButtonOption("Review details")]
 
@@ -478,7 +478,7 @@ class PSBTMathScreen(ButtonListScreen):
 
     def __post_init__(self):
         # Customize defaults
-        self.title = _("PSBT Math")
+        self.title = _("Transaction Math")
         self.button_data = [ButtonOption("Review recipients")]
         self.is_bottom_list = True
 
@@ -763,7 +763,7 @@ class PSBTOpReturnScreen(ButtonListScreen):
 class PSBTFinalizeScreen(ButtonListScreen):
     def __post_init__(self):
         # Customize defaults
-        self.title = _("Sign PSBT")
+        self.title = _("Sign Transaction")
         self.is_bottom_list = True
         super().__post_init__()
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -473,7 +473,7 @@ class PSBTAddressVerificationFailedView(View):
             title=_("Suspicious Transaction"),
             status_headline=_("Address Verification Failed"),
             text=text,
-            button_data=[ButtonOption("Discard Transaction")],
+            button_data=[ButtonOption("Discard transaction")],
             show_back_button=False,
         )
 
@@ -515,7 +515,7 @@ class PSBTOpReturnView(View):
 class PSBTFinalizeView(View):
     """
     """
-    APPROVE_PSBT = ButtonOption("Approve Transaction")
+    APPROVE_PSBT = ButtonOption("Approve transaction")
 
     
     def run(self):

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -22,7 +22,7 @@ class PSBTSelectSeedView(View):
         # multisig where we want to sign with more than one key on this device.
         if not self.controller.psbt:
             # Shouldn't be able to get here
-            raise Exception("No PSBT currently loaded")
+            raise Exception("No transaction currently loaded")
 
         if self.controller.psbt_seed:
              if PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=self.controller.psbt_seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
@@ -169,7 +169,7 @@ class PSBTUnsupportedScriptTypeWarningView(View):
         selected_menu_num = self.run_screen(
             WarningScreen,
             status_headline=_("Unsupported Script Type!"),
-            text=_("PSBT has unsupported input script type, please verify your change addresses."),
+            text=_("Transaction has unsupported input script type, please verify your change addresses."),
             button_data=[ButtonOption("Continue")],
         )
         
@@ -191,7 +191,7 @@ class PSBTNoChangeWarningView(View):
             WarningScreen,
             # TRANSLATOR_NOTE: User will receive no change back; the inputs to this transaction are fully spent
             status_headline=_("Full Spend!"),
-            text=_("This PSBT spends its entire input value. No change is coming back to your wallet."),
+            text=_("This transaction spends its entire input value. No change is coming back to your wallet."),
             button_data=[ButtonOption("Continue")],
         )
 
@@ -463,17 +463,17 @@ class PSBTAddressVerificationFailedView(View):
     def run(self):
         if self.is_multisig:
             # TRANSLATOR_NOTE: Variable is either "change" or "self-transfer".
-            text = _("PSBT's {} address could not be verified from wallet descriptor.").format(_("change") if self.is_change else _("self-transfer"))
+            text = _("Transaction's {} address could not be verified from wallet descriptor.").format(_("change") if self.is_change else _("self-transfer"))
         else:
             # TRANSLATOR_NOTE: Variable is either "change" or "self-transfer".
-            text = _("PSBT's {} address could not be generated from your seed.").format(_("change") if self.is_change else _("self-transfer"))
+            text = _("Transaction's {} address could not be generated from your seed.").format(_("change") if self.is_change else _("self-transfer"))
         
         self.run_screen(
             DireWarningScreen,
-            title=_("Suspicious PSBT"),
+            title=_("Suspicious Transaction"),
             status_headline=_("Address Verification Failed"),
             text=text,
-            button_data=[ButtonOption("Discard PSBT")],
+            button_data=[ButtonOption("Discard Transaction")],
             show_back_button=False,
         )
 
@@ -515,7 +515,7 @@ class PSBTOpReturnView(View):
 class PSBTFinalizeView(View):
     """
     """
-    APPROVE_PSBT = ButtonOption("Approve PSBT")
+    APPROVE_PSBT = ButtonOption("Approve Transaction")
 
     
     def run(self):
@@ -583,7 +583,7 @@ class PSBTSigningErrorView(View):
         # Just a WarningScreen here; only use DireWarningScreen for true security risks.
         selected_menu_num = self.run_screen(
             WarningScreen,
-            title=_("PSBT Error"),
+            title=_("Transaction Error"),
             status_icon_name=SeedSignerIconConstants.WARNING,
             status_headline=_("Signing Failed"),
             text=_("Signing with this seed did not add a valid signature."),

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -171,8 +171,8 @@ class ScanView(View):
 
 
 class ScanPSBTView(ScanView):
-    instructions_text = _mft("Scan PSBT")
-    invalid_qr_type_message = _mft("Expected a PSBT")
+    instructions_text = _mft("Scan Transaction")
+    invalid_qr_type_message = _mft("Expected a transaction")
 
     @property
     def is_valid_qr_type(self):

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -524,7 +524,7 @@ class SeedElectrumMnemonicStartView(View):
     Views for actions on individual seeds:
 ****************************************************************************"""
 class SeedOptionsView(View):
-    SCAN_PSBT = ButtonOption("Scan PSBT", SeedSignerIconConstants.QRCODE)
+    SCAN_PSBT = ButtonOption("Scan transaction", SeedSignerIconConstants.QRCODE)
     VERIFY_ADDRESS = ButtonOption("Verify addr")
     EXPORT_XPUB = ButtonOption("Export xpub")
     EXPLORER = ButtonOption("Address explorer")
@@ -2077,7 +2077,7 @@ class LoadMultisigWalletDescriptorView(View):
 
 
 class MultisigWalletDescriptorView(View):
-    RETURN = ButtonOption("Return to PSBT")
+    RETURN = ButtonOption("Return to transaction")
     VERIFY_ADDR = ButtonOption("Verify addr")
     ADDRESS_EXPLORER = ButtonOption("Address explorer")
     OK = ButtonOption("OK")


### PR DESCRIPTION
## Description

This PR begins the process of replacing the acronym "PSBT" with the more descriptive phrase "Proposed Transaction" or "Transaction" throughout the user interface.

The reason for this change is to reduce technical jargon and make the on-screen language more accessible and intuitive for all users.

Following are some screenshot for the change.
<img width="240" height="240" alt="PSBTAddressVerificationFailedView_multisig_change" src="https://github.com/user-attachments/assets/787f47ab-69f0-4fd4-9b5e-93da0eb94465" />
<img width="240" height="240" alt="PSBTAddressVerificationFailedView_multisig_selftransfer" src="https://github.com/user-attachments/assets/5ba92795-0c4f-49e6-8243-5c5a694fdfde" />
<img width="240" height="240" alt="PSBTAddressVerificationFailedView_singlesig_change" src="https://github.com/user-attachments/assets/34e8442b-e605-4ef1-9b17-e8cc7d4621be" />
<img width="240" height="240" alt="PSBTAddressVerificationFailedView_singlesig_selftransfer" src="https://github.com/user-attachments/assets/e0a57145-5a08-4166-822d-0d6e32abd735" />
<img width="240" height="240" alt="PSBTFinalizeView" src="https://github.com/user-attachments/assets/d19d8a67-0e1b-41ed-9c87-2dd42f9d6ed6" />
<img width="240" height="240" alt="PSBTMathView" src="https://github.com/user-attachments/assets/4bfd62fe-dc11-4b67-a324-093a2a39f25b" />
<img width="240" height="240" alt="PSBTNoChangeWarningView" src="https://github.com/user-attachments/assets/d8bc7572-2c85-49e5-893b-349a5072b8f5" />
<img width="240" height="240" alt="PSBTOverviewView" src="https://github.com/user-attachments/assets/84800efa-6f9e-45f9-8286-d738b2e07940" />


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other

