### PR TITLE
test: Add regression test for Issue #550 (long message overflow)

### DIFF
--- a/tests/test_issue_550.py
+++ b/tests/test_issue_550.py
@@ -1,53 +1,44 @@
+import sys
+from unittest.mock import MagicMock, patch
 import pytest
-from unittest.mock import MagicMock
 
-# Import base test class
-from base import BaseTest
+# Mock hardware dependencies (replacing BaseTest functionality)
+sys.modules['RPi'] = MagicMock()
+sys.modules['RPi.GPIO'] = MagicMock()
+sys.modules['spidev'] = MagicMock()
 
-# Import project modules
 from seedsigner.controller import Controller
 from seedsigner.gui.screens.seed_screens import SeedSignMessageConfirmMessageScreen
 from seedsigner.gui.components import TextDoesNotFitException
 from seedsigner.gui.renderer import Renderer
 
-class TestIssue550(BaseTest):
+class TestIssue550:
+    @pytest.fixture
+    def mock_controller(self):
+        # Standard controller mocking pattern for SeedSigner
+        with patch('seedsigner.controller.Controller') as MockController:
+            controller_instance = MockController.get_instance.return_value
+            yield controller_instance
+
     def test_long_message_overflow(self):
-        """
-        Issue #550: TextDoesNotFitException when trying to sign very long messages.
-        
-        This test simulates a long, uninterrupted string (like a BOLT12 invoice) 
-        being passed to the SeedSignMessageConfirmMessageScreen.
-        """
-        # Setup Controller
         controller = Controller.get_instance()
         
-        # Configure Renderer mock dimensions so the layout math works with real integers
         renderer = Renderer.get_instance()
         renderer.canvas_width = 240
         renderer.canvas_height = 240
 
-        # A very long string with no spaces (simulating BOLT12 invoice or similar)
-        # 100 chars of 'A' is wider than 240px screen width
         long_message = "A" * 100
         
-        # Mock the sign_message_data structure in the controller
         controller.sign_message_data = {
             "message": long_message,
         }
         
-        # Instantiate the screen. This triggers __post_init__ which calls reflow_text_into_pages.
-        # If the bug is present (allow_text_overflow=False), this raises TextDoesNotFitException.
         try:
-            # Fix: Pass page_num=0 to avoid TypeError in __post_init__ validation
             screen = SeedSignMessageConfirmMessageScreen(page_num=0)
         except TextDoesNotFitException:
             pytest.fail("SeedSignMessageConfirmMessageScreen raised TextDoesNotFitException on long message")
 
-        # Verify paged message was created and stored
         assert "paged_message" in controller.sign_message_data
         assert len(controller.sign_message_data["paged_message"]) > 0
         
-        # Verify the content is handled (likely truncated/split arbitrarily or overflowed)
-        # We just want to ensure it didn't crash.
-        print(f"Paged message content: {controller.sign_message_data['paged_message']}")
         assert controller.sign_message_data["paged_message"][0].startswith("AAAA")

--- a/tests/test_issue_550.py
+++ b/tests/test_issue_550.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import MagicMock
+
+# Import base test class
+from base import BaseTest
+
+# Import project modules
+from seedsigner.controller import Controller
+from seedsigner.gui.screens.seed_screens import SeedSignMessageConfirmMessageScreen
+from seedsigner.gui.components import TextDoesNotFitException
+from seedsigner.gui.renderer import Renderer
+
+class TestIssue550(BaseTest):
+    def test_long_message_overflow(self):
+        """
+        Issue #550: TextDoesNotFitException when trying to sign very long messages.
+        
+        This test simulates a long, uninterrupted string (like a BOLT12 invoice) 
+        being passed to the SeedSignMessageConfirmMessageScreen.
+        """
+        # Setup Controller
+        controller = Controller.get_instance()
+        
+        # Configure Renderer mock dimensions so the layout math works with real integers
+        renderer = Renderer.get_instance()
+        renderer.canvas_width = 240
+        renderer.canvas_height = 240
+
+        # A very long string with no spaces (simulating BOLT12 invoice or similar)
+        # 100 chars of 'A' is wider than 240px screen width
+        long_message = "A" * 100
+        
+        # Mock the sign_message_data structure in the controller
+        controller.sign_message_data = {
+            "message": long_message,
+        }
+        
+        # Instantiate the screen. This triggers __post_init__ which calls reflow_text_into_pages.
+        # If the bug is present (allow_text_overflow=False), this raises TextDoesNotFitException.
+        try:
+            # Fix: Pass page_num=0 to avoid TypeError in __post_init__ validation
+            screen = SeedSignMessageConfirmMessageScreen(page_num=0)
+        except TextDoesNotFitException:
+            pytest.fail("SeedSignMessageConfirmMessageScreen raised TextDoesNotFitException on long message")
+
+        # Verify paged message was created and stored
+        assert "paged_message" in controller.sign_message_data
+        assert len(controller.sign_message_data["paged_message"]) > 0
+        
+        # Verify the content is handled (likely truncated/split arbitrarily or overflowed)
+        # We just want to ensure it didn't crash.
+        print(f"Paged message content: {controller.sign_message_data['paged_message']}")
+        assert controller.sign_message_data["paged_message"][0].startswith("AAAA")


### PR DESCRIPTION
This PR addresses Issue #550: "TextDoesNotFitException when trying to sign very long messages".

It adds a regression test (`tests/test_issue_550.py`) that simulates passing a very long, uninterrupted string (such as a BOLT12 invoice) to the `SeedSignMessageConfirmMessageScreen`. This test ensures that the text reflow logic handles the overflow gracefully (using `allow_text_overflow=True`) instead of raising a `TextDoesNotFitException` and crashing the app.

The fix was confirmed to already be present in the codebase; this PR adds the test case to prevent future regressions.

_Screenshots omitted as this PR only adds a backend test case and does not modify the visible UI._

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other (Test coverage / Regression test)

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [[Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)]
- [ ] [[SeedSigner OS](https://github.com/SeedSigner/seedsigner-os)]on a Pi0/Pi0W board
- [x] Other (GitHub Codespaces / Linux environment)