### PR TITLE
[Cleanup] Remove dead code: `mnemonic_generation.py`

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -110,14 +110,3 @@ def get_partial_final_word(coin_flips: str, wordlist_language_code: str = Settin
     wordlist_index = int(binary_string, 2)
 
     return Seed.get_wordlist(wordlist_language_code)[wordlist_index]
-
-
-
-# Note: This currently isn't being used since we're now chaining hashed bytes for the
-#   image-based entropy and aren't just ingesting a single image.
-def generate_mnemonic_from_image(image, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
-    import hashlib
-    hash = hashlib.sha256(image.tobytes())
-
-    # Return as a list
-    return bip39.mnemonic_from_bytes(hash.digest(), wordlist=Seed.get_wordlist(wordlist_language_code)).split()


### PR DESCRIPTION
## Description

This is part of a series of PRs that I'm keeping separate and simple so that they'll be easy to review.

Finding dead code via `vulture`:

```python
pip install vulture
vulture src/seedsigner tests tools
```

Note: there are false-positives in its results as it doesn't actually run the code.


## Misc Notes
This way-outdated `generate_mnemonic_from_image()` function isn't serving any purpose for us. And since our actual image entropy system is way more robust, leaving this in risks adding a bit of possible confusion / misunderstanding.

---

This pull request is categorized as a:
- [x] Other: remove unused code

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: local dev test suite
