### PR TITLE
[CI] Ensure messages.pot stays updated

### DIFF
--- a/.github/workflows/l10n-pre-commit.yml
+++ b/.github/workflows/l10n-pre-commit.yml
@@ -1,0 +1,27 @@
+name: l10n pre-commit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  l10n-pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: "3.x"
+      - name: Install l10n deps
+        run: pip install -r l10n/requirements-l10n.txt
+      - name: Install project
+        run: pip install -e .
+      - uses: pre-commit/action@v3.0.1
+        with:
+          # Pass extra arguments to the `pre-commit run` command:
+          # run_extract_messages: Run only this specific hook
+          # --all-files: Check all files, not just changed ones
+          # --verbose: Show detailed output for debugging
+          extra_args: run_extract_messages --all-files --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: local
+    hooks:
+      - id: run_extract_messages
+        name: Update and check messages.pot
+        language: system
+        entry: python3
+        args: ["l10n/run_extract_messages.py"]
+        files: ^src/
+        require_serial: true
+        stages: [pre-commit]

--- a/l10n/README.md
+++ b/l10n/README.md
@@ -269,8 +269,27 @@ python setup.py extract_messages
 
 This will rescan all wrapped text, picking up new strings as well as updating existings strings that have been edited.
 
-_TODO: Github Action to auto-generate messages.pot and fail a PR update if the PR has an out of date messages.pot?_
+### Pre-commit hook for `extract_messages`
 
+A pre-commit hook is configured to run this command automatically before each commit.
+
+To set it up:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Once installed, the `run_extract_messages` hook will run every time you commit.
+If it updates `messages.pot`, the commit will be blocked so you can review and stage the updated file before trying again.
+
+To trigger the hook manually, run:
+
+```bash
+pre-commit run run_extract_messages --all-files
+```
+
+---
 
 ### Making new text available to translators
 Upload the master `messages.pot` to Transifex. It will automatically update each language with the new or changed source strings.

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: seedsigner 0.8.5\n"
+"Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-05-20 09:27-0500\n"
+"POT-Creation-Date: 2025-08-30 01:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,7 +55,7 @@ msgid "Review PSBT"
 msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Review Details"
+msgid "Review details"
 msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
@@ -121,7 +121,7 @@ msgid "PSBT Math"
 msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Review Recipients"
+msgid "Review recipients"
 msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
@@ -214,7 +214,7 @@ msgid "Privacy Leak!"
 msgstr ""
 
 #: src/seedsigner/gui/screens/screen.py
-msgid "I Understand"
+msgid "I understand"
 msgstr ""
 
 #: src/seedsigner/gui/screens/screen.py
@@ -298,14 +298,14 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/views/seed_views.py
-msgid "Export Xpub"
+msgid "Export xpub"
 msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Xpub Details"
 msgstr ""
 
-#. Short for "BIP32 Master Fingerprint"
+#. Short for "BIP-32 Master Fingerprint"
 #. a label for the shortened Key-id of a BIP-32 master HD wallet
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
@@ -379,7 +379,7 @@ msgid ""
 msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+#: src/seedsigner/views/seed_views.py
 msgid "Verify Address"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/views/seed_views.py
-msgid "Sign Message"
+msgid "Sign message"
 msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
@@ -701,7 +701,7 @@ msgstr ""
 msgid "Custom Derivation"
 msgstr ""
 
-#. Terminology used by Electrum seeds; equivalent to bip39 passphrase
+#. Terminology used by Electrum seeds; equivalent to BIP-39 passphrase
 #: src/seedsigner/models/settings_definition.py
 msgid "Custom Extension"
 msgstr ""
@@ -877,15 +877,15 @@ msgid "Will Send"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Next Recipient"
+msgid "Next recipient"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Skip Verification"
+msgid "Skip verification"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Verify Multisig Change"
+msgid "Verify multisig change"
 msgstr ""
 
 #. The amount you're receiving back from the transaction
@@ -936,7 +936,7 @@ msgid "Approve PSBT"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Select Diff Seed"
+msgid "Select diff seed"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Expected a SeedQR"
 msgstr ""
 
-#: src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
 msgid "Scan descriptor"
 msgstr ""
 
@@ -1030,6 +1030,10 @@ msgid "Select seed to verify"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+msgid "Sign Message"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
 msgid "Load the seed to sign with"
 msgstr ""
 
@@ -1055,7 +1059,7 @@ msgid "Seed Word #{}"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Review & Edit"
+msgid "Review & edit"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
@@ -1079,15 +1083,27 @@ msgid "Discard passphrase"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
 msgid "Discard passphrase?"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Your current passphrase entry will be erased"
+msgid "Your current passphrase entry will be erased."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Keep Seed"
+msgid "Skip passphrase?"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
 msgstr ""
 
 #. Inserts the seed fingerprint
@@ -1108,23 +1124,35 @@ msgid "Some features are disabled for Electrum seeds."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Verify Addr"
+msgid "Verify addr"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "BIP-85 Child Seed"
+msgid "Backup seed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Discard Seed"
+msgid "BIP-85 child seed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "View Seed Words"
+msgid "Discard seed"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Export as SeedQR"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Export Xpub"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1173,7 +1201,7 @@ msgid "BIP-85 Child Index must be between 0 and 2^31-1."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Try Again"
+msgid "Try again"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1190,7 +1218,7 @@ msgid "Verify Word #{}"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Review Seed Words"
+msgid "Review seed words"
 msgstr ""
 
 #. Inserts the word number and the word (e.g. "Word #1 is not "apple"!")
@@ -1294,10 +1322,6 @@ msgid "Can't validate a single sig addr without specifying a seed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Scan Descriptor"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
 msgid "Return to PSBT"
 msgstr ""
 
@@ -1337,6 +1361,10 @@ msgstr ""
 msgid "Calc 12th/24th word"
 msgstr ""
 
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr ""
+
 #: src/seedsigner/views/tools_views.py src/seedsigner/views/view.py
 msgid "Tools"
 msgstr ""
@@ -1351,6 +1379,10 @@ msgstr ""
 
 #: src/seedsigner/views/tools_views.py
 msgid "Mnemonic Length?"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Calculating..."
 msgstr ""
 
 #. Inserts the number of dice rolls needed for a 12-word mnemonic
@@ -1397,12 +1429,12 @@ msgstr ""
 
 #. label for addresses where others send us incoming payments
 #: src/seedsigner/views/tools_views.py
-msgid "Receive Addresses"
+msgid "Receive addresses"
 msgstr ""
 
 #. label for addresses that collect the change from our own outgoing payments
 #: src/seedsigner/views/tools_views.py
-msgid "Change Addresses"
+msgid "Change addresses"
 msgstr ""
 
 #. a status message that our payment addresses are being calculated
@@ -1439,7 +1471,7 @@ msgid "Restart"
 msgstr ""
 
 #: src/seedsigner/views/view.py
-msgid "Power Off"
+msgid "Power off"
 msgstr ""
 
 #: src/seedsigner/views/view.py
@@ -1459,7 +1491,7 @@ msgid "Not Yet Implemented"
 msgstr ""
 
 #: src/seedsigner/views/view.py
-msgid "Back to Main Menu"
+msgid "Back to main menu"
 msgstr ""
 
 #. The network setting (mainnet/testnet/regtest) doesn't match the provided
@@ -1483,7 +1515,7 @@ msgid "System Error"
 msgstr ""
 
 #: src/seedsigner/views/view.py
-msgid "Update Setting"
+msgid "Update setting"
 msgstr ""
 
 #. Inserts the name of a settings option (e.g. "Persistent Settings" is

--- a/l10n/requirements-l10n.txt
+++ b/l10n/requirements-l10n.txt
@@ -1,1 +1,2 @@
 Babel==2.16.0
+setuptools>=80.9.0

--- a/l10n/run_extract_messages.py
+++ b/l10n/run_extract_messages.py
@@ -1,0 +1,47 @@
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+POT_FILE_PATH = Path("l10n/messages.pot")
+
+
+def strip_metadata(lines):
+    # Removes lines starting with the POT-Creation-Date or Generated-By
+    meta_re = re.compile(r'^"(POT-Creation-Date|Generated-By):')
+    return [line for line in lines if not meta_re.match(line)]
+
+
+def main():
+    if not POT_FILE_PATH.exists():
+        print(f"{POT_FILE_PATH} does not exist. Make sure that your local repo has fetched the `seedsigner-translations` submodule.")
+        sys.exit(1)
+
+    # keepends=True preserves newline chars so join writes the file back exactly.
+    # This avoids unnecessary git diffs if different newline chars are used
+    original = POT_FILE_PATH.read_text().splitlines(keepends=True)
+
+    # This command updates messages.pot in place
+    result = subprocess.run("python3 setup.py extract_messages", shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error running extract_messages:\n\n{result.stderr}")
+        sys.exit(1)
+
+    new = POT_FILE_PATH.read_text().splitlines(keepends=True)
+
+    if strip_metadata(original) == strip_metadata(new):
+        print("All strings are up to date.")
+        # Restore original file if no changes
+        POT_FILE_PATH.write_text("".join(original))
+        sys.exit(0)
+
+    else:
+        print(
+            "messages.pot was regenerated.\n"
+            "Stage the update and re-run your commit:\n"
+            "  git add l10n/messages.pot"
+        )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR introduces a new CI job to ensure that the `messages.pot` file is always up to date. It also adds a `pre-commit` hook that automatically runs the `extract_messages` step before each commit.

### Pre-commit hook

The hook runs a Python script that does the following:
- Runs `python3 setup.py extract_messages`.
- Checks if the updated `messages.pot` differs from the previous version, ignoring changes to the metadata fields `POT-Creation-Date` and `Generated-By`.
- If there are meaningful changes, the hook ends with a "failed" status because it modified tracked files (this is expected). The developer can then review and commit the updated messages.pot.
- If the only differences are in the ignored metadata fields, the file is reverted to its previous state, preventing unnecessary diffs.

### Github Action

Similarly, the GitHub workflow runs the `pre-commit` hook. If it results in any changes, they will appear as a diff in the logs, and the action will fail. This makes it clear that the PR must be updated to include the corresponding changes to `messages.pot`.

### Other changes
- Added `setuptools` as a dependency in `requirements-l10n.txt`.
- Updated `messages.pot` since the `dev` branch was not up to date.
- Updated documentation with instructions for setting up the `pre-commit` hook.

I also considered adding `pre-commit` itself to `requirements-l10n.txt`, but decided against it. It’s not strictly an l10n dependency. We may want to add a `requirements-dev.txt` instead, or even better, migrate fully to `pyproject.toml` and/or a tool like [uv](https://github.com/astral-sh/uv).

---

This pull request is categorized as a:

- [x] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Other
