### PR TITLE
[Screenshot Generator][Enhancement] Add `ScreenshotRenderer` check to catch missing screenshots

### DIFF
--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -413,8 +413,16 @@ def generate_screenshots(locale):
         try:
             print(f"Running {screenshot_config.screenshot_name}")
             try:
+                cur_count = screenshot_renderer.render_count
+
+                # Set up and run the target View
                 screenshot_config.run_callback_before()
                 screenshot_config.View_cls(**screenshot_config.view_kwargs).run()
+
+                if screenshot_renderer.render_count == cur_count:
+                    # The View didn't actually render anything
+                    raise Exception(f"{screenshot_config.screenshot_name} did not render a screenshot. Verify that its `run_screen()` is reachable by the screenshot generator.")
+
             except ScreenshotComplete:
                 # The target View has run and its Screen has rendered what it needs to
                 if toast_thread is not None:
@@ -507,3 +515,5 @@ def generate_screenshots(locale):
 
     with open(os.path.join(screenshot_root, "README.md"), 'w') as readme_file:
         readme_file.write(main_readme)
+
+    print(f"Screenshots rendered: {screenshot_renderer.render_count}")

--- a/tests/screenshot_generator/utils.py
+++ b/tests/screenshot_generator/utils.py
@@ -10,6 +10,10 @@ from seedsigner.views.view import View
 
 
 class ScreenshotComplete(Exception):
+    """
+        Slightly hacky way for the ScreenshotRenderer to intentionally break out of the
+        normal Controller flow in order to return control to the screenshot generator.
+    """
     pass
 
 
@@ -30,6 +34,8 @@ class ScreenshotRenderer(Renderer):
 
         renderer.canvas = Image.new('RGB', (renderer.canvas_width, renderer.canvas_height))
         renderer.draw = ImageDraw.Draw(renderer.canvas)
+
+        renderer.render_count = 0
     
 
     def set_screenshot_filename(self, filename:str):
@@ -56,6 +62,9 @@ class ScreenshotRenderer(Renderer):
             self.canvas.paste(image)
 
         self.canvas.save(os.path.join(self.screenshot_path, self.screenshot_filename))
+        self.render_count += 1
+
+        # Break out of the normal Controller flow and return to the screenshot generator
         raise ScreenshotComplete()
 
 


### PR DESCRIPTION
## Description

Depends on #803. Note that CI will NOT pass on this PR until #803 is merged since the change here is to intentionally raise an Exception to alert us that a screenshot is not rendering (which is currently the case in `dev`!).

#758 introduced a change that quietly broke the `RestartView` screenshot.

#803 fixes that screenshot but also suggested a way to detect when a screenshot fails to render.

This PR is an alternate approach to alerting us that a screenshot failed to render. It also adds a minor nice-to-have of optionally reporting total number of screenshots generated (if run with the `pytest` flag `-s`).

Includes some additional explanatory code comments for the somewhat complex / unorthodox / "slightly hacky" `ScreenshotComplete` usage.

---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR


If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: local dev test suite / screenshot generator