### PR TITLE
[Fix] Stop translation of seed words in `SeedWordsBackupTestView`

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -284,6 +284,15 @@ class ButtonOption:
 
 
 @dataclass
+class ButtonOptionWithoutTranslation(ButtonOption):
+    """
+    Same as ButtonOption but does NOT translate button_label or active_button_label.
+    The labels are also not extracted for translation by babel.
+    """
+
+
+
+@dataclass
 class ButtonListScreen(BaseTopNavScreen):
     button_data: list[ButtonOption] = None
     selected_button: int = 0
@@ -341,13 +350,22 @@ class ButtonListScreen(BaseTopNavScreen):
 
         self.buttons: List[Button] = []
         for i, button_option in enumerate(self.button_data):
-            if type(button_option) != ButtonOption:
+            if not isinstance(button_option, ButtonOption):
                 raise Exception("Refactor to ButtonOption approach needed!")
+
+            if isinstance(button_option, ButtonOptionWithoutTranslation):
+                # Don't wrap labels in _()
+                button_label = button_option.button_label
+                active_button_label = button_option.active_button_label
+            else:
+                # Wrap labels in _() for just-in-time translations
+                button_label = _(button_option.button_label)
+                active_button_label = _(button_option.active_button_label)
 
             # TODO: Refactor `Button` to optionally use ButtonOption directly?
             button_kwargs = dict(
-                text=_(button_option.button_label),  # Wrap here for just-in-time translations
-                active_text=_(button_option.active_button_label),  # Wrap here for just-in-time translations
+                text=button_label,
+                active_text=active_button_label,
                 icon_name=button_option.icon_name,
                 icon_color=button_option.icon_color if button_option.icon_color else GUIConstants.BUTTON_FONT_COLOR,
                 is_icon_inline=True,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -10,7 +10,7 @@ from embit.descriptor import Descriptor
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens)
-from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed
@@ -1301,10 +1301,10 @@ class SeedWordsBackupTestView(View):
             while self.cur_index in self.confirmed_list:
                 self.cur_index = int(random.random() * len(self.mnemonic_list))
 
-        real_word = ButtonOption(self.mnemonic_list[self.cur_index])
-        fake_word1 = ButtonOption(bip39.WORDLIST[int(random.random() * 2047)])
-        fake_word2 = ButtonOption(bip39.WORDLIST[int(random.random() * 2047)])
-        fake_word3 = ButtonOption(bip39.WORDLIST[int(random.random() * 2047)])
+        real_word = ButtonOptionWithoutTranslation(self.mnemonic_list[self.cur_index])
+        fake_word1 = ButtonOptionWithoutTranslation(bip39.WORDLIST[int(random.random() * 2047)])
+        fake_word2 = ButtonOptionWithoutTranslation(bip39.WORDLIST[int(random.random() * 2047)])
+        fake_word3 = ButtonOptionWithoutTranslation(bip39.WORDLIST[int(random.random() * 2047)])
 
         button_data = [real_word, fake_word1, fake_word2, fake_word3]
         random.shuffle(button_data)


### PR DESCRIPTION
## Description

This PR prevents seed words from being translated in `SeedWordsBackupTestView`. Previously, if a seed word matched any word used elsewhere in the SeedSigner UI (e.g., "fee"), it could be translated, causing the seed phrase to display incorrectly.

### Before

<img width="240" height="240" alt="SeedWordsBackupTestView" src="https://github.com/user-attachments/assets/618df1e5-5eee-4950-9ad1-e4800e778c2b" />

### After

<img width="240" height="240" alt="SeedWordsBackupTestView_fixed" src="https://github.com/user-attachments/assets/99bb53a1-b3b3-4c21-ae7d-d3354a6eeccd" />

---

This pull request is categorized as a:

- [x] Bug fix

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
