### PR TITLE
Updated test to use full navigation path for valid back stack (Implements Issue #775)

### DIFF
--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -43,11 +43,21 @@ class ScanView(View):
         from seedsigner.gui.screens.scan_screens import ScanScreen
 
         # Start the live preview and background QR reading
-        self.run_screen(
+        ret = self.run_screen(
             ScanScreen,
             instructions_text=self.instructions_text,
             decoder=self.decoder
         )
+
+        if ret is False:
+            # User cancelled the scan.
+            # If we are in a flow that expects data from this scan (e.g. Sign Message),
+            # we must abort that flow so the previous screen doesn't try to auto-resume it.
+            if self.controller.resume_main_flow:
+                logger.info(f"Scan cancelled. Aborting flow: {self.controller.resume_main_flow}")
+                self.controller.resume_main_flow = None
+                
+            return Destination(BackStackView)
 
         # A long scan might have exceeded the screensaver timeout; ensure screensaver
         # doesn't immediately engage when we leave here.

--- a/tests/test_issue_775.py
+++ b/tests/test_issue_775.py
@@ -1,65 +1,43 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock hardware dependencies
+sys.modules['RPi'] = MagicMock()
+sys.modules['RPi.GPIO'] = MagicMock()
+sys.modules['spidev'] = MagicMock()
+
 from base import FlowTest, FlowStep
-from seedsigner.views.view import MainMenuView, BackStackView
+from seedsigner.views.view import MainMenuView
 from seedsigner.views import scan_views, tools_views, seed_views
 from seedsigner.models.settings import SettingsConstants
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
-from seedsigner.controller import Controller
 from seedsigner.models.seed import Seed
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.gui.components import SeedSignerIconConstants
 
 class TestIssue775(FlowTest):
     def test_scan_view_cancellation_returns_to_back_stack(self):
-        """
-        Scenario 1: Simple Tool Flow (Address Explorer)
-        Cancelling a scan should return to the previous screen (ToolsMenuView).
-        """
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
             FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
-            # Simulate the user cancelling the scan (ScanScreen returns False on KEY_LEFT/RIGHT)
             FlowStep(scan_views.ScanAddressView, screen_return_value=False),
-            # We expect to go back to the previous screen (ToolsMenuView)
             FlowStep(tools_views.ToolsMenuView),
         ])
 
     def test_scan_view_cancellation_clears_flow_state(self):
-        """
-        Scenario 2: State-Dependent Flow (Sign Message)
-        Cancelling the scan must CLEAR the 'resume_main_flow' state.
-        If it doesn't, returning to SeedOptionsView will cause it to infinite-loop 
-        forward into the next step with missing data, causing a crash.
-        """
-        # Enable message signing
         self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
         
-        # Load a dummy seed so we can access SeedOptions
         seed = Seed(mnemonic=["abandon"]*11 + ["about"])
         self.controller.storage.seeds.append(seed)
-        seed_num = 0
         fingerprint = seed.get_fingerprint()
 
         self.run_sequence(
             sequence=[
-                # 1. Start at Main Menu
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-                
-                # 2. Select the first seed (SeedsMenuView)
                 FlowStep(seed_views.SeedsMenuView, button_data_selection=ButtonOption(fingerprint, SeedSignerIconConstants.FINGERPRINT)),
-                
-                # 3. In SeedOptions, select "Sign Message"
                 FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
-                
-                # 4. This enters ScanView. We simulate a cancel (False return).
-                # Crucially, BEFORE we leave this view, the Controller's flow state must be cleared.
                 FlowStep(scan_views.ScanView, screen_return_value=False),
-                
-                # 5. We should land back at SeedOptionsView.
-                # If flow state wasn't cleared, this view would try to auto-forward us 
-                # to the next step (SeedSignMessageConfirmMessageView), failing the test.
                 FlowStep(seed_views.SeedOptionsView),
             ]
         )
         
-        # Verify the flow state was actually cleared
         assert self.controller.resume_main_flow is None

--- a/tests/test_issue_775.py
+++ b/tests/test_issue_775.py
@@ -1,0 +1,65 @@
+from base import FlowTest, FlowStep
+from seedsigner.views.view import MainMenuView, BackStackView
+from seedsigner.views import scan_views, tools_views, seed_views
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+from seedsigner.controller import Controller
+from seedsigner.models.seed import Seed
+from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.gui.components import SeedSignerIconConstants
+
+class TestIssue775(FlowTest):
+    def test_scan_view_cancellation_returns_to_back_stack(self):
+        """
+        Scenario 1: Simple Tool Flow (Address Explorer)
+        Cancelling a scan should return to the previous screen (ToolsMenuView).
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            # Simulate the user cancelling the scan (ScanScreen returns False on KEY_LEFT/RIGHT)
+            FlowStep(scan_views.ScanAddressView, screen_return_value=False),
+            # We expect to go back to the previous screen (ToolsMenuView)
+            FlowStep(tools_views.ToolsMenuView),
+        ])
+
+    def test_scan_view_cancellation_clears_flow_state(self):
+        """
+        Scenario 2: State-Dependent Flow (Sign Message)
+        Cancelling the scan must CLEAR the 'resume_main_flow' state.
+        If it doesn't, returning to SeedOptionsView will cause it to infinite-loop 
+        forward into the next step with missing data, causing a crash.
+        """
+        # Enable message signing
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+        
+        # Load a dummy seed so we can access SeedOptions
+        seed = Seed(mnemonic=["abandon"]*11 + ["about"])
+        self.controller.storage.seeds.append(seed)
+        seed_num = 0
+        fingerprint = seed.get_fingerprint()
+
+        self.run_sequence(
+            sequence=[
+                # 1. Start at Main Menu
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                
+                # 2. Select the first seed (SeedsMenuView)
+                FlowStep(seed_views.SeedsMenuView, button_data_selection=ButtonOption(fingerprint, SeedSignerIconConstants.FINGERPRINT)),
+                
+                # 3. In SeedOptions, select "Sign Message"
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+                
+                # 4. This enters ScanView. We simulate a cancel (False return).
+                # Crucially, BEFORE we leave this view, the Controller's flow state must be cleared.
+                FlowStep(scan_views.ScanView, screen_return_value=False),
+                
+                # 5. We should land back at SeedOptionsView.
+                # If flow state wasn't cleared, this view would try to auto-forward us 
+                # to the next step (SeedSignMessageConfirmMessageView), failing the test.
+                FlowStep(seed_views.SeedOptionsView),
+            ]
+        )
+        
+        # Verify the flow state was actually cleared
+        assert self.controller.resume_main_flow is None


### PR DESCRIPTION
This PR addresses issue #775, and fixes inconsistent back navigation when cancelling a scan operation.

Previously, cancelling a scan (e.g., in "Sign Message" or "Address Explorer") would incorrectly return the user to the Main Menu instead of the previous screen. Additionally, in state-dependent flows like "Sign Message," this could cause a crash or infinite loop because the `resume_main_flow` state was not cleared upon cancellation.

This PR updates `ScanView` to:
1.  Explicitly return `Destination(BackStackView)` when a scan is cancelled.
2.  Clear `self.controller.resume_main_flow` upon cancellation to prevent state conflict errors when returning to the previous view.

_Screenshots omitted as this is a logic/flow fix with no visual UI changes._

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [[Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)]
- [ ] [[SeedSigner OS](https://github.com/SeedSigner/seedsigner-os)] on a Pi0/Pi0W board
- [x] Simulated via GitHub Codespaces / Test Suite