### PR TITLE
[Refactor] Make `DisplayDriver` a true parent class; add `DisplayDriverFactory`

### DIFF
--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -1,9 +1,7 @@
 from PIL import Image, ImageDraw
 from threading import Lock
 
-# from seedsigner.hardware.st7789_mpy import ST7789
-from seedsigner.hardware.displays.display_driver import ALL_DISPLAY_TYPES, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486, DISPLAY_TYPE__ST7789, DisplayDriver
-from seedsigner.hardware.displays.ili9341 import ILI9341, ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT
+from seedsigner.hardware.displays.display_driver import ALL_DISPLAY_TYPES, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486, DISPLAY_TYPE__ST7789, DisplayDriverFactory
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.models.singleton import ConfigurableSingleton
@@ -45,7 +43,12 @@ class Renderer(ConfigurableSingleton):
             raise Exception(f"Invalid display type: {self.display_type}")
 
         width, height = display_config.split("_")[1].split("x")
-        self.disp = DisplayDriver(self.display_type, width=int(width), height=int(height))
+
+        if self.disp:
+            # Existing instances might need to close resources like pwm
+            self.disp.cleanup()
+
+        self.disp = DisplayDriverFactory.instantiate_display_driver(self.display_type, width=int(width), height=int(height))
 
         if Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED:
             self.disp.invert()

--- a/src/seedsigner/hardware/displays/ST7789.py
+++ b/src/seedsigner/hardware/displays/ST7789.py
@@ -4,12 +4,12 @@ import time
 import array
 from dataclasses import dataclass
 
-from seedsigner.hardware.displays.display_driver import DisplayDriver
+from seedsigner.hardware.displays.display_driver import BaseDisplayDriver
 
 
 
 @dataclass
-class ST7789(DisplayDriver):
+class ST7789(BaseDisplayDriver):
     """
     The original SeedSigner display driver.
 

--- a/src/seedsigner/hardware/displays/ST7789.py
+++ b/src/seedsigner/hardware/displays/ST7789.py
@@ -2,16 +2,23 @@ import spidev
 import RPi.GPIO as GPIO
 import time
 import array
+from dataclasses import dataclass
+
+from seedsigner.hardware.displays.display_driver import DisplayDriver
 
 
 
-class ST7789(object):
-    """class for ST7789  240*240 1.3inch OLED displays."""
+@dataclass
+class ST7789(DisplayDriver):
+    """
+    The original SeedSigner display driver.
 
-    def __init__(self):
-        self.width = 240
-        self.height = 240
+    Note that self._width and self._height are provided by the parent DisplayDriver class
+    and are set during instantiation via the DisplayDriverFactory.
 
+    class for ST7789  240*240 1.3inch OLED displays.
+    """
+    def __post_init__(self):
         #Initialize DC RST pin
         self._dc = 22
         self._rst = 13

--- a/src/seedsigner/hardware/displays/display_driver.py
+++ b/src/seedsigner/hardware/displays/display_driver.py
@@ -10,13 +10,12 @@ ALL_DISPLAY_TYPES = [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__
     
 
 @dataclass
-class DisplayDriver:
+class BaseDisplayDriver:
     _width: int
     _height: int
 
-
     def __str__(self):
-        return f"DisplayDriver(display_type={self.display_type}, width={self.width}, height={self.height})"
+        return f"DisplayDriver(display_type={getattr(self, 'display_type', None)}, width={self.width}, height={self.height})"
 
 
     @property
@@ -30,16 +29,26 @@ class DisplayDriver:
 
 
     def invert(self, enabled: bool = True):
-        """Invert how the display interprets colors"""
-        raise Exception("Must be implemented in child class")
+        """
+        Invert how the display interprets colors.
+        Implementation in child classes is optional.
+        """
+        pass
 
 
     def show_image(self, image, x_start: int = 0, y_start: int = 0):
-        raise Exception("Must be implemented in child class")
-    
+        """
+        The main rendering call to the display driver.
+        Must be implemented in child classes.
+        """
+        raise Exception("show_image() must be implemented in child classes")
+
 
     def cleanup(self):
-        """Cleanup resources related to the display driver."""
+        """
+        Cleanup resources used by the display driver.
+        Implementation in child classes is optional.
+        """
         pass
 
 
@@ -52,7 +61,7 @@ class DisplayDriverFactory:
     """
 
     @classmethod
