### PR TITLE
[Screenshot Generator][Refactor] Clean up the end of the screenshot generation process

### DIFF
--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -422,7 +422,6 @@ def generate_screenshots(locale):
                     controller.activate_toast(toast_thread)
                     while controller.toast_notification_thread.is_alive():
                         # Give the Toast a moment to complete its work
-
                         time.sleep(0.01)
 
                 print(f"Completed {screenshot_config.screenshot_name}")

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -425,15 +425,8 @@ def generate_screenshots(locale):
 
                         time.sleep(0.01)
 
-                    # TODO: Necessary now that the lock is in place?
-                    # Whenever possible, clean up toast thread HERE before killing the
-                    # main thread with ScreenshotComplete.
-                    toast_thread.stop()
-                    toast_thread.join()
-                raise ScreenshotComplete()
-        except ScreenshotComplete:
-            # Slightly hacky way to exit ScreenshotRenderer as expected
-            print(f"Completed {screenshot_config.screenshot_name}")
+                print(f"Completed {screenshot_config.screenshot_name}")
+
         except Exception as e:
             # Something else went wrong
             from traceback import print_exc


### PR DESCRIPTION
## Description

This PR removes some unnecessary confusion around the resolution of the `ScreenshotComplete` exception.

`ScreenshotRenderer` has to raise `ScreenshotComplete` in order to break the execution flow out of the normal Controller and give control back to the screenshot generator. The affected code here picks up once that break out exception has been caught.

At this point, control has been returned to the screenshot generator and so there is no need to re-raise `ScreenshotComplete`. Perhaps there was a need for this in the past or it's entirely likely that I just got myself confused at some point. I also wonder / suspect that some of this code was moved from elsewhere where that reraise might have made more sense.

This PR also follows up on the TODO regarding the final toast calls. In my testing, removing the `stop()` and `join()` calls had no effect and are called in the `finally` block anyway.

---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: test suite, screenshot generator in local dev