### PR TITLE
[Cleanup] Remove unnecessary `CameraConnectionError` error message

### DIFF
--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -9,9 +9,7 @@ from seedsigner.models.singleton import Singleton
 
 
 class CameraConnectionError(Exception):
-    def __init__(self, *args, **kwargs):
-        message = _("Camera error. Check camera connections.")
-        super().__init__(message)
+    pass
 
 
 


### PR DESCRIPTION
## Description

When `CameraConnectionError` is raised, the exception handler routes users to the new `CameraConnectionErrorView`. That View then has its own text to guide the user to resolve the issue.

The error message defined in `CameraConnectionError` is never presented to the user and does not provide any useful debugging into for devs.

Worse, the unnecessary error message is marked for translation. Obviously there's no need to create additional translation burden on a string that is never presented to the user.

---

This pull request is categorized as a:
- [x] Other: cleanup

## Checklist
- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
- [x] N/A