### PR TITLE
[fix] Transaction handling when PSBT does not contain wallet fingerprint

### DIFF
--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -149,25 +149,15 @@ class TestPSBTParser:
             assert PSBTParser.has_matching_input_fingerprint(psbt, PSBTTestData.multisig_key_3)
 
 
-    def test_zero_fingerprint_handling(self):
+    def test_missing_fingerprint_handling(self):
         """
-        PSBTParser should correctly handle PSBTs with zero fingerprints (created from XPUB-only imports, 
+        PSBTParser should correctly handle PSBTs with missing fingerprints (created from XPUB-only imports, 
         without derivation path) by matching public keys against the seed and filling in correct fingerprints.
         """
-        for input in PSBTTestData.ALL_INPUTS:
+        for input in PSBTTestData.SINGLE_SIG_INPUTS:
             psbt = PSBT.parse(a2b_base64(input))
             
-            # Backup original derivations
-            original_derivations = []
-            original_taproot_derivations = []
-            for inp in psbt.inputs:
-                for pub, derivation in inp.bip32_derivations.items():
-                    original_derivations.append((pub, derivation))
-
-                for pub, (leaf_hashes, derivation) in inp.taproot_bip32_derivations.items():
-                    original_taproot_derivations.append((pub, leaf_hashes, derivation))
-            
-            # Set fingerprints to zero to simulate XPUB-only import
+            # Set fingerprints to zero to simulate XPUB-only import (missing fingerprint)
             from embit.psbt import DerivationPath
             for inp in psbt.inputs:
                 for pub, derivation in inp.bip32_derivations.items():
@@ -182,39 +172,32 @@ class TestPSBTParser:
                         derivation=derivation.derivation
                     ))
             
-            # Verify that has_matching_input_fingerprint works with zero fingerprints
-            # This tests the fallback mechanism that tries to derive and match pubkeys
+            # Test that has_matching_input_fingerprint can correctly identify that an input 
+            # from the psbt does belong to the provided seed, even when the fingerprints 
+            # (in the inputs' bip32 derivations) have been zeroed out.
             assert PSBTParser.has_matching_input_fingerprint(psbt, PSBTTestData.seed, SettingsConstants.REGTEST)
             
             # Test that it correctly rejects wrong seeds
             wrong_seed = Seed(["bacon"] * 24)
-            assert PSBTParser.has_matching_input_fingerprint(psbt, wrong_seed, SettingsConstants.REGTEST) == False
+            assert not PSBTParser.has_matching_input_fingerprint(psbt, wrong_seed, SettingsConstants.REGTEST)
             
-            # Test the PSBTParser's ability to fill zero fingerprints during parsing
+            # Test the PSBTParser's ability to fill missing fingerprints during parsing
             parser = PSBTParser(p=psbt, seed=PSBTTestData.seed, network=SettingsConstants.REGTEST)
             
             # Verify fingerprints were correctly filled after parsing
             seed_fingerprint = parser.seed.get_fingerprint(SettingsConstants.REGTEST)
-            fingerprints_filled = False
             
             for inp in parser.psbt.inputs:
                 for pub, derivation in inp.bip32_derivations.items():
-                    if derivation.fingerprint != b"\x00\x00\x00\x00":
-                        fingerprints_filled = True
-                        # Should match the seed's fingerprint
-                        from binascii import hexlify
-                        assert hexlify(derivation.fingerprint).decode() == seed_fingerprint
-                
+                    # Must match the signing seed's fingerprint
+                    from binascii import hexlify
+                    assert hexlify(derivation.fingerprint).decode() == seed_fingerprint
+
                 # Also check Taproot derivations
                 for pub, (leaf_hashes, derivation) in inp.taproot_bip32_derivations.items():
-                    if derivation.fingerprint != b"\x00\x00\x00\x00":
-                        fingerprints_filled = True
-                        # Should match the seed's fingerprint
-                        from binascii import hexlify
-                        assert hexlify(derivation.fingerprint).decode() == seed_fingerprint
-            
-            # Fingerprints should have been filled
-            assert fingerprints_filled > 0
+                    # Must match the signing seed's fingerprint
+                    from binascii import hexlify
+                    assert hexlify(derivation.fingerprint).decode() == seed_fingerprint
 
 
     def test_trim_and_sig_count(self):


### PR DESCRIPTION
## Description

SeedSigner fails to recognize PSBTs created from wallets that imported an xpub without derivation paths (common with BlueWallet and other software wallets). These PSBTs contain zero fingerprints instead of the actual master fingerprint, causing SeedSigner to incorrectly reject valid seeds.

This PR adds zero fingerprint handling to the PSBT parsing system, as per [Krux approach](https://github.com/selfcustody/krux/blob/8e4a2cfb64341505a035f3477277a84aaaf06025/src/krux/psbt.py#L443).

This was functionally tested in Raspberry Pi OS Manual Build using a zero-fingerprint xpub imported from Blue Wallet into Sparrow Wallet, with PSBT signing coordinated by Sparrow Wallet.

Solves #359 

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