-    def instantiate_display_driver(cls, display_type: str = DISPLAY_TYPE__ST7789, width: int = None, height: int = None) -> DisplayDriver:
+    def instantiate_display_driver(cls, display_type: str = DISPLAY_TYPE__ST7789, width: int = None, height: int = None) -> BaseDisplayDriver:
         if display_type not in ALL_DISPLAY_TYPES:
             raise ValueError(f"Invalid display type: {display_type}")
 

--- a/src/seedsigner/hardware/displays/display_driver.py
+++ b/src/seedsigner/hardware/displays/display_driver.py
@@ -1,41 +1,19 @@
+from dataclasses import dataclass
+
+
 DISPLAY_TYPE__ST7789 = "st7789"
 DISPLAY_TYPE__ILI9341 = "ili9341"
 DISPLAY_TYPE__ILI9486 = "ili9486"
 
 ALL_DISPLAY_TYPES = [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486]
 
-
-class DisplayDriver:
-    def __init__(self, display_type: str = DISPLAY_TYPE__ST7789, width: int = None, height: int = None):
-        if display_type not in ALL_DISPLAY_TYPES:
-            raise ValueError(f"Invalid display type: {display_type}")
-        self.display_type = display_type
-
-        if self.display_type == DISPLAY_TYPE__ST7789:
-            if width not in [240, 320] or height != 240:
-                raise ValueError("ST7789 display only supports 240x240 or 320x240 resolutions")
-
-            if width == 240:
-                # TODO: For now the original ST7789 driver has to be used for 240x240.
-                # The mpy version below renders incorrectly (almost like each row of pixels
-                # is one pixel short, so the entire screen exhibits a diagonal skew).
-                from seedsigner.hardware.displays.ST7789 import ST7789
-                self.display = ST7789()
-
-            elif width == 320:
-                from seedsigner.hardware.displays.st7789_mpy import ST7789
-                # Have to swap width and height; screen is natively 240x320
-                self.display = ST7789(width=height, height=width)
-        
-        elif self.display_type == DISPLAY_TYPE__ILI9341:
-            from seedsigner.hardware.displays.ili9341 import ILI9341
-            self.display = ILI9341()
-            self.display.begin()
-        
-        elif self.display_type == DISPLAY_TYPE__ILI9486:
-            # TODO: improve performance of ili9486 driver
-            raise Exception("ILI9486 display not implemented yet")
     
+
+@dataclass
+class DisplayDriver:
+    _width: int
+    _height: int
+
 
     def __str__(self):
         return f"DisplayDriver(display_type={self.display_type}, width={self.width}, height={self.height})"
@@ -43,18 +21,63 @@ class DisplayDriver:
 
     @property
     def width(self):
-        return self.display.width
+        return self._width
 
 
     @property
     def height(self):
-        return self.display.height
+        return self._height
 
 
     def invert(self, enabled: bool = True):
         """Invert how the display interprets colors"""
-        self.display.invert(enabled)
+        raise Exception("Must be implemented in child class")
 
 
     def show_image(self, image, x_start: int = 0, y_start: int = 0):
-        self.display.show_image(image, x_start, y_start)
+        raise Exception("Must be implemented in child class")
+    
+
+    def cleanup(self):
+        """Cleanup resources related to the display driver."""
+        pass
+
+
+
+class DisplayDriverFactory:
+    """
+    Manages all logic related to instantiating display drivers based on type and resolution.
+
+    Imports for specific display drivers are done within this class to avoid circular imports.
+    """
+
+    @classmethod
+    def instantiate_display_driver(cls, display_type: str = DISPLAY_TYPE__ST7789, width: int = None, height: int = None) -> DisplayDriver:
+        if display_type not in ALL_DISPLAY_TYPES:
+            raise ValueError(f"Invalid display type: {display_type}")
+
+        if display_type == DISPLAY_TYPE__ST7789:
+            if width not in [240, 320] or height != 240:
+                raise ValueError("ST7789 display only supports 240x240 or 320x240 resolutions")
+
+            if width == 240:
+                # TODO: For now the original ST7789 driver has to be used for 240x240.
+                # The mpy version below renders incorrectly (almost like each row of pixels
+                # is one pixel short, so the entire screen exhibits a diagonal skew).
+                from seedsigner.hardware.displays.ST7789 import ST7789 as original_ST7789
+                return original_ST7789(_width=width, _height=height)
+
+            elif width == 320:
+                from seedsigner.hardware.displays.st7789_mpy import ST7789 as mpy_ST7789
+                # Have to swap width and height; screen is natively 240x320
+                return mpy_ST7789(_width=height, _height=width)
+
+        elif display_type == DISPLAY_TYPE__ILI9341:
+            from seedsigner.hardware.displays.ili9341 import ILI9341
+            display = ILI9341(_width=width, _height=height)
+            display.begin()
+            return display
+        
+        elif display_type == DISPLAY_TYPE__ILI9486:
+            # TODO: improve performance of ili9486 driver
+            raise Exception("ILI9486 display not implemented yet")

