### PR TITLE
[Performance] Scrolling text can cause delays moving to next screen

### DIFF
--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -713,8 +713,8 @@ class TextArea(BaseComponent):
 
                 # Only render an update if we're going to move at least 1px
                 if abs(scroll_position_increment) > 0:
-                    # max: Ensure we don't scroll past left edge (0)
-                    # min: Ensure we don't scroll past right edge (max_scroll)
+                    # max: Don't over-scroll when returning to the left edge (0)
+                    # min: Don't over-scroll when revealing the right edge (max_scroll)
                     self.horizontal_scroll_position = max(
                         0,
                         min(self.horizontal_scroll_position + scroll_position_increment, max_scroll)
@@ -733,13 +733,14 @@ class TextArea(BaseComponent):
 
                     last_render_time = next_render_time
 
-                    # No need to CPU limit when running in its own thread?
-                    time.sleep(0.02)
                 else:
-                    # Wait to accumulate more time before scrolling
+                    # Wait to accumulate more time so we can scroll at least 1px
                     pass
 
+                # Free up the processor for a bit each loop
+                time.sleep(0.02)
 
+ 
     def render(self):
         """
             Even if we need to animate for scrolling, all instances should explicitly render


### PR DESCRIPTION
## The Problem
First, against current `dev` follow these steps to reproduce an intermittent delay:
* Create a new seed via image entropy.
* Joystick RIGHT to accept the final image.
* On the "Mnemonic Length?" screen select 12 or 24 words. NOTE how long it takes from this click until the loading spinner appears. The delay can be anywhere from quick-ish to up to 2s.

It's so annoying because the whole point of the spinner is to fill in the wait time while the image entropy code performs all of its hashing. And yet we're still sitting here for up to 2s wondering if the device is frozen.

 ---

### What's happening
Turns out the culprit is the `ScrollableTextLine` in the TopNav. It uses its own thread to manage the scrollable title text.

`BaseScreen.display()` (in screens.py) waits for all child threads to signal via `Thread.is_alive()` that they have shut themselves down. This wait was a fix for the screenshot renderer which was getting random rendering artifacts due to not-yet-dead child threads trying to render when the generator had already moved on to the next screenshot.

ALL of the delay in displaying the loading spinner is due to this `Thread.is_alive()` wait.

The culprit is here: https://github.com/SeedSigner/seedsigner/blob/dev/src/seedsigner/gui/components.py#L651-L669

The `time.sleep(self.begin_hold_secs)` and `time.sleep(self.end_hold_secs)` pause the scrolling animation at the start and end of the scrollable text. The begin/end pauses are 2.0s and 1.0s, respectively.

In the case of this "Mnemonic Length?" screen, the TopNav text ends up being too big by ONE PIXEL!! It's easy to miss, but if you stare at the title, it DOES scroll that 1px after its initial 2.0s wait. But obviously this title will spend most of its time in its `time.sleep()` at the beginning (2.0s) or at the end (1.0s) of its 1px scroll range.

SO... when the "Mnemonic Length?" screen exits, you're almost guaranteed to be in the middle of one of those two `time.sleep()` calls. So the `BaseScreen.display()` sits there and waits until the scrolling thread ends its sleep and finally sees that it's supposed to exit.

---

### The Fix, part 1
Eliminate those `time.sleep()` calls in the text scrolling thread. This PR refactors that area to use a time elapsed strategy to yield the same 2.0s and 1.0s pauses, but without the monolithic `time.sleep()` calls. Instead it keeps looping and just checks if it's time to start scrolling again.


### The Fix, part 2
Having the "Mnemonic Length?" title dancing back and forth 1px is pointless. So I added a `min_scrollable_diff` threshold (scrolling must now cover at least 2px, and even that might be too small to be worth it).

---

### Discussion
The second fix alone would have eliminated the delays when exiting the "Mnemonic Length?" screen (because the scrolling thread never would have been created since the text length wouldn't cross the new `min_scrollable_diff` threshold). In reality, this was just dumb bad luck that it ended up being 1px too wide for the TopNav. But it's also incredibly dumb GOOD luck. Because:

The first fix should have huge performance wins on potentially EVERY screen when other languages are loaded.

In fact, if you switch to German, it doesn't take long to find a title that has to scroll (e.g. in the Address Explorer when viewing your list of receive addrs). Watch the title scrolling back and forth. Just as it returns to its starting position, click any UX button. You'll see the effect of the 2.0s hold delay.

Interestingly, the Home screen "Settings" button also needs to scroll in German. But clicking it doesn't produce as noticeable a delay because those begin/end timings are set to 0.5s.

---

### Testing
Obviously repeating the steps that produce the delay should now feel basically instantaneous.

Test suite passes. Ran the screenshot generator for English and for German. Did not spot any rendering artifacts.

---

This pull request is categorized as a:
- [x] Other: Performance improvement

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
