### PR TITLE
fix: Display error on PSBT change output fingerprint mismatch

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -4,7 +4,7 @@ from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens.screen import (RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption, WarningScreen, DireWarningScreen, QRDisplayScreen)
-from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination
+from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination, ErrorView
 
 
 
@@ -335,8 +335,17 @@ class PSBTChangeDetailsView(View):
         seed_fingerprint = self.controller.psbt_seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
 
         if seed_fingerprint not in change_data.get("fingerprint"):
-            # TODO: Something is wrong with this psbt(?). Reroute to warning?
-            return Destination(NotYetImplementedView)
+            return Destination(
+                ErrorView,
+                view_args=dict(
+                    title=_("Error"),
+                    status_headline=_("Fingerprint Mismatch"),
+                    text=_("Change output fingerprint mismatch. This seed cannot sign for this change output."),
+                    button_text=_("Discard transaction"),
+                    next_destination=Destination(MainMenuView, clear_history=True),
+                    show_back_button=False
+                )
+            )
 
         i = change_data.get("fingerprint").index(seed_fingerprint)
         derivation_path = change_data.get("derivation_path")[i]


### PR DESCRIPTION

Replaced the generic \`NotYetImplementedView\` with a specific \`ErrorView\` in \`PSBTChangeDetailsView\`.

Previously, if a user attempted to sign a PSBT where the change output fingerprint did not match the current seed, they were routed to a confusing 'Not Yet Implemented' screen. This fix provides a clear error message explaining the mismatch.

_No screenshots included as this reuses the existing ErrorView component._

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run \`pytest\` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other"

Screenshot

<img width="240" height="240" alt="error_screenshot" src="https://github.com/user-attachments/assets/b127cb0d-896e-40ad-8cf2-64c3c5be6b30" />