--- a/src/seedsigner/hardware/displays/ili9341.py
+++ b/src/seedsigner/hardware/displays/ili9341.py
@@ -35,6 +35,8 @@ from PIL import ImageDraw
 import RPi.GPIO as GPIO
 from spidev import SpiDev
 
+from seedsigner.hardware.displays.display_driver import BaseDisplayDriver
+
 
 # Constants for interacting with display registers.
 ILI9341_TFTWIDTH    = 240
@@ -129,16 +131,14 @@ def image_to_data(image):
     return arr.tobytes()
 
 
-class ILI9341(object):
+class ILI9341(BaseDisplayDriver):
     """Representation of an ILI9341 TFT LCD."""
 
-    def __init__(self, dc=22, rst=13, led=12, width=ILI9341_TFTWIDTH,
-        height=ILI9341_TFTHEIGHT, rotation=90):
-        """Create an instance of the display using SPI communication.  Must
-        provide the GPIO pin number for the D/C pin and the SPI driver.  Can
-        optionally provide the GPIO pin number for the reset pin as the rst
-        parameter.
-        """
+    def __post_init__(self):
+        dc=22
+        rst=13
+        led=12
+        rotation=90
         spi = SpiDev(0, 0)
         # spi.mode = 0b10  # [CPOL|CPHA] -> polarity 1, phase 0
         spi.max_speed_hz = 64_000_000
@@ -146,8 +146,6 @@ class ILI9341(object):
         self._dc = dc
         self._rst = rst
         self._spi = spi
-        self.width = width
-        self.height = height
         self.rotation = rotation
         self.inverted = False
         # if self._gpio is None:
@@ -165,15 +163,7 @@ class ILI9341(object):
             GPIO.output(self._rst, GPIO.HIGH)
 
         # Create an image buffer.
-        self.buffer = Image.new('RGB', (width, height))
-
-    # @property
-    # def width(self):
-    #     return self.width
-
-    # @property
-    # def height(self):
-    #     return self.height
+        self.buffer = Image.new('RGB', (self.width, self.height))
 
 
     def send(self, data, is_data=True, chunk_size=4096):

--- a/src/seedsigner/hardware/displays/ili9341.py
+++ b/src/seedsigner/hardware/displays/ili9341.py
@@ -29,6 +29,8 @@ import time
 # import numpy as np
 import array
 
+from dataclasses import dataclass
+
 from PIL import Image
 from PIL import ImageDraw
 
@@ -131,6 +133,7 @@ def image_to_data(image):
     return arr.tobytes()
 
 
+@dataclass
 class ILI9341(BaseDisplayDriver):
     """Representation of an ILI9341 TFT LCD."""
 
@@ -300,15 +303,15 @@ class ILI9341(BaseDisplayDriver):
         self.reset()
         self._init()
 
-    def invert(self, state: bool = True):
+    def invert(self, enabled: bool = True):
         """Sets display inversion to the specified state. If not provided, state
         is True, which inverts the display. If state is False, the display turns
         back into normal mode."""
-        if state:
+        if enabled:
             self.command(ILI9341_INVON)
         else:
             self.command(ILI9341_INVOFF)
-        self.inverted = state
+        self.inverted = enabled
         return self
 
     def set_window(self, x0=0, y0=0, x1=None, y1=None):

--- a/src/seedsigner/hardware/displays/st7789_mpy.py
+++ b/src/seedsigner/hardware/displays/st7789_mpy.py
@@ -54,7 +54,10 @@ import array
 import spidev
 import RPi.GPIO as GPIO
 
+from dataclasses import dataclass
 from math import sin, cos
+
+from seedsigner.hardware.displays.display_driver import DisplayDriver
 
 #
 # This allows sphinx to build the docs
@@ -228,7 +231,9 @@ def color565(red, green=0, blue=0):
     return (red & 0xF8) << 8 | (green & 0xFC) << 3 | blue >> 3
 
 
-class ST7789:
+
+@dataclass
+class ST7789(DisplayDriver):
     """
     ST7789 driver class
 
@@ -262,20 +267,15 @@ class ST7789:
 
     """
 
