### PR TITLE
[FIX] Make screensaver animation speed consistent across devices

### DIFF
--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -211,6 +211,8 @@ class ScreensaverScreen(LogoScreen):
                         self.cur_x + self.renderer.canvas_width, self.cur_y + self.renderer.canvas_height))
                     self.renderer.disp.show_image(crop, 0, 0)
 
+                    time.sleep(0.03)
+
                     self.cur_x += self.increment_x
                     self.cur_y += self.increment_y
 


### PR DESCRIPTION
## Description

This PR adds a fixed delay (`time.sleep(0.03)`) to the screensaver animation loop, making the logo movement speed consistent across all devices. Previously, the animation was too fast on powerful CPUs, making the logo hard to see. This change improves usability and ensures a uniform experience.

No UI changes except for the screensaver animation speed. Screenshots are omitted since the visual appearance remains the same, only the movement speed is affected.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other (https://github.com/enteropositivo/seedsigner-emulator)