### PR TITLE
[Bugfix] Multiselect settings must have a selection

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -159,10 +159,12 @@ class Settings(Singleton):
                 # Clean the incoming data, if necessary
                 if entry.type == SettingsConstants.TYPE__MULTISELECT:
                     if type(new_settings[entry.attr_name]) == str:
-                        # Break comma-separated SettingsQR input into List
-                        new_settings[entry.attr_name] = new_settings[entry.attr_name].split(",")
-                    elif new_settings[entry.attr_name] is None:
-                        # Multiselect cannot be None; load defaults to avoid issues
+                        # Break comma-separated multiselect options into List; avoid empty
+                        # values.
+                        new_settings[entry.attr_name] = [value for value in new_settings[entry.attr_name].split(",") if value.strip()]
+
+                    if not new_settings[entry.attr_name]:
+                        # Multiselect cannot be empty; load defaults to avoid issues
                         new_settings[entry.attr_name] = entry.default_value
 
         for key, value in new_settings.items():

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -161,6 +161,9 @@ class Settings(Singleton):
                     if type(new_settings[entry.attr_name]) == str:
                         # Break comma-separated SettingsQR input into List
                         new_settings[entry.attr_name] = new_settings[entry.attr_name].split(",")
+                    elif new_settings[entry.attr_name] is None:
+                        # Multiselect cannot be None; load defaults to avoid issues
+                        new_settings[entry.attr_name] = entry.default_value
 
         for key, value in new_settings.items():
             self.set_value(key, value)

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -81,6 +81,10 @@ class Settings(Singleton):
         for entry in data.split()[split_index:]:
             abbreviated_name, value = entry.split("=")
 
+            # Empty values ("some_setting= other_setting=E") are invalid
+            if value == "":
+                raise InvalidSettingsQRData(f"{abbreviated_name} cannot be empty")
+
             # Parse multi-value settings; integer-ize where needed
             if "," in value:
                 values_updated = []
@@ -103,6 +107,7 @@ class Settings(Singleton):
                 values = [value]
             else:
                 values = value
+
             for v in values:
                 if v not in [opt[0] for opt in settings_entry.selection_options]:
                     if settings_entry.attr_name == SettingsConstants.SETTING__PERSISTENT_SETTINGS and v == SettingsConstants.OPTION__ENABLED:

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -427,6 +427,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(settings_views.DonateView),
                 ScreenshotConfig(settings_views.SettingsIngestSettingsQRView, dict(data=settingsqr_data_persistent), screenshot_name="SettingsIngestSettingsQRView_persistent"),
                 ScreenshotConfig(settings_views.SettingsIngestSettingsQRView, dict(data=settingsqr_data_not_persistent), screenshot_name="SettingsIngestSettingsQRView_not_persistent"),
+                ScreenshotConfig(settings_views.SettingsSelectionRequiredWarningView, dict(attr_name=SettingsConstants.SETTING__SCRIPT_TYPES)),
             ],
             "Misc Error Views": [
                 ScreenshotConfig(NotYetImplementedView),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -108,6 +108,14 @@ class TestSettings(BaseTest):
         assert "passphrase" in str(e.value)
 
 
+    def test_settingsqr_fails_empty_values(self):
+        """ SettingsQR parser should fail if a setting is empty """
+        settingsqr_data = "settings::v1 persistent=D sigs= camera=180"
+        with pytest.raises(InvalidSettingsQRData) as e:
+            Settings.parse_settingsqr(settingsqr_data)
+        assert "sigs" in str(e.value)
+
+
     def test_settingsqr_parses_line_break_separators(self):
         """ SettingsQR parser should read line breaks as acceptable separators """
         settingsqr_data = "settings::v1\nname=Foo\nsigs=ss,ms\nscripts=nat,nes,tr\npassphrase=E\n"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from base import BaseTest
 from seedsigner.models.settings import InvalidSettingsQRData, Settings
-from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition, SettingsEntry
+from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 
 
 
@@ -52,14 +52,14 @@ class TestSettings(BaseTest):
         settings_json = None
         with open(Settings.SETTINGS_FILENAME) as settings_file:
             settings_json = json.loads(settings_file.read())
-        
+
         # Now wipe out the Settings singleton
         BaseTest.reset_settings()
 
         # This also deletes settings.json, so recreate it
         with open(Settings.SETTINGS_FILENAME, "w") as settings_file:
             settings_file.write(json.dumps(settings_json))
-        
+
         # Now instantiate the Settings singleton again; it should load from disk
         settings = Settings.get_instance()
         assert settings.get_value(SettingsConstants.SETTING__QR_DENSITY) == SettingsConstants.DENSITY__HIGH
@@ -72,9 +72,7 @@ class TestSettings(BaseTest):
         settings_json[settings_entry.attr_name] = None
         with open(Settings.SETTINGS_FILENAME, "w") as settings_file:
             settings_file.write(json.dumps(settings_json))
-        
-        print(json.dumps(settings_json, indent=4))
-        
+
         # Re-instantiate and verify that the multiselect setting has loaded its defaults
         settings = Settings.get_instance()
         sig_types = settings.get_value(settings_entry.attr_name)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -87,7 +87,7 @@ class TestSettings(BaseTest):
             assert cur_setting_value == SettingsDefinition.get_settings_entry(attr_name).default_value
 
         # Alter the settings to test against various empty values
-        for empty_value in ["", ",", None]:
+        for empty_value in ["", ",", [], None]:
             settings_dict[SettingsConstants.SETTING__SIG_TYPES] = empty_value
             settings.update(settings_dict)
             _verify_defaults_loaded(SettingsConstants.SETTING__SIG_TYPES)


### PR DESCRIPTION
## Description

Bug found by @Chaitanya-Keyal in discussion [here](https://github.com/SeedSigner/seedsigner/pull/844#discussion_r2617419466).

Users can de-select all options in a multiselect, leaving their configuration in an invalid state. This can ultimately cause an exception during the xpub export flow.

Current multiselect settings:
* Coordinators
* Sig types
* Script types

---

## Changes in this PR

### New UX flow: Enforce selecting at least one option

<img width="240" height="240" alt="SettingsSelectionRequiredWarningView" src="https://github.com/user-attachments/assets/dc61db7f-ff15-492f-8ec2-528b2e54994b" />

If users try to exit the multiselect options Setting screen with no options selected, they are presented with this warning screen and then re-routed back to the Setting screen. There is no way to escape this flow until at least one option is selected.

---

### Check when loading persistent Settings
If the persistent settings json has a multiselect with no options selected, the Setting's defaults are loaded instead. There's no good flow to notify the user of the issue: imagine the case where all three multiselects are invalid. The resulting additional flow logic to notify the user and have them fix each one would be a mess.

So instead we just ensure that the Views that depend on those multiselect Settings can function properly by initializing the defaults.

---

### Check when loading SettingsQR
We already have failure exceptions for invalid SettingsQRs so we add a new one for multiselects with no options selected.

---

### Discussion
Currently it doesn't make sense to have a multiselect with no options selected. But if we ever need to relax this for some future Setting, we can add a bool to `SettingsDefinition` like `can_select_none` and adjust the logic in these 3 places accordingly.

---

### Misc notes
Various tests and flow tests either amended or created to verify each of the 3 new behaviors.

Adds screenshot shown above.

---

This pull request is categorized as a:
- [x] Bug fix

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] Yes

I have tested this PR on the following platforms/os:
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
