### PR TITLE
[Cleanup] Remove dead code: misc `*_screens.py`

### DIFF
--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -33,9 +33,6 @@ class PSBTOverviewScreen(ButtonListScreen):
         self.is_bottom_list = True
         self.button_data = [ButtonOption("Review details")]
 
-        # This screen can take a while to load while parsing the PSBT
-        self.show_loading_screen = True
-
         super().__post_init__()
 
         # Prep the headline amount being spent in large callout

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -441,7 +441,6 @@ class SeedFinalizeScreen(ButtonListScreen):
 @dataclass
 class SeedOptionsScreen(ButtonListScreen):
     fingerprint: str = None
-    has_passphrase: bool = False
 
     def __post_init__(self):
         self.top_nav_icon_name = SeedSignerIconConstants.FINGERPRINT
@@ -590,7 +589,6 @@ class SeedExportXpubDetailsScreen(WarningEdgesMixin, ButtonListScreen):
     # Customize defaults
     is_bottom_list: bool = True
     fingerprint: str = None
-    has_passphrase: bool = False
     derivation_path: str = "m/84'/0'/0'"
     xpub: str = "zpub6r..."
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -455,24 +455,6 @@ class SeedOptionsScreen(ButtonListScreen):
 
 
 @dataclass
-class SeedBackupScreen(ButtonListScreen):
-    has_passphrase: bool = False
-
-    def __post_init__(self):
-        self.title = _("Backup Seed")
-        self.is_bottom_list = True
-        super().__post_init__()
-
-        if self.has_passphrase:
-            self.components.append(TextArea(
-                # TRANSLATOR_NOTE: Additional explainer for the two seed backup options (mnemonic phrase and SeedQR).
-                text=_("Backups do not include your passphrase."),
-                screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
-            ))
-
-
-
-@dataclass
 class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
     words: List[str] = None
     page_index: int = 0

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -25,7 +25,6 @@ class SettingsEntryUpdateSelectionScreen(ButtonListScreen):
     def __post_init__(self):
         self.title = _("Settings")
         self.is_bottom_list = True
-        self.use_checked_selection_buttons = True
         if self.settings_entry_type == SettingsConstants.TYPE__MULTISELECT:
             self.Button_cls = CheckboxButton
         else:

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -269,7 +269,7 @@ class ToolsCalcFinalWordScreen(ButtonListScreen):
         # First what's the total bit display width and where do the checksum bits start?
         bit_font_size = GUIConstants.get_button_font_size(locale="default") + 2  # bit font size should not vary by locale
         font = Fonts.get_font(GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME, bit_font_size)
-        (left, top, bit_display_width, bit_font_height) = font.getbbox("0" * 11, anchor="lt")
+        (left, top, bit_display_width, bottom) = font.getbbox("0" * 11, anchor="lt")
         (left, top, checksum_x, bottom) = font.getbbox("0" * (11 - len(self.checksum_bits)), anchor="lt")
         bit_display_x = int((self.canvas_width - bit_display_width)/2)
         checksum_x += bit_display_x

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -597,7 +597,6 @@ class SeedOptionsView(View):
             seed_screens.SeedOptionsScreen,
             button_data=button_data,
             fingerprint=self.seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
-            has_passphrase=self.seed.passphrase is not None,
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
@@ -958,7 +957,6 @@ class SeedExportXpubDetailsView(View):
             selected_menu_num = self.run_screen(
                 seed_screens.SeedExportXpubDetailsScreen,
                 fingerprint=fingerprint,
-                has_passphrase=self.seed.passphrase is not None,
                 derivation_path=derivation_path,
                 xpub=xpub_base58,
             )


### PR DESCRIPTION
## Description

This is part of a series of PRs that I'm keeping separate and simple so that they'll be easy to review.

Finding dead code via `vulture`:

```python
pip install vulture
vulture src/seedsigner tests tools
```

Note: there are false-positives in its results as it doesn't actually run the code.

## Additional Details
* After removing the unused `SeedBackupScreen` class from `seed_screens.py`, the `has_passphrase` attr also became dead code and was removed from two Screens and their associated View calls (in `seed_views.py`).
* The loading screen spinner in `PSBTOverviewScreen` (`psbt_screens.py`) had previously been moved to its associated View. The deletion here is just overdue cleanup after that change.

---

This pull request is categorized as a:
- [x] Other: remove unused code

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: local dev test suite
