### PR TITLE
[l10n] Exception str does not need to be translated

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1868,7 +1868,8 @@ class SeedAddressVerificationView(View):
         self.seed_derivation_override = ""
         if not self.is_multisig:
             if seed_num is None:
-                raise Exception(_("Can't validate a single sig addr without specifying a seed"))
+                # Shouldn't be able to get here
+                raise Exception("Can't validate a single sig addr without specifying a seed")
             self.seed_num = seed_num
             self.seed = self.controller.get_seed(seed_num)
             self.seed_derivation_override = self.seed.derivation_override(sig_type=SettingsConstants.SINGLE_SIG)


### PR DESCRIPTION
## Description

The exception in this PR is meant to catch possible routing mistakes made during development. It's really just a basic sanity check. 

The error message is not meant to be displayed to the end user (and is currently unreachable, as expected). So there's no need to burden translators with translating this message.

---

This pull request is categorized as a:
- [x] Other: l10n

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] N/A