### PR TITLE
SeedOptionsView: Remove unreachable VERIFY_ADDRESS code

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -525,7 +525,6 @@ class SeedElectrumMnemonicStartView(View):
 ****************************************************************************"""
 class SeedOptionsView(View):
     SCAN_PSBT = ButtonOption("Scan transaction", SeedSignerIconConstants.QRCODE)
-    VERIFY_ADDRESS = ButtonOption("Verify addr")
     EXPORT_XPUB = ButtonOption("Export xpub")
     EXPLORER = ButtonOption("Address explorer")
     SIGN_MESSAGE = ButtonOption("Sign message")
@@ -571,12 +570,6 @@ class SeedOptionsView(View):
 
         button_data = []
 
-        if self.controller.unverified_address:
-            # TODO: Verify that an addr verification flow can actually reach this code
-            addr = self.controller.unverified_address["address"][:7]
-            self.VERIFY_ADDRESS.button_label += f" {addr}"
-            button_data.append(self.VERIFY_ADDRESS)
-
         button_data.append(self.SCAN_PSBT)
         
         if self.settings.get_value(SettingsConstants.SETTING__XPUB_EXPORT) == SettingsConstants.OPTION__ENABLED:
@@ -608,9 +601,6 @@ class SeedOptionsView(View):
             from seedsigner.views.scan_views import ScanPSBTView
             self.controller.psbt_seed = self.controller.get_seed(self.seed_num)
             return Destination(ScanPSBTView)
-
-        elif button_data[selected_menu_num] == self.VERIFY_ADDRESS:
-            return Destination(SeedAddressVerificationView, view_args=dict(seed_num=self.seed_num))
 
         elif button_data[selected_menu_num] == self.EXPORT_XPUB:
             return Destination(SeedExportXpubSigTypeView, view_args=dict(seed_num=self.seed_num))


### PR DESCRIPTION
## Description

The `# TODO` note in the deleted code was correct: the entire `VERIFY_ADDRESS` bits here are unreachable.

[This earlier code](https://github.com/SeedSigner/seedsigner/blob/dev/src/seedsigner/views/seed_views.py#L547-L551) already routes away from this View when we're in the single sig addr verification flow.

---

This pull request is categorized as a:
- [x] Code refactor

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: via test suite and hands-on to test various flow routes to verify single sig addr