-    def __init__(
-        self,
-        # spi,
-        width,
-        height,
-        reset=13,
-        dc=22,
-        cs=None,
-        backlight=18,
-        rotation=1,
-        color_order=BGR,
-        custom_init=None,
-        custom_rotations=None,
-    ):
+    def __post_init__(self):
+        reset=13
+        dc=22
+        cs=None
+        backlight=18
+        rotation=1
+        color_order=BGR
+        custom_init=None
+        custom_rotations=None
 
         GPIO.setmode(GPIO.BOARD)
         GPIO.setwarnings(False)
@@ -290,20 +290,20 @@ class ST7789:
         """
         Initialize display.
         """
-        self.rotations = custom_rotations or self._find_rotations(width, height)
+        self.rotations = custom_rotations or self._find_rotations(self.width, self.height)
         if not self.rotations:
             supported_displays = ", ".join(
                 [f"{display[0]}x{display[1]}" for display in _SUPPORTED_DISPLAYS]
             )
             raise ValueError(
-                f"Unsupported {width}x{height} display. Supported displays: {supported_displays}"
+                f"Unsupported {self.width}x{self.height} display. Supported displays: {supported_displays}"
             )
 
         if dc is None:
             raise ValueError("dc pin is required.")
 
-        self.physical_width = self.width = width
-        self.physical_height = self.height = height
+        self.physical_width = self.width
+        self.physical_height = self.height
         self.xstart = 0
         self.ystart = 0
         self.spi = spi
@@ -445,8 +445,8 @@ class ST7789:
         self._rotation = rotation
         (
             madctl,
-            self.width,
-            self.height,
+            self._width,   # have to use the settable internal vars
+            self._height,  # have to use the settable internal vars
             self.xstart,
             self.ystart,
             self.needs_swap,

--- a/src/seedsigner/hardware/displays/st7789_mpy.py
+++ b/src/seedsigner/hardware/displays/st7789_mpy.py
@@ -57,7 +57,7 @@ import RPi.GPIO as GPIO
 from dataclasses import dataclass
 from math import sin, cos
 
-from seedsigner.hardware.displays.display_driver import DisplayDriver
+from seedsigner.hardware.displays.display_driver import BaseDisplayDriver
 
 #
 # This allows sphinx to build the docs
@@ -233,7 +233,7 @@ def color565(red, green=0, blue=0):
 
 
 @dataclass
-class ST7789(DisplayDriver):
+class ST7789(BaseDisplayDriver):
     """
     ST7789 driver class
 


### PR DESCRIPTION
## Description

This refactor does not create any user-facing changes. It is strictly a restructuring to enable future feature changes to display drivers.

Prior to this PR, `DisplayDriver` was already a factory class that would explicitly instantiate the requested display driver (ST7789, ST7789_mpy, ili9341). I'm not quite sure what I was thinking in that original implementation as it's somewhat obvious that I did mean for `DisplayDriver` to eventually be a parent base class (e.g. defining a `show_image()` method that then internally makes the same call to its `self.display` member var). I think the original implementation trying to be both a factory and a parent class at the same time threw me off.

So this PR rectifies that.

The part of the prior `DisplayDriver` class that handled actual driver instantiation has been moved into the new `DisplayDriverFactory`.

And then the rest of the prior `DisplayDriver` class that defined the driver interface is now made into a proper parent class (`BaseDisplayDriver`). `ST7789` (our original driver for the standard Waveshare hat) and `ST7789_mpy` (driver for the SeedSigner+ 320x240 hat) have been updated to be child classes of the new `DisplayDriver`.

I also made a cursory attempt at making the same changes to `ILI9341` but I haven't tested it as I don't have a hardware setup for it at the moment. Its inclusion in the display driver list was always a "eh, why not?" at this stage but was only intended to facilitate hardware R&D (it's specified as "beta" anyway).

### Motivation
I've been working on separate R&D efforts around user-selected gamma curves in the display drivers and controlling the screen backlight via pwm. In both cases, it was clear that having a common `BaseDisplayDriver` parent class was an improvement to the code structure.

But both of those efforts are in limbo, unsure of how to proceed.

So instead I pulled out just the factory/parent/child changes for this PR. Otherwise I was worried that this useful refactor would get lost as the gamma curve and pwm backlight branches languished.

_Note: I did not use python's built-in abstract base class (`abc.ABC`) because we haven't used it for any other abstract base classes (e.g. `BaseScreen`) and `ABC` is not supported in MicroPython. Using the `ABC` class isn't much of a "win" as far as I can tell, anyway._

---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
