### PR TITLE
[Refactor] use _Seed_cls to handle seed type

### DIFF
--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -1,5 +1,5 @@
 from typing import List
-from seedsigner.models.seed import Seed, ElectrumSeed, InvalidSeedException
+from seedsigner.models.seed import Seed, InvalidSeedException
 from seedsigner.models.settings_definition import SettingsConstants
 
 
@@ -9,7 +9,7 @@ class SeedStorage:
         self.seeds: List[Seed] = []
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
-        self._Seed_cls = Seed
+        self._pending_Seed_cls = None
 
 
     def set_pending_seed(self, seed: Seed):
@@ -50,9 +50,9 @@ class SeedStorage:
         return len(self._pending_mnemonic)
 
 
-    def init_pending_mnemonic(self, num_words:int = 12, is_electrum:bool = False):
+    def init_pending_mnemonic(self, num_words:int = 12, seed_class = Seed):
         self._pending_mnemonic = [None] * num_words
-        self._Seed_cls = ElectrumSeed if is_electrum else Seed
+        self._pending_Seed_cls = seed_class
 
 
     def update_pending_mnemonic(self, word: str, index: int):
@@ -74,17 +74,16 @@ class SeedStorage:
 
     def get_pending_mnemonic_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
         try:
-            seed = self._Seed_cls(self._pending_mnemonic)
+            seed = self._pending_Seed_cls(self._pending_mnemonic)
             return seed.get_fingerprint(network)
         except InvalidSeedException:
             return None
 
 
     def convert_pending_mnemonic_to_pending_seed(self):
-        self.pending_seed = self._Seed_cls(self._pending_mnemonic)
+        self.pending_seed = self._pending_Seed_cls(self._pending_mnemonic)
         self.discard_pending_mnemonic()
     
 
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
-        self._Seed_cls = Seed

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -9,7 +9,7 @@ class SeedStorage:
         self.seeds: List[Seed] = []
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
-        self._pending_is_electrum : bool = False
+        self._Seed_cls = Seed
 
 
     def set_pending_seed(self, seed: Seed):
@@ -35,15 +35,6 @@ class SeedStorage:
         self.pending_seed = None
 
 
-    def validate_mnemonic(self, mnemonic: List[str]) -> bool:
-        try:
-            Seed(mnemonic=mnemonic)
-        except InvalidSeedException as e:
-            return False
-        
-        return True
-
-
     def num_seeds(self):
         return len(self.seeds)
     
@@ -61,7 +52,7 @@ class SeedStorage:
 
     def init_pending_mnemonic(self, num_words:int = 12, is_electrum:bool = False):
         self._pending_mnemonic = [None] * num_words
-        self._pending_is_electrum = is_electrum
+        self._Seed_cls = ElectrumSeed if is_electrum else Seed
 
 
     def update_pending_mnemonic(self, word: str, index: int):
@@ -83,23 +74,17 @@ class SeedStorage:
 
     def get_pending_mnemonic_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
         try:
-            if self._pending_is_electrum:
-                seed = ElectrumSeed(self._pending_mnemonic)
-            else:
-                seed = Seed(self._pending_mnemonic)
+            seed = self._Seed_cls(self._pending_mnemonic)
             return seed.get_fingerprint(network)
         except InvalidSeedException:
             return None
 
 
     def convert_pending_mnemonic_to_pending_seed(self):
-        if self._pending_is_electrum:
-            self.pending_seed = ElectrumSeed(self._pending_mnemonic)
-        else:
-            self.pending_seed = Seed(self._pending_mnemonic)
+        self.pending_seed = self._Seed_cls(self._pending_mnemonic)
         self.discard_pending_mnemonic()
     
 
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
-        self._pending_is_electrum = False
+        self._Seed_cls = Seed

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -13,7 +13,7 @@ from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import Seed, ElectrumSeed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
@@ -514,7 +514,7 @@ class SeedElectrumMnemonicStartView(View):
                 show_back_button=False,
         )
 
-        self.controller.storage.init_pending_mnemonic(num_words=12, is_electrum=True)
+        self.controller.storage.init_pending_mnemonic(num_words=12, seed_class=ElectrumSeed)
 
         return Destination(SeedMnemonicEntryView)
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -372,7 +372,7 @@ class TestSeedFlows(FlowTest):
             Electrum seeds should skip script type selection
         """            
         # Load a finalized Seed into the Controller
-        self.controller.storage.init_pending_mnemonic(num_words=12, is_electrum=True)
+        self.controller.storage.init_pending_mnemonic(num_words=12, seed_class=ElectrumSeed)
         self.controller.storage.set_pending_seed(ElectrumSeed("regular reject rare profit once math fringe chase until ketchup century escape".split()))
         self.controller.storage.finalize_pending_seed()
 


### PR DESCRIPTION
This PR addresses this [comment](https://github.com/SeedSigner/seedsigner/pull/800#issuecomment-3225941377). 

## Description

- Added `_pending_Seed_cls` reference to handle both Seed and ElectrumSeed.

- Removed unused `validate_mnemonic()` function.

- Updated `init_pending_mnemonic` to accept seed_class instead of `is_electrum`, making the code more extensible for future seed types (e.g., Shamir Secret, #636).


## Reason for Change

eliminates conditional logic throughout the codebase. instead of checking boolean flags and then deciding which class to instantiate, we directly store the class and follows the same pattern as Destination class and makes the code cleaner and less error prone.



This pull request is categorized as a:

- [X] Code refactor

## Checklist

- [X] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [X] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other
