### PR TITLE
Fix back navigation trap in seed backup verification "Review seed words"

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1365,6 +1365,7 @@ class SeedWordsBackupTestMistakeView(View):
             return Destination(
                 SeedWordsView,
                 view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                clear_history=True,
             )
 
         elif button_data[selected_menu_num] == self.RETRY:


### PR DESCRIPTION
## Summary
- Fixes navigation trap where users selecting "Review seed words" after a wrong word selection couldn't exit the verification flow using the back button
- Adds `clear_history=True` to the Destination when navigating to SeedWordsView from the error screen

Fixes #XXX (replace with issue number once created)

## Problem
When a user made a mistake during seed backup verification and chose "Review seed words", the back button would return them to the error screen instead of exiting. This created an infinite loop with no escape except remembering the correct seed word.

## Solution
The fix adds `clear_history=True` to the `Destination` in `SeedWordsBackupTestMistakeView` when the user selects "Review seed words". This clears the navigation back stack so that pressing back from the seed words view properly exits the verification flow rather than returning to the error screen.

## Test plan
- [ ] Load a seed and go to "Backup Seed" → "Verify backup"
- [ ] Intentionally select the wrong word
- [ ] Select "Review seed words" from the error screen
- [ ] Press the back button
- [ ] Verify you exit the verification flow (not returned to error screen)
- [ ] Test with both normal seeds and BIP-85 child seeds
