### PR TITLE
[Bugfix] Fix inadvertently persistent test artifacts

### DIFF
--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -61,7 +61,6 @@ class TestSeedFlows(FlowTest):
             the SeedOptionsView.
         """
         def test_with_mnemonic(mnemonic):
-            Settings.HOSTNAME = "not seedsigner-os"
             sequence = [
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
                 FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # When no seeds are loaded it auto-redirects to LoadSeedView
@@ -128,7 +127,6 @@ class TestSeedFlows(FlowTest):
             Most BIP-39 mnemonics should generate an error if entered as Electrum seeds.
         """
         def test_with_mnemonic(mnemonic: list[str], custom_extension: str = None, expects_electrum_seed_is_valid: bool = True):
-            Settings.HOSTNAME = "not seedsigner-os"
             settings = Settings.get_instance()
             settings.set_value(SettingsConstants.SETTING__ELECTRUM_SEEDS, SettingsConstants.OPTION__ENABLED)
 

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -30,13 +30,13 @@ class TestViewFlows(FlowTest):
         """
         Basic flow from MainMenuView to PowerOffView
         """
-        Settings.HOSTNAME = Settings.SEEDSIGNER_OS
-        self.run_sequence([
-            FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
-            FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
-            FlowStep(PowerOffView),  # returns BackStackView
-            FlowStep(PowerOptionsView),
-        ])
+        with patch.object(Settings, 'HOSTNAME', return_value=Settings.SEEDSIGNER_OS):
+            self.run_sequence([
+                FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
+                FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
+                FlowStep(PowerOffView),  # returns BackStackView
+                FlowStep(PowerOptionsView),
+            ])
 
 
     def test_not_yet_implemented_flow(self):

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -30,13 +30,12 @@ class TestViewFlows(FlowTest):
         """
         Basic flow from MainMenuView to PowerOffView
         """
-        with patch.object(Settings, 'HOSTNAME', return_value=Settings.SEEDSIGNER_OS):
-            self.run_sequence([
-                FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
-                FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
-                FlowStep(PowerOffView),  # returns BackStackView
-                FlowStep(PowerOptionsView),
-            ])
+        self.run_sequence([
+            FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
+            FlowStep(PowerOptionsView, button_data_selection=PowerOptionsView.POWER_OFF),
+            FlowStep(PowerOffView),  # returns BackStackView
+            FlowStep(PowerOptionsView),
+        ])
 
 
     def test_not_yet_implemented_flow(self):

--- a/tests/test_settings_definition.py
+++ b/tests/test_settings_definition.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import Mock
+from unittest.mock import patch
 
 from base import BaseTest
 from seedsigner.models.settings_definition import SettingsConstants
@@ -31,8 +31,7 @@ class TestSettingsDefinition(BaseTest):
         # We're going to mock the `root` results to include the absent language code's .mo file
         mocked_results = [(os.path.join(root, "en", "LC_MESSAGES"), [], ["messages.po", "messages.mo"])]
         mocked_results.append((os.path.join(root, absent_language_code, "LC_MESSAGES"), [], ["messages.po", "messages.mo"]))
-        os.walk = Mock(return_value=mocked_results)
-
-        # Recheck w/our mocked dir listing:
-        detected_languages = [lang_tuple[0] for lang_tuple in SettingsConstants.get_detected_languages()]
-        assert absent_language_code in detected_languages
+        with patch("os.walk", return_value=mocked_results):
+            # Recheck w/our mocked dir listing:
+            detected_languages = [lang_tuple[0] for lang_tuple in SettingsConstants.get_detected_languages()]
+            assert absent_language_code in detected_languages


### PR DESCRIPTION
## Description

* `test_flows_seed.py` had two instances where `Settings.HOSTNAME` was being overridden in a way that affected the remainder of the test suite. Neither case was even necessary for the test and so was removed.

* `test_flows_view.py` another unnecessary`Settings.HOSTNAME` override.

* `test_settings_definition.py`: `os.walk` was unintentionally being permanently mocked out for the remainder of the `pytest` run, creating confusing side effects in an unrelated test. Changed to a `patch`.

---

This pull request is categorized as a:
- [x] Bug fix

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] Other: Only applies when running the test suite in local dev or CI
