### PR TITLE
style: fix typos in source code comments and strings

### DIFF
--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class HardwareButtons(Singleton):
     if GPIO.RPI_INFO['P1_REVISION'] == 3: #This indicates that we have revision 3 GPIO
-        logger.info("Detected 40pin GPIO (Rasbperry Pi 2 and above)")
+        logger.info("Detected 40pin GPIO (Raspberry Pi 2 and above)")
         KEY_UP_PIN = 31
         KEY_DOWN_PIN = 35
         KEY_LEFT_PIN = 29
@@ -22,7 +22,7 @@ class HardwareButtons(Singleton):
         KEY3_PIN = 36
 
     else:
-        logger.info("Assuming 26 Pin GPIO (Raspberry P1 1)")
+        logger.info("Assuming 26 Pin GPIO (Raspberry Pi 1)")
         KEY_UP_PIN = 5
         KEY_DOWN_PIN = 11
         KEY_LEFT_PIN = 3

--- a/src/seedsigner/hardware/displays/ST7789.py
+++ b/src/seedsigner/hardware/displays/ST7789.py
@@ -41,7 +41,7 @@ class ST7789(object):
         self._spi.writebytes([val])
 
     def init(self):
-        """Initialize dispaly"""    
+        """Initialize display"""    
         self.reset()
 
         self.command(0x36)

--- a/src/seedsigner/hardware/pivideostream.py
+++ b/src/seedsigner/hardware/pivideostream.py
@@ -42,7 +42,7 @@ class PiVideoStream:
 			self.rawCapture.truncate(0)
 
 			# if the thread indicator variable is set, stop the thread
-			# and resource camera resources
+			# and release camera resources
 			if self.should_stop:
 				logger.info("PiVideoStream: closing everything")
 				self.stream.close()

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -26,7 +26,7 @@ class PSBTSelectSeedView(View):
 
         if self.controller.psbt_seed:
              if PSBTParser.has_matching_input_fingerprint(psbt=self.controller.psbt, seed=self.controller.psbt_seed, network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)):
-                 # skip the seed prompt if a seed was previous selected and has matching input fingerprint
+                 # skip the seed prompt if a seed was previously selected and has matching input fingerprint
                  return Destination(PSBTOverviewView)
 
         seeds = self.controller.storage.seeds


### PR DESCRIPTION
## Description

Fixed obvious spelling errors in source code comments and string literals to improve readability. No program logic or variable names were changed.

Specific fixes:
- `buttons.py`: "Rasbperry" -> "Raspberry"
- `ST7789.py`: "dispaly" -> "display"
- `psbt_views.py`: "previous selected" -> "previously selected"
- `pivideostream.py`: "resource camera" -> "release camera"

_Screenshots omitted as these are non-visual text changes._

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [x] Documentation
- [ ] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Other (Static Analysis)