### PR TITLE
[Refactor] Remove bip85 app num

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -629,7 +629,7 @@ class SeedOptionsView(View):
             return Destination(SeedBackupView, view_args=dict(seed_num=self.seed_num))
 
         elif button_data[selected_menu_num] == self.BIP85_CHILD_SEED:
-            return Destination(SeedBIP85ApplicationModeView, view_args={"seed_num": self.seed_num})
+            return Destination(SeedBIP85SelectNumWordsView, view_args={"seed_num": self.seed_num})
 
         elif button_data[selected_menu_num] == self.DISCARD:
             return Destination(SeedDiscardView, view_args=dict(seed_num=self.seed_num))
@@ -1120,17 +1120,9 @@ class SeedWordsView(View):
 
 
 """****************************************************************************
-    BIP-85 - Derive child mnemonic (seed) flow
+    BIP-85 - Derive child mnemonic (seed) flow (Application number 39')
 ****************************************************************************"""
-class SeedBIP85ApplicationModeView(View):
-    """
-        * Ask the user the application type as defined in the BIP-85 spec.
-        * Currently only Word mode of 12, 24 words (Application number: 39')
-        * Possible future additions are
-        *  WIF (HDSEED)
-        *  XPRV (BIP-32)
-    """
-    # TODO: Future enhancement to display WIF (HD-SEED) and XPRV (BIP-32)?
+class SeedBIP85SelectNumWordsView(View):
     WORDS_12 = ButtonOption("12 Words")
     WORDS_24 = ButtonOption("24 Words")
 
@@ -1138,7 +1130,6 @@ class SeedBIP85ApplicationModeView(View):
         super().__init__()
         self.seed_num = seed_num
         self.num_words = 0
-        self.bip85_app_num = 39     # TODO: Support other Application numbers; TODO: Define this as a constant
 
 
     def run(self):

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -304,7 +304,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedWordsWarningView, dict(seed_num=0)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed_num=0)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed_num=0, page_index=2), screenshot_name="SeedWordsView_2"),
-                ScreenshotConfig(seed_views.SeedBIP85ApplicationModeView, dict(seed_num=0)),
+                ScreenshotConfig(seed_views.SeedBIP85SelectNumWordsView, dict(seed_num=0)),
                 ScreenshotConfig(seed_views.SeedBIP85SelectChildIndexView, dict(seed_num=0, num_words=24)),
                 ScreenshotConfig(seed_views.SeedBIP85InvalidChildIndexView, dict(seed_num=0, num_words=12)), 
                 ScreenshotConfig(seed_views.SeedWordsBackupTestPromptView, dict(seed_num=0)),


### PR DESCRIPTION
## Description

Given the discussion in #713 (and my other BIP-85 PR, #785), this PR removes `bip85_app_num` from the BIP85 View.

I agree with the points raised previously and don’t see any reasonable use case for other application types in the SeedSigner world.

Summary of changes:
- Removed `bip85_app_num` from the BIP85 View.
- Simplified comments to note that only application number 39' is used.
- Renamed `SeedBIP85ApplicationModeView` to `SeedBIP85SelectNumWordsView`.

---

This pull request is categorized as a:

- [x] Code refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
