### PR TITLE
[Refactor] Use random bytes instead of hardware serial for entropy in camera module 

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -146,16 +146,9 @@ class ToolsImageEntropyMnemonicLengthView(View):
             preview_images = self.controller.image_entropy_preview_frames
             seed_entropy_image = self.controller.image_entropy_final_image
 
-            # Build in some hardware-level uniqueness via CPU unique Serial num
-            try:
-                stream = os.popen("cat /proc/cpuinfo | grep Serial")
-                output = stream.read()
-                serial_num = output.split(":")[-1].strip().encode('utf-8')
-                serial_hash = hashlib.sha256(serial_num)
-                hash_bytes = serial_hash.digest()
-            except Exception as e:
-                logger.info(repr(e), exc_info=True)
-                hash_bytes = b'0'
+            random_bytes = os.urandom(32)  # 32 bytes for SHA256 input
+            serial_hash = hashlib.sha256(random_bytes)
+            hash_bytes = serial_hash.digest()
 
             # Build in modest entropy via millis since power on
             millis_hash = hashlib.sha256(hash_bytes + str(time.time()).encode('utf-8'))


### PR DESCRIPTION


## Description

Replaced hardware-dependent CPU serial hash generation with `os.urandom` for entropy.
No UI or screen changes, so no screenshots are included.

This pull request is categorized as a:

* [ ] New feature
* [ ] Bug fix
* [x] Code refactor
* [ ] Documentation
* [ ] Other

## Checklist

* [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

* [ ] No, I’m a fool
* [ ] Yes
* [x] N/A

I have tested this PR on the following platforms/os:

* [ ] Raspberry Pi OS [[Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
* [ ] [[SeedSigner OS](https://github.com/SeedSigner/seedsigner-os)](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
* [x] Other (local development environment)
