### PR TITLE
Add Silent Payments (BIP-352/375) send support

### DIFF
--- a/PR_DESCRIPTION.txt
+++ b/PR_DESCRIPTION.txt
@@ -1,0 +1,43 @@
+Add Waveshare 2.8" DPI LCD touchscreen support
+
+## Description
+
+Adds support for the Waveshare 2.8" DPI LCD (480x640) with capacitive touchscreen, addressing the bounty in issue #150.
+
+**Key features:**
+- Direct framebuffer rendering via PIL/Pillow + mmap (no windowing/mirroring)
+- Pure Python touch input reading raw `/dev/input/` events (no C extensions, no external libs)
+- 240x240 UI scaled 2x to 480x480, with 480x160 touch bar below
+- Auto-detection: existing 1.3" SPI HAT continues to work unchanged
+- Touch bar adapts to context (navigation vs keyboard modes)
+
+**Demo videos:** See issue #150 comment
+
+**Hardware:** Waveshare 2.8" DPI LCD (~$25-45)
+https://www.waveshare.com/2.8inch-DPI-LCD.htm
+
+Closes #150
+
+This pull request is categorized as a:
+
+- [x] New feature
+- [ ] Bug fix
+- [ ] Code refactor
+- [ ] Documentation
+- [ ] Other
+
+## Checklist
+
+- [x] I've run `pytest` and made sure all unit tests pass before submitting the PR
+
+If you modified or added functionality/workflow, did you add new unit tests?
+
+- [ ] No, I'm a fool
+- [x] Yes
+- [ ] N/A
+
+I have tested this PR on the following platforms/os:
+
+- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
+- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
+- [x] Other (Pi Zero W with Raspberry Pi OS Buster)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you have specific questions about the project, our [Telegram Group](https://t
   * Support for user-defined custom derivation paths.
   * In-depth transaction (aka PSBT) review flow before signing.
   * Verify the PSBT's single sig or multisig change outputs or self-transfer outputs.
+  * [Silent Payments (BIP-352)](docs/silent_payments.md) send verification with BIP-375/BIP-374 support.
   * Mainnet, testnet, and regtest.
 
 * Additional utilities:

--- a/docs/qr_formats.md
+++ b/docs/qr_formats.md
@@ -13,6 +13,9 @@ Animated QR Formats:
 Static QR Formats:
 - PSBT
     - Base64 (if the PSBT byte size is too large, SS may have trouble scanning)
+- Silent Payment Address
+    - [BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) Silent Payment addresses (`sp1...` mainnet, `tsp1...` testnet)
+    - Used for verifying Silent Payment transaction outputs. See [Silent Payments Guide](silent_payments.md).
 - Seed
     - [SeedSigner SeedQR](seed_qr/README.md) format
         - A 48 or 96 length string of numbers representing a BIP-39 wordlist (all wordlist languages supported). The numeric sequence is a concatenation of four-digit, zero-padded segments. Each four-digit segment represents a BIP-39 word expressed by a zero-indexed position in the wordlist. For example, "0000" is "abandon" in the English BIP-39 wordlist.

--- a/docs/silent_payments.md
+++ b/docs/silent_payments.md
@@ -122,6 +122,14 @@ The "scan SP address first" workflow remains valuable as:
 - Works with any SP-capable wallet today
 - An extra layer of verification even with BIP-375 support
 
+**Note on PSBTv2:** BIP-375 specifies these fields for PSBTv2 (BIP-370). SeedSigner uses the embit library which stores BIP-375 fields in its `unknown` dict regardless of PSBT version. This means:
+
+- PSBTv0 with BIP-375 fields added: **Supported**
+- PSBTv2 with embedded transaction: **Supported** (embit parses v2)
+- Pure PSBTv2 without `PSBT_GLOBAL_UNSIGNED_TX`: May have limited support depending on embit version
+
+Most coordinator wallets currently export v0-compatible PSBTs, so this should not be an issue in practice.
+
 ## Technical Reference
 
 For implementation details, see:

--- a/docs/silent_payments.md
+++ b/docs/silent_payments.md
@@ -130,6 +130,20 @@ The "scan SP address first" workflow remains valuable as:
 
 Most coordinator wallets currently export v0-compatible PSBTs, so this should not be an issue in practice.
 
+## Testing BIP-375 Verification
+
+To test SeedSigner's BIP-375 verification without a full wallet setup, use the **BIP-375 Test PSBT Generator**:
+
+[github.com/FreeOnlineUser/bip375-test-tools](https://github.com/FreeOnlineUser/bip375-test-tools)
+
+This tool generates valid BIP-375 PSBTs with fake inputs for testing purposes. It includes:
+
+- GUI with side-by-side QR codes for SP address and PSBT
+- Proper DLEQ proof generation per BIP-374
+- Educational notes explaining Silent Payment behavior
+
+**Note:** Test PSBTs reference non-existent inputs and cannot be broadcast to the network.
+
 ## Technical Reference
 
 For implementation details, see:

--- a/docs/silent_payments.md
+++ b/docs/silent_payments.md
@@ -96,6 +96,36 @@ Silent Payment-capable coordinator wallets that work with SeedSigner:
 - Sparrow Wallet (with SP support)
 - Any wallet that exports PSBTs with SP-derived Taproot outputs
 
+## BIP-375 Support (Automatic Verification)
+
+SeedSigner now supports [BIP-375](https://github.com/bitcoin/bips/blob/master/bip-0375.mediawiki), which embeds SP information directly in the PSBT. When a coordinator wallet includes BIP-375 fields, SeedSigner automatically verifies the SP output using [DLEQ proofs](https://github.com/bitcoin/bips/blob/master/bip-0374.mediawiki) - no address scanning required.
+
+**Verification priority:**
+
+1. PSBT contains BIP-375 SP fields → Verify via DLEQ proof (automatic, no scanning needed)
+2. No BIP-375 fields, but user scanned SP address → Verify via re-derivation
+3. Neither → Display `bc1p...` only (no SP verification possible)
+
+**BIP-375 PSBT Fields Supported:**
+
+| Field                              | Type       | Description                         |
+| ---------------------------------- | ---------- | ----------------------------------- |
+| `PSBT_OUT_SP_V0_INFO` (0x09)       | Per-output | Contains B_scan and B_spend keys    |
+| `PSBT_GLOBAL_SP_ECDH_SHARE` (0x07) | Global     | ECDH shared point for verification  |
+| `PSBT_GLOBAL_SP_DLEQ` (0x08)       | Global     | 64-byte DLEQ proof                  |
+| `PSBT_IN_SP_ECDH_SHARE` (0x1d)     | Per-input  | Per-input ECDH share (future)       |
+| `PSBT_IN_SP_DLEQ` (0x1e)           | Per-input  | Per-input DLEQ proof (future)       |
+
+The "scan SP address first" workflow remains valuable as:
+
+- A fallback for coordinators that don't include BIP-375 fields
+- Works with any SP-capable wallet today
+- An extra layer of verification even with BIP-375 support
+
 ## Technical Reference
 
-For implementation details, see [BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki).
+For implementation details, see:
+
+- [BIP-352: Silent Payments](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)
+- [BIP-375: Sending Silent Payments with PSBTs](https://github.com/bitcoin/bips/blob/master/bip-0375.mediawiki)
+- [BIP-374: DLEQ Proofs](https://github.com/bitcoin/bips/blob/master/bip-0374.mediawiki)

--- a/docs/silent_payments.md
+++ b/docs/silent_payments.md
@@ -1,0 +1,101 @@
+# Silent Payments (BIP-352)
+
+SeedSigner supports verifying Silent Payment transactions. This guide explains what Silent Payments are, how they work with SeedSigner, and how to use the feature.
+
+## What are Silent Payments?
+
+Silent Payments allow you to receive Bitcoin without revealing a reusable address on-chain. Instead of giving someone a static `bc1q...` address (which links all payments together), you share a Silent Payment address (`sp1...`) that generates a unique, unlinkable output for each transaction.
+
+**Key benefit**: Privacy - observers cannot link multiple payments to the same recipient.
+
+## How It Works Without SeedSigner Verification
+
+Your wallet software (BlueWallet, Sparrow, etc.) handles Silent Payments:
+
+1. You enter the recipient's `sp1...` address
+2. Wallet derives a unique `bc1p...` Taproot output address
+3. Wallet builds the transaction (PSBT)
+4. You scan the PSBT into SeedSigner
+5. SeedSigner shows: **"Sending 0.01 BTC to bc1p7x9y..."**
+6. You approve and sign
+
+**The problem**: You see a random-looking `bc1p...` address with no way to verify it actually corresponds to the `sp1...` address you intended to pay.
+
+## The Risk
+
+If your wallet software is:
+- **Buggy** - it might miscalculate the output address
+- **Compromised** - malware could substitute a different address
+- **MITM attacked** - the PSBT could be modified in transit
+
+You would unknowingly sign a transaction sending funds to the wrong address.
+
+## How SeedSigner Verification Helps
+
+With SeedSigner's Silent Payment support, you can verify the wallet did the math correctly:
+
+1. **Scan the SP address first** - Point your SeedSigner at the `sp1...` QR code
+2. SeedSigner confirms: "Silent Payment Address - Mainnet"
+3. **Scan the PSBT** from your wallet
+4. SeedSigner independently calculates what the output should be
+5. SeedSigner verifies the PSBT output matches
+6. SeedSigner shows: **"Sending 0.01 BTC to sp1qq..."** with the original address
+7. You approve with confidence
+
+## Step-by-Step Usage
+
+### 1. Prepare the SP Address QR
+Display or print the recipient's `sp1...` address as a QR code.
+
+### 2. Scan the SP Address
+- On SeedSigner: **Scan** (from main menu or with a seed loaded)
+- Point camera at the SP address QR
+- Confirm the address and network shown
+
+### 3. Build the Transaction
+- In your wallet (BlueWallet, Sparrow, etc.), create a transaction to the SP address
+- Export as PSBT (QR code format)
+
+### 4. Scan and Sign the PSBT
+- Scan the PSBT QR into SeedSigner
+- Review the transaction details
+- Verify the SP address matches your intended recipient
+- Approve and sign
+
+### 5. Broadcast
+- Scan the signed PSBT back into your wallet
+- Broadcast to the network
+
+## Why Can't SeedSigner Generate SP Addresses?
+
+Unlike regular Bitcoin addresses, Silent Payment outputs are **transaction-specific**. The derived `bc1p...` address depends on:
+
+1. Which UTXOs (coins) you're spending
+2. The specific transaction inputs (txid:vout)
+
+This means:
+- Every transaction to the same `sp1...` produces a **different** `bc1p...` output
+- You need to know which coins you're spending before deriving the address
+- Only a wallet with UTXO knowledge can create the transaction
+
+**SeedSigner is stateless by design** - it holds your keys but has no blockchain data or UTXO information. Therefore:
+- Your wallet builds the transaction and derives the SP output
+- SeedSigner verifies the derivation is correct and signs
+
+## Supported Address Formats
+
+| Format | Network | Example |
+|--------|---------|---------|
+| `sp1...` | Mainnet | `sp1qqgste7k9hx0qftg6qmwlkqtwuy6...` |
+| `tsp1...` | Testnet | `tsp1qqgste7k9hx0qftg6qmwlkqtwuy6...` |
+
+## Compatible Wallets
+
+Silent Payment-capable coordinator wallets that work with SeedSigner:
+- BlueWallet (with SP support)
+- Sparrow Wallet (with SP support)
+- Any wallet that exports PSBTs with SP-derived Taproot outputs
+
+## Technical Reference
+
+For implementation details, see [BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki).

--- a/docs/silent_payments.md
+++ b/docs/silent_payments.md
@@ -139,8 +139,11 @@ To test SeedSigner's BIP-375 verification without a full wallet setup, use the *
 This tool generates valid BIP-375 PSBTs with fake inputs for testing purposes. It includes:
 
 - GUI with side-by-side QR codes for SP address and PSBT
+- Seed QR export for loading test sender keys into SeedSigner
+- Animated UR QR codes for easy PSBT scanning
+- Camera scanning to verify signed PSBTs returned from SeedSigner
 - Proper DLEQ proof generation per BIP-374
-- Educational notes explaining Silent Payment behavior
+- Full end-to-end signing flow testing
 
 **Note:** Test PSBTs reference non-existent inputs and cannot be broadcast to the network.
 

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -123,6 +123,9 @@ class Controller(Singleton):
     address_explorer_data: dict = None
 
     sign_message_data: dict = None
+
+    # BIP-352 Silent Payments: temporarily store SP address data until PSBT is scanned
+    pending_sp_address: dict = None
     # TODO: end refactor section
 
     # Destination placeholder for when we need to jump out to a side flow but intend to
@@ -304,7 +307,7 @@ class Controller(Singleton):
                 if next_destination.View_cls == MainMenuView:
                     # Home always wipes the back_stack
                     self.clear_back_stack()
-                    
+
                     # Home always wipes the back_stack/state of temp vars
                     self.resume_main_flow = None
                     self.multisig_wallet_descriptor = None
@@ -313,6 +316,7 @@ class Controller(Singleton):
                     self.psbt = None
                     self.psbt_parser = None
                     self.psbt_seed = None
+                    self.pending_sp_address = None
                 
                 logger.info(f"\nback_stack: {self.back_stack}")
 

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -597,6 +597,7 @@ class PSBTMathScreen(ButtonListScreen):
 class PSBTAddressDetailsScreen(ButtonListScreen):
     address: str = None
     amount: int = 0
+    is_silent_payment: bool = False
 
     def __post_init__(self):
         # Customize defaults
@@ -611,11 +612,28 @@ class PSBTAddressDetailsScreen(ButtonListScreen):
         center_img = Image.new("RGB", (self.canvas_width, center_img_height), GUIConstants.BACKGROUND_COLOR)
         draw = ImageDraw.Draw(center_img)
 
+        current_y = int(GUIConstants.COMPONENT_PADDING/2)
+
+        # Show "Silent Payment" indicator if applicable
+        if self.is_silent_payment:
+            sp_label = TextArea(
+                image_draw=draw,
+                canvas=center_img,
+                text=_("Silent Payment Verified"),
+                font_name=GUIConstants.BODY_FONT_NAME,
+                font_size=GUIConstants.BODY_FONT_SIZE - 2,
+                font_color=GUIConstants.SUCCESS_COLOR,
+                is_text_centered=True,
+                screen_y=current_y,
+            )
+            sp_label.render()
+            current_y += sp_label.height + int(GUIConstants.COMPONENT_PADDING/2)
+
         btc_amount = BtcAmount(
             image_draw=draw,
             canvas=center_img,
             total_sats=self.amount,
-            screen_y=int(GUIConstants.COMPONENT_PADDING/2),
+            screen_y=current_y,
         )
 
         formatted_address = FormattedAddress(
@@ -623,7 +641,7 @@ class PSBTAddressDetailsScreen(ButtonListScreen):
             canvas=center_img,
             width=self.canvas_width - 2*GUIConstants.EDGE_PADDING,
             screen_x=GUIConstants.EDGE_PADDING,
-            screen_y=btc_amount.height + GUIConstants.COMPONENT_PADDING,
+            screen_y=btc_amount.height + btc_amount.screen_y + GUIConstants.COMPONENT_PADDING,
             font_size=24,
             address=self.address,
         )

--- a/src/seedsigner/helpers/silent_payments.py
+++ b/src/seedsigner/helpers/silent_payments.py
@@ -944,3 +944,48 @@ def has_bip375_sp_fields(psbt) -> bool:
                     return True
 
     return False
+
+
+# PSBTv2 Detection Constants
+PSBT_GLOBAL_VERSION = 0xFB  # BIP-370 PSBT version field
+
+
+def get_psbt_version(psbt) -> int:
+    """
+    Detect the PSBT version.
+
+    PSBTv0: No version field (default)
+    PSBTv2: Has PSBT_GLOBAL_VERSION (0xFB) field with value >= 2
+
+    Args:
+        psbt: PSBT object (embit)
+
+    Returns:
+        int: PSBT version (0 for v0/unknown, 2 for v2)
+    """
+    if not hasattr(psbt, 'unknown') or not psbt.unknown:
+        return 0
+
+    # Check for BIP-370 version field
+    version_key = bytes([PSBT_GLOBAL_VERSION])
+    if version_key in psbt.unknown:
+        version_value = psbt.unknown[version_key]
+        # Version is a 32-bit unsigned little-endian integer
+        if len(version_value) >= 4:
+            version = int.from_bytes(version_value[:4], 'little')
+            return version
+
+    return 0
+
+
+def is_psbt_v2(psbt) -> bool:
+    """
+    Check if PSBT is version 2 (BIP-370).
+
+    Args:
+        psbt: PSBT object (embit)
+
+    Returns:
+        True if this is a PSBTv2
+    """
+    return get_psbt_version(psbt) >= 2

--- a/src/seedsigner/helpers/silent_payments.py
+++ b/src/seedsigner/helpers/silent_payments.py
@@ -524,3 +524,423 @@ def full_to_xonly_pubkey(full: bytes) -> Tuple[bytes, int]:
 
     parity = 0 if full[0] == 0x02 else 1
     return full[1:], parity
+
+
+# =============================================================================
+# BIP-375 PSBT Field Constants
+# =============================================================================
+
+# Global PSBT fields (PSBTv2)
+PSBT_GLOBAL_SP_ECDH_SHARE = 0x07  # Key: 33-byte scan pubkey, Value: 33-byte ECDH share
+PSBT_GLOBAL_SP_DLEQ = 0x08        # Key: 33-byte scan pubkey, Value: 64-byte DLEQ proof
+
+# Per-input PSBT fields
+PSBT_IN_SP_ECDH_SHARE = 0x1d      # Key: 33-byte scan pubkey, Value: 33-byte ECDH share
+PSBT_IN_SP_DLEQ = 0x1e            # Key: 33-byte scan pubkey, Value: 64-byte DLEQ proof
+
+# Per-output PSBT fields
+PSBT_OUT_SP_V0_INFO = 0x09        # Key: none, Value: 66 bytes (33-byte scan + 33-byte spend)
+
+
+# =============================================================================
+# BIP-374 DLEQ Proof Verification
+# =============================================================================
+
+def verify_dleq_proof(
+    A: bytes,
+    B: bytes,
+    C: bytes,
+    proof: bytes,
+    G: bytes = None
+) -> bool:
+    """
+    Verify a BIP-374 DLEQ proof.
+
+    Verifies that the same scalar 'a' was used to compute:
+    - A = a * G (public key)
+    - C = a * B (ECDH shared point)
+
+    This proves the ECDH share was computed correctly without revealing 'a'.
+
+    Args:
+        A: 33-byte compressed public key (sum of input pubkeys, or single input pubkey)
+        B: 33-byte compressed public key (recipient's B_scan)
+        C: 33-byte compressed ECDH share point
+        proof: 64-byte DLEQ proof (32-byte challenge e || 32-byte response s)
+        G: Optional generator point (uses secp256k1 generator if None)
+
+    Returns:
+        True if proof is valid, False otherwise
+    """
+    try:
+        # Parse proof components
+        if len(proof) != 64:
+            logger.debug(f"DLEQ proof wrong length: {len(proof)}")
+            return False
+
+        e = int.from_bytes(proof[:32], 'big')
+        s = int.from_bytes(proof[32:], 'big')
+
+        n = SECP256K1_ORDER
+
+        # Reject if s >= curve order
+        if s >= n:
+            logger.debug("DLEQ proof: s >= curve order")
+            return False
+
+        # Parse the input points
+        A_parsed = secp256k1.ec_pubkey_parse(A)
+        B_parsed = secp256k1.ec_pubkey_parse(B)
+        C_parsed = secp256k1.ec_pubkey_parse(C)
+
+        # Get generator G
+        if G is None:
+            # Use secp256k1 generator - derive from privkey=1
+            G_point = ec.PrivateKey(b'\x00' * 31 + b'\x01').get_public_key().sec()
+            G_parsed = secp256k1.ec_pubkey_parse(G_point)
+        else:
+            G_parsed = secp256k1.ec_pubkey_parse(G)
+            G_point = G
+
+        # R1 = s*G - e*A
+        # First compute s*G
+        sG_parsed = secp256k1.ec_pubkey_parse(G_point)
+        s_bytes = s.to_bytes(32, 'big')
+        secp256k1.ec_pubkey_tweak_mul(sG_parsed, s_bytes)
+
+        # Compute e*A (need to negate for subtraction)
+        eA_parsed = secp256k1.ec_pubkey_parse(A)
+        e_bytes = e.to_bytes(32, 'big')
+        secp256k1.ec_pubkey_tweak_mul(eA_parsed, e_bytes)
+
+        # Negate e*A to get -e*A
+        secp256k1.ec_pubkey_negate(eA_parsed)
+
+        # R1 = s*G + (-e*A)
+        R1_parsed = secp256k1.ec_pubkey_combine(sG_parsed, eA_parsed)
+        R1 = secp256k1.ec_pubkey_serialize(R1_parsed)
+
+        # R2 = s*B - e*C
+        # First compute s*B
+        sB_parsed = secp256k1.ec_pubkey_parse(B)
+        secp256k1.ec_pubkey_tweak_mul(sB_parsed, s_bytes)
+
+        # Compute e*C
+        eC_parsed = secp256k1.ec_pubkey_parse(C)
+        secp256k1.ec_pubkey_tweak_mul(eC_parsed, e_bytes)
+
+        # Negate e*C
+        secp256k1.ec_pubkey_negate(eC_parsed)
+
+        # R2 = s*B + (-e*C)
+        R2_parsed = secp256k1.ec_pubkey_combine(sB_parsed, eC_parsed)
+        R2 = secp256k1.ec_pubkey_serialize(R2_parsed)
+
+        # Compute challenge hash
+        # e' = hash_BIP0374/challenge(A || B || C || G || R1 || R2)
+        challenge_data = A + B + C + G_point + R1 + R2
+        e_computed = tagged_hash("BIP0374/challenge", challenge_data)
+        e_computed_int = int.from_bytes(e_computed, 'big')
+
+        # Verify e == e'
+        if e != e_computed_int:
+            logger.debug(f"DLEQ proof: challenge mismatch")
+            return False
+
+        logger.info("DLEQ proof verified successfully")
+        return True
+
+    except Exception as ex:
+        logger.debug(f"DLEQ verification failed: {ex}")
+        return False
+
+
+# =============================================================================
+# BIP-375 PSBT Parsing
+# =============================================================================
+
+def extract_sp_info_from_output(output_scope) -> Optional[Tuple[bytes, bytes]]:
+    """
+    Extract Silent Payment info from PSBT output's unknown fields.
+
+    Looks for PSBT_OUT_SP_V0_INFO (0x09) field containing the
+    scan and spend public keys.
+
+    Args:
+        output_scope: PSBT OutputScope object
+
+    Returns:
+        Tuple of (B_scan, B_spend) if found, None otherwise
+    """
+    if not hasattr(output_scope, 'unknown') or not output_scope.unknown:
+        return None
+
+    # Key format: type byte (0x09) with no additional key data
+    for key, value in output_scope.unknown.items():
+        # Key is bytes, first byte is type
+        if len(key) >= 1 and key[0] == PSBT_OUT_SP_V0_INFO:
+            # Value should be 66 bytes: 33-byte scan key + 33-byte spend key
+            if len(value) == 66:
+                B_scan = bytes(value[:33])
+                B_spend = bytes(value[33:66])
+
+                # Validate pubkey prefixes
+                if B_scan[0] in (0x02, 0x03) and B_spend[0] in (0x02, 0x03):
+                    logger.debug(f"Found SP info in output: B_scan={B_scan[:4].hex()}...")
+                    return (B_scan, B_spend)
+
+    return None
+
+
+def extract_global_ecdh_share(psbt, B_scan: bytes) -> Optional[Tuple[bytes, bytes]]:
+    """
+    Extract global ECDH share and DLEQ proof for a given scan key.
+
+    Args:
+        psbt: PSBT object
+        B_scan: 33-byte scan public key to look for
+
+    Returns:
+        Tuple of (ecdh_share, dleq_proof) if found, None otherwise
+    """
+    if not hasattr(psbt, 'unknown') or not psbt.unknown:
+        return None
+
+    ecdh_share = None
+    dleq_proof = None
+
+    for key, value in psbt.unknown.items():
+        if len(key) < 1:
+            continue
+
+        key_type = key[0]
+        key_data = key[1:] if len(key) > 1 else b''
+
+        # Check for ECDH share with matching B_scan
+        if key_type == PSBT_GLOBAL_SP_ECDH_SHARE:
+            if key_data == B_scan and len(value) == 33:
+                ecdh_share = bytes(value)
+                logger.debug(f"Found global ECDH share: {ecdh_share[:4].hex()}...")
+
+        # Check for DLEQ proof with matching B_scan
+        elif key_type == PSBT_GLOBAL_SP_DLEQ:
+            if key_data == B_scan and len(value) == 64:
+                dleq_proof = bytes(value)
+                logger.debug(f"Found global DLEQ proof")
+
+    if ecdh_share and dleq_proof:
+        return (ecdh_share, dleq_proof)
+
+    return None
+
+
+def extract_input_ecdh_shares(psbt, B_scan: bytes) -> List[Tuple[int, bytes, bytes]]:
+    """
+    Extract per-input ECDH shares and DLEQ proofs for a given scan key.
+
+    Args:
+        psbt: PSBT object
+        B_scan: 33-byte scan public key to look for
+
+    Returns:
+        List of (input_index, ecdh_share, dleq_proof) tuples
+    """
+    result = []
+
+    for i, inp in enumerate(psbt.inputs):
+        if not hasattr(inp, 'unknown') or not inp.unknown:
+            continue
+
+        ecdh_share = None
+        dleq_proof = None
+
+        for key, value in inp.unknown.items():
+            if len(key) < 1:
+                continue
+
+            key_type = key[0]
+            key_data = key[1:] if len(key) > 1 else b''
+
+            if key_type == PSBT_IN_SP_ECDH_SHARE:
+                if key_data == B_scan and len(value) == 33:
+                    ecdh_share = bytes(value)
+
+            elif key_type == PSBT_IN_SP_DLEQ:
+                if key_data == B_scan and len(value) == 64:
+                    dleq_proof = bytes(value)
+
+        if ecdh_share and dleq_proof:
+            result.append((i, ecdh_share, dleq_proof))
+
+    return result
+
+
+def verify_sp_output_with_bip375(
+    psbt,
+    output_index: int,
+    B_scan: bytes,
+    B_spend: bytes,
+    seed_fingerprint: str = None
+) -> Optional[bytes]:
+    """
+    Verify a Silent Payment output using BIP-375 ECDH shares and DLEQ proofs.
+
+    This verifies that the coordinator correctly computed the SP output
+    by checking the DLEQ proof against the provided ECDH share.
+
+    Args:
+        psbt: PSBT object
+        output_index: Index of the output to verify
+        B_scan: 33-byte recipient scan public key
+        B_spend: 33-byte recipient spend public key
+        seed_fingerprint: Optional fingerprint to identify owned inputs
+
+    Returns:
+        Expected x-only output pubkey if verified, None if verification fails
+    """
+    from binascii import hexlify
+
+    n = SECP256K1_ORDER
+
+    # Try global ECDH share first
+    global_share = extract_global_ecdh_share(psbt, B_scan)
+
+    if global_share:
+        ecdh_share, dleq_proof = global_share
+
+        # Get sum of all eligible input pubkeys (A_n)
+        input_pubkeys = []
+        for inp in psbt.inputs:
+            if not is_eligible_input(inp, seed_fingerprint):
+                continue
+
+            # Get pubkey from derivation
+            if inp.taproot_bip32_derivations:
+                for pub, (leaf_hashes, der) in inp.taproot_bip32_derivations.items():
+                    pubkey = pub.sec()
+                    # For Taproot, use even-Y version
+                    if pubkey[0] == 0x03:
+                        parsed = secp256k1.ec_pubkey_parse(pubkey)
+                        negated = secp256k1.ec_pubkey_negate(parsed)
+                        pubkey = secp256k1.ec_pubkey_serialize(negated)
+                    input_pubkeys.append(pubkey)
+                    break
+            elif inp.bip32_derivations:
+                for pub, der in inp.bip32_derivations.items():
+                    input_pubkeys.append(pub.sec())
+                    break
+
+        if not input_pubkeys:
+            logger.warning("No eligible input pubkeys found for BIP-375 verification")
+            return None
+
+        A_n = sum_public_keys(input_pubkeys)
+
+        # Verify DLEQ proof
+        if not verify_dleq_proof(A_n, B_scan, ecdh_share, dleq_proof):
+            logger.warning("BIP-375 global DLEQ proof verification failed")
+            return None
+
+        # Compute expected output from verified ECDH share
+        # Get smallest outpoint and input hash
+        smallest_outpoint = get_smallest_outpoint(psbt.tx)
+        input_hash = get_input_hash(smallest_outpoint, A_n)
+        input_hash_scalar = int.from_bytes(input_hash, 'big') % n
+
+        # The ECDH share is: C = a_n * B_scan
+        # We need: shared_secret = input_hash * C = input_hash * a_n * B_scan
+        C_parsed = secp256k1.ec_pubkey_parse(ecdh_share)
+        input_hash_bytes = input_hash_scalar.to_bytes(32, 'big')
+        secp256k1.ec_pubkey_tweak_mul(C_parsed, input_hash_bytes)
+        shared_secret = secp256k1.ec_pubkey_serialize(C_parsed)
+
+        # Calculate t_k
+        t_k = get_shared_secret_hash(shared_secret, output_index)
+
+        # P_k = B_spend + t_k * G
+        B_spend_parsed = secp256k1.ec_pubkey_parse(B_spend)
+        secp256k1.ec_pubkey_tweak_add(B_spend_parsed, t_k)
+        expected_pubkey = secp256k1.ec_pubkey_serialize(B_spend_parsed)
+
+        expected_xonly, _ = full_to_xonly_pubkey(expected_pubkey)
+        logger.info(f"BIP-375 verification successful for output {output_index}")
+        return expected_xonly
+
+    # TODO: Handle per-input ECDH shares (aggregate them)
+    # This is more complex - need to sum the per-input shares
+    per_input_shares = extract_input_ecdh_shares(psbt, B_scan)
+    if per_input_shares:
+        logger.warning("Per-input ECDH shares not yet implemented - falling back")
+
+    return None
+
+
+def encode_silent_payment_address(B_scan: bytes, B_spend: bytes, network: str = "mainnet") -> str:
+    """
+    Encode scan and spend public keys into a BIP-352 Silent Payment address.
+
+    Args:
+        B_scan: 33-byte compressed scan public key
+        B_spend: 33-byte compressed spend public key
+        network: "mainnet" or "testnet"
+
+    Returns:
+        Bech32m encoded SP address (sp1... or tsp1...)
+    """
+    if len(B_scan) != 33 or len(B_spend) != 33:
+        raise ValueError("Public keys must be 33 bytes")
+
+    hrp = "sp" if network == "mainnet" else "tsp"
+
+    # Payload: B_scan + B_spend (66 bytes)
+    payload = B_scan + B_spend
+
+    # Convert payload to 5-bit groups
+    data_5bit = _convertbits(list(payload), 8, 5, True)
+    if data_5bit is None:
+        raise ValueError("Failed to convert to 5-bit groups")
+
+    # Prepend version byte (0) as first 5-bit value
+    # This is the witness version, encoded separately
+    data_5bit = [0] + data_5bit
+
+    # Add checksum
+    values = _bech32_hrp_expand(hrp) + data_5bit
+    polymod = _bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ BECH32M_CONST
+    checksum = [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
+
+    # Encode to string
+    return hrp + "1" + "".join(CHARSET[d] for d in data_5bit + checksum)
+
+
+def has_bip375_sp_fields(psbt) -> bool:
+    """
+    Check if PSBT contains any BIP-375 Silent Payment fields.
+
+    Args:
+        psbt: PSBT object
+
+    Returns:
+        True if any BIP-375 SP fields are present
+    """
+    # Check global fields
+    if hasattr(psbt, 'unknown') and psbt.unknown:
+        for key in psbt.unknown.keys():
+            if len(key) >= 1 and key[0] in (PSBT_GLOBAL_SP_ECDH_SHARE, PSBT_GLOBAL_SP_DLEQ):
+                return True
+
+    # Check output fields
+    for out in psbt.outputs:
+        if hasattr(out, 'unknown') and out.unknown:
+            for key in out.unknown.keys():
+                if len(key) >= 1 and key[0] == PSBT_OUT_SP_V0_INFO:
+                    return True
+
+    # Check input fields
+    for inp in psbt.inputs:
+        if hasattr(inp, 'unknown') and inp.unknown:
+            for key in inp.unknown.keys():
+                if len(key) >= 1 and key[0] in (PSBT_IN_SP_ECDH_SHARE, PSBT_IN_SP_DLEQ):
+                    return True
+
+    return False

--- a/src/seedsigner/helpers/silent_payments.py
+++ b/src/seedsigner/helpers/silent_payments.py
@@ -2,28 +2,71 @@
 BIP-352 Silent Payments - Send Verification Support
 
 This module implements verification for the sending side of BIP-352 Silent Payments.
-It provides functionality to:
-- Parse Silent Payment addresses (sp1.../tsp1...)
-- Compute the derived Taproot output pubkey for verification
 
-User Flow:
-1. User scans SP address QR (sp1... or tsp1...) - SeedSigner stores it
-2. User scans PSBT from SP-aware coordinator wallet (e.g., BlueWallet, Sparrow)
-3. SeedSigner independently re-derives the expected Taproot output
-4. SeedSigner verifies a PSBT output matches the derived address
-5. User sees "Silent Payment Verified" with the original sp1... address
-6. User approves and signs
 
-Security Model:
-The coordinator wallet (not SeedSigner) performs the actual SP derivation and
-creates the PSBT with a normal P2TR output. SeedSigner's role is VERIFICATION:
-it independently computes what the output SHOULD be and confirms the coordinator
-derived it correctly.
+WHAT HAPPENS TODAY (WITHOUT THIS UPDATE)
+========================================
+Silent Payments already work with SeedSigner - the coordinator wallet does the math:
 
-Without this verification, users would only see a bc1p... address with no way
-to confirm it corresponds to their intended sp1... recipient. A malicious or
-buggy coordinator could substitute a different address. SeedSigner catches this
-by re-deriving from the user's scanned SP address (their source of truth).
+1. BlueWallet/Sparrow derives bc1p... from the sp1... address
+2. Coordinator builds PSBT with that Taproot output
+3. User scans PSBT into SeedSigner
+4. SeedSigner shows: "Sending 0.01 BTC to bc1p7x9y2z..."
+5. User thinks: "I have no idea if that bc1p address is correct"
+6. User approves blindly, SeedSigner signs
+
+The payment works fine. But the user has NO WAY to verify the bc1p... address
+actually corresponds to their intended sp1... recipient.
+
+
+THE RISK
+========
+A malicious or buggy coordinator could substitute a different bc1p... address:
+- Compromised wallet software
+- Man-in-the-middle attack modifying the PSBT
+- Bug in the SP derivation code
+
+The user would unknowingly sign a transaction sending funds to the wrong address.
+
+
+WHAT THIS UPDATE ADDS
+=====================
+SeedSigner can now VERIFY the coordinator did the math correctly:
+
+1. User scans sp1... address QR first (their source of truth)
+2. Coordinator builds PSBT as normal
+3. User scans PSBT into SeedSigner
+4. SeedSigner independently re-derives what the output SHOULD be
+5. SeedSigner verifies the PSBT output matches
+6. SeedSigner shows: "Sending 0.01 BTC to sp1qq..." with verification checkmark
+7. User thinks: "That's the address I intended to pay"
+8. User approves with confidence, SeedSigner signs
+
+
+WHY SEEDSIGNER CAN ONLY VERIFY, NOT GENERATE SP ADDRESSES
+==========================================================
+Unlike regular Bitcoin addresses (where m/84'/0'/0'/0/0 always produces the same
+bc1q... address), Silent Payment output addresses are TRANSACTION-SPECIFIC.
+
+The derived bc1p... address depends on:
+1. The private keys of the UTXOs being spent
+2. The outpoints (txid:vout) of those specific UTXOs
+
+This means:
+- Every transaction to the same sp1... address produces a DIFFERENT bc1p... output
+- You cannot derive the output address until you know WHICH UTXOs you're spending
+- Only a wallet with UTXO set knowledge can build the transaction
+
+SeedSigner is stateless by design - it has:
+- Your seed (private keys) ✓
+- No blockchain data ✗
+- No wallet state ✗
+- No UTXO set ✗
+
+Therefore the flow MUST be:
+1. Coordinator wallet (with UTXO knowledge) selects inputs, derives SP output, builds PSBT
+2. SeedSigner (with private keys) verifies the derivation was correct, then signs
+
 
 Reference: https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki
 """

--- a/src/seedsigner/helpers/silent_payments.py
+++ b/src/seedsigner/helpers/silent_payments.py
@@ -614,10 +614,11 @@ def verify_dleq_proof(
         secp256k1.ec_pubkey_tweak_mul(eA_parsed, e_bytes)
 
         # Negate e*A to get -e*A
-        secp256k1.ec_pubkey_negate(eA_parsed)
+        # NOTE: ec_pubkey_negate RETURNS the negated point, does NOT modify in-place
+        neg_eA = secp256k1.ec_pubkey_negate(eA_parsed)
 
         # R1 = s*G + (-e*A)
-        R1_parsed = secp256k1.ec_pubkey_combine(sG_parsed, eA_parsed)
+        R1_parsed = secp256k1.ec_pubkey_combine(sG_parsed, neg_eA)
         R1 = secp256k1.ec_pubkey_serialize(R1_parsed)
 
         # R2 = s*B - e*C
@@ -630,10 +631,11 @@ def verify_dleq_proof(
         secp256k1.ec_pubkey_tweak_mul(eC_parsed, e_bytes)
 
         # Negate e*C
-        secp256k1.ec_pubkey_negate(eC_parsed)
+        # NOTE: ec_pubkey_negate RETURNS the negated point, does NOT modify in-place
+        neg_eC = secp256k1.ec_pubkey_negate(eC_parsed)
 
         # R2 = s*B + (-e*C)
-        R2_parsed = secp256k1.ec_pubkey_combine(sB_parsed, eC_parsed)
+        R2_parsed = secp256k1.ec_pubkey_combine(sB_parsed, neg_eC)
         R2 = secp256k1.ec_pubkey_serialize(R2_parsed)
 
         # Compute challenge hash

--- a/src/seedsigner/helpers/silent_payments.py
+++ b/src/seedsigner/helpers/silent_payments.py
@@ -1,0 +1,483 @@
+"""
+BIP-352 Silent Payments - Send Verification Support
+
+This module implements verification for the sending side of BIP-352 Silent Payments.
+It provides functionality to:
+- Parse Silent Payment addresses (sp1.../tsp1...)
+- Compute the derived Taproot output pubkey for verification
+
+User Flow:
+1. User scans SP address QR (sp1... or tsp1...) - SeedSigner stores it
+2. User scans PSBT from SP-aware coordinator wallet (e.g., BlueWallet, Sparrow)
+3. SeedSigner independently re-derives the expected Taproot output
+4. SeedSigner verifies a PSBT output matches the derived address
+5. User sees "Silent Payment Verified" with the original sp1... address
+6. User approves and signs
+
+Security Model:
+The coordinator wallet (not SeedSigner) performs the actual SP derivation and
+creates the PSBT with a normal P2TR output. SeedSigner's role is VERIFICATION:
+it independently computes what the output SHOULD be and confirms the coordinator
+derived it correctly.
+
+Without this verification, users would only see a bc1p... address with no way
+to confirm it corresponds to their intended sp1... recipient. A malicious or
+buggy coordinator could substitute a different address. SeedSigner catches this
+by re-deriving from the user's scanned SP address (their source of truth).
+
+Reference: https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki
+"""
+
+import logging
+from hashlib import sha256
+from typing import Tuple, List, Optional
+
+from embit import ec
+from embit.util import secp256k1
+
+logger = logging.getLogger(__name__)
+
+
+# Bech32m constants
+BECH32M_CONST = 0x2bc830a3
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+# secp256k1 curve order
+SECP256K1_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+def _bech32_polymod(values: List[int]) -> int:
+    """Internal function for Bech32 checksum calculation."""
+    GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for v in values:
+        top = chk >> 25
+        chk = (chk & 0x1ffffff) << 5 ^ v
+        for i in range(5):
+            chk ^= GEN[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def _bech32_hrp_expand(hrp: str) -> List[int]:
+    """Expand HRP for checksum calculation."""
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+
+def _bech32m_verify_checksum(hrp: str, data: List[int]) -> bool:
+    """Verify Bech32m checksum."""
+    return _bech32_polymod(_bech32_hrp_expand(hrp) + data) == BECH32M_CONST
+
+
+def _convertbits(data: List[int], frombits: int, tobits: int, pad: bool = True) -> Optional[List[int]]:
+    """General power-of-2 base conversion."""
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
+    for value in data:
+        if value < 0 or (value >> frombits):
+            return None
+        acc = ((acc << frombits) | value) & max_acc
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        return None
+    return ret
+
+
+def bech32m_decode(bech: str) -> Tuple[str, bytes]:
+    """
+    Decode a Bech32m string (SP address) into HRP and data.
+
+    Args:
+        bech: The Bech32m encoded string
+
+    Returns:
+        Tuple of (hrp, data_bytes)
+
+    Raises:
+        ValueError: If the address is invalid
+    """
+    bech = bech.lower()
+
+    # Find separator
+    pos = bech.rfind('1')
+    if pos < 1 or pos + 7 > len(bech):
+        raise ValueError("Invalid separator position")
+
+    hrp = bech[:pos]
+    data_part = bech[pos + 1:]
+
+    # Decode data characters
+    data = []
+    for c in data_part:
+        if c not in CHARSET:
+            raise ValueError(f"Invalid character: {c}")
+        data.append(CHARSET.index(c))
+
+    # Verify checksum
+    if not _bech32m_verify_checksum(hrp, data):
+        raise ValueError("Invalid checksum")
+
+    # Remove checksum (last 6 characters) and convert from 5-bit to 8-bit
+    data = data[:-6]
+
+    # First element is the witness version
+    if len(data) == 0:
+        raise ValueError("Empty data")
+
+    version = data[0]
+
+    # Convert remaining 5-bit groups to bytes
+    decoded = _convertbits(data[1:], 5, 8, False)
+    if decoded is None:
+        raise ValueError("Invalid padding")
+
+    return hrp, bytes([version] + decoded)
+
+
+def parse_silent_payment_address(address: str) -> Tuple[bytes, bytes, str]:
+    """
+    Parse a BIP-352 Silent Payment address.
+
+    Args:
+        address: The SP address string (sp1... or tsp1...)
+
+    Returns:
+        Tuple of (B_scan, B_spend, network) where:
+        - B_scan: 33-byte compressed public key for scanning
+        - B_spend: 33-byte compressed public key for spending
+        - network: "mainnet" or "testnet"
+
+    Raises:
+        ValueError: If address is invalid
+    """
+    hrp, data = bech32m_decode(address)
+
+    if hrp == "sp":
+        network = "mainnet"
+    elif hrp == "tsp":
+        network = "testnet"
+    else:
+        raise ValueError(f"Invalid HRP for SP address: {hrp}")
+
+    # First byte is version (should be 0 for v0 SP addresses)
+    if len(data) < 1:
+        raise ValueError("Missing version byte")
+
+    version = data[0]
+    if version != 0:
+        raise ValueError(f"Unsupported SP address version: {version}")
+
+    payload = data[1:]
+
+    if len(payload) != 66:
+        raise ValueError(f"Invalid SP address data length: {len(payload)}, expected 66")
+
+    B_scan = payload[:33]
+    B_spend = payload[33:66]
+
+    # Validate that both are valid compressed public keys
+    if B_scan[0] not in (0x02, 0x03) or B_spend[0] not in (0x02, 0x03):
+        raise ValueError("Invalid public key prefix in SP address")
+
+    return bytes(B_scan), bytes(B_spend), network
+
+
+def tagged_hash(tag: str, data: bytes) -> bytes:
+    """
+    Create a BIP-340 style tagged hash.
+
+    tagged_hash(tag, data) = SHA256(SHA256(tag) || SHA256(tag) || data)
+
+    Args:
+        tag: The tag string (e.g., "BIP0352/Inputs")
+        data: The data to hash
+
+    Returns:
+        32-byte hash
+    """
+    tag_hash = sha256(tag.encode()).digest()
+    return sha256(tag_hash + tag_hash + data).digest()
+
+
+def get_input_hash(smallest_outpoint: bytes, sum_input_pubkeys: bytes) -> bytes:
+    """
+    Calculate the input_hash per BIP-352.
+
+    input_hash = hash_BIP0352/Inputs(smallest_outpoint || A)
+
+    Args:
+        smallest_outpoint: The lexicographically smallest outpoint (36 bytes: txid || vout)
+        sum_input_pubkeys: The sum of all input public keys A (33 bytes compressed)
+
+    Returns:
+        32-byte hash
+    """
+    return tagged_hash("BIP0352/Inputs", smallest_outpoint + sum_input_pubkeys)
+
+
+def get_shared_secret_hash(shared_secret: bytes, output_index: int) -> bytes:
+    """
+    Calculate t_k for output k.
+
+    t_k = hash_BIP0352/SharedSecret(ser_P(ecdh_shared_secret) || ser_32(k))
+
+    Args:
+        shared_secret: 33-byte compressed point (ecdh_shared_secret)
+        output_index: The output index k
+
+    Returns:
+        32-byte scalar t_k
+    """
+    k_bytes = output_index.to_bytes(4, 'big')
+    return tagged_hash("BIP0352/SharedSecret", shared_secret + k_bytes)
+
+
+def sum_public_keys(pubkeys: List[bytes]) -> bytes:
+    """
+    Sum multiple public keys into a single point.
+
+    Args:
+        pubkeys: List of 33-byte compressed public keys
+
+    Returns:
+        33-byte compressed public key representing the sum
+    """
+    if len(pubkeys) == 0:
+        raise ValueError("Cannot sum empty list of public keys")
+
+    if len(pubkeys) == 1:
+        return pubkeys[0]
+
+    # Parse all public keys to internal secp256k1 format
+    parsed_keys = []
+    for pk in pubkeys:
+        parsed = secp256k1.ec_pubkey_parse(pk)
+        parsed_keys.append(parsed)
+
+    # Combine using secp256k1 (pass as *args)
+    combined = secp256k1.ec_pubkey_combine(*parsed_keys)
+
+    # Serialize back to compressed format
+    return secp256k1.ec_pubkey_serialize(combined)
+
+
+def compute_sp_output_pubkey(
+    input_privkeys: List[Tuple[bytes, bool]],
+    input_pubkeys: List[bytes],
+    B_scan: bytes,
+    B_spend: bytes,
+    smallest_outpoint: bytes,
+    output_index: int = 0
+) -> bytes:
+    """
+    Compute the expected Silent Payment output public key.
+
+    This is the core BIP-352 sending algorithm.
+
+    Args:
+        input_privkeys: List of (privkey_bytes, is_taproot) tuples
+        input_pubkeys: List of 33-byte compressed public keys (corresponding to privkeys)
+        B_scan: Recipient's scan public key (33 bytes)
+        B_spend: Recipient's spend public key (33 bytes)
+        smallest_outpoint: Lexicographically smallest outpoint (36 bytes)
+        output_index: Output index k (default 0 for single output)
+
+    Returns:
+        33-byte compressed public key P_k for the output
+
+    Raises:
+        ValueError: If computation fails
+    """
+    if len(input_privkeys) != len(input_pubkeys):
+        raise ValueError("Mismatched privkey/pubkey count")
+
+    if len(input_privkeys) == 0:
+        raise ValueError("No input keys provided")
+
+    n = SECP256K1_ORDER
+
+    # Step 1: Sum all private keys (with Taproot negation if needed)
+    a_sum = 0
+    adjusted_pubkeys = []
+
+    for i, (privkey, is_taproot) in enumerate(input_privkeys):
+        # Convert privkey bytes to integer
+        a_i = int.from_bytes(privkey, 'big')
+        pubkey = input_pubkeys[i]
+
+        if is_taproot:
+            # For Taproot inputs: negate privkey if pubkey Y is odd
+            if pubkey[0] == 0x03:  # Odd Y
+                a_i = n - a_i
+                # Also need to use the negated pubkey (even Y)
+                negated_parsed = secp256k1.ec_pubkey_parse(pubkey)
+                negated = secp256k1.ec_pubkey_negate(negated_parsed)
+                adjusted_pubkeys.append(secp256k1.ec_pubkey_serialize(negated))
+            else:
+                adjusted_pubkeys.append(pubkey)
+        else:
+            adjusted_pubkeys.append(pubkey)
+
+        a_sum = (a_sum + a_i) % n
+
+    if a_sum == 0:
+        raise ValueError("Sum of private keys is zero")
+
+    # Step 2: Calculate sum of input public keys A
+    A = sum_public_keys(adjusted_pubkeys)
+
+    # Step 3: Calculate input_hash
+    input_hash = get_input_hash(smallest_outpoint, A)
+    input_hash_scalar = int.from_bytes(input_hash, 'big') % n
+
+    if input_hash_scalar == 0:
+        raise ValueError("Input hash is zero")
+
+    # Step 4: Compute a' = input_hash * a_sum
+    a_prime = (input_hash_scalar * a_sum) % n
+
+    # Step 5: ECDH: shared_secret = a' * B_scan
+    a_prime_bytes = a_prime.to_bytes(32, 'big')
+    B_scan_parsed = secp256k1.ec_pubkey_parse(B_scan)
+
+    # Multiply B_scan by a' (modifies B_scan_parsed in-place, returns None)
+    secp256k1.ec_pubkey_tweak_mul(B_scan_parsed, a_prime_bytes)
+    shared_secret = secp256k1.ec_pubkey_serialize(B_scan_parsed)
+
+    # Step 6: Calculate t_k
+    t_k = get_shared_secret_hash(shared_secret, output_index)
+    t_k_scalar = int.from_bytes(t_k, 'big') % n
+
+    if t_k_scalar == 0:
+        raise ValueError("t_k is zero")
+
+    # Step 7: P_k = B_spend + t_k * G
+    B_spend_parsed = secp256k1.ec_pubkey_parse(B_spend)
+
+    # Add t_k * G to B_spend (modifies B_spend_parsed in-place, returns None)
+    secp256k1.ec_pubkey_tweak_add(B_spend_parsed, t_k)
+
+    return secp256k1.ec_pubkey_serialize(B_spend_parsed)
+
+
+def get_smallest_outpoint(tx) -> bytes:
+    """
+    Get the lexicographically smallest outpoint from transaction inputs.
+
+    Outpoint format: txid (32 bytes, little-endian) || vout (4 bytes, little-endian)
+
+    Args:
+        tx: embit Transaction object with vin attribute
+
+    Returns:
+        36-byte outpoint (smallest lexicographically)
+    """
+    outpoints = []
+    for vin in tx.vin:
+        # txid is already bytes (little-endian in embit)
+        txid = vin.txid
+        vout = vin.vout.to_bytes(4, 'little')
+        outpoints.append(txid + vout)
+
+    if not outpoints:
+        raise ValueError("No inputs in transaction")
+
+    return min(outpoints)
+
+
+def is_eligible_input(psbt_input, fingerprint: str = None) -> bool:
+    """
+    Check if a PSBT input is eligible for Silent Payment computation.
+
+    Per BIP-352, eligible inputs are:
+    - P2PKH (single-sig)
+    - P2WPKH (single-sig)
+    - P2SH-P2WPKH (single-sig)
+    - P2TR (key path spend only, single-sig)
+
+    Excluded:
+    - Multisig (any type)
+    - P2TR script path spends
+
+    Args:
+        psbt_input: PSBT InputScope
+        fingerprint: Optional fingerprint to match (hex string)
+
+    Returns:
+        True if input is eligible for SP computation
+    """
+    from binascii import hexlify
+
+    # Check for Taproot
+    if psbt_input.taproot_bip32_derivations:
+        # Must be exactly one key (single-sig)
+        if len(psbt_input.taproot_bip32_derivations) != 1:
+            return False
+
+        # Check for script path (has leaf hashes)
+        for pub, (leaf_hashes, der) in psbt_input.taproot_bip32_derivations.items():
+            if len(leaf_hashes) > 0:
+                return False  # Script path spend, not eligible
+
+            # If fingerprint specified, check it matches
+            if fingerprint:
+                if hexlify(der.fingerprint).decode() != fingerprint:
+                    return False
+
+        return True
+
+    # Check for regular single-sig (P2PKH, P2WPKH, P2SH-P2WPKH)
+    if psbt_input.bip32_derivations:
+        # Must be exactly one key (single-sig)
+        if len(psbt_input.bip32_derivations) != 1:
+            return False
+
+        # If fingerprint specified, check it matches
+        if fingerprint:
+            for pub, der in psbt_input.bip32_derivations.items():
+                if hexlify(der.fingerprint).decode() != fingerprint:
+                    return False
+
+        return True
+
+    return False
+
+
+def xonly_to_full_pubkey(xonly: bytes, parity: int = 0) -> bytes:
+    """
+    Convert 32-byte x-only pubkey to 33-byte compressed pubkey.
+
+    Args:
+        xonly: 32-byte x-only public key
+        parity: 0 for even Y (0x02 prefix), 1 for odd Y (0x03 prefix)
+
+    Returns:
+        33-byte compressed public key
+    """
+    prefix = 0x02 if parity == 0 else 0x03
+    return bytes([prefix]) + xonly
+
+
+def full_to_xonly_pubkey(full: bytes) -> Tuple[bytes, int]:
+    """
+    Convert 33-byte compressed pubkey to 32-byte x-only pubkey.
+
+    Args:
+        full: 33-byte compressed public key
+
+    Returns:
+        Tuple of (32-byte x-only pubkey, parity: 0=even, 1=odd)
+    """
+    if len(full) != 33:
+        raise ValueError(f"Expected 33 bytes, got {len(full)}")
+
+    parity = 0 if full[0] == 0x02 else 1
+    return full[1:], parity

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -88,6 +88,9 @@ class DecodeQR:
             elif self.qr_type == QRType.BITCOIN_ADDRESS:
                 self.decoder = BitcoinAddressQrDecoder() # Single Segment bitcoin address
 
+            elif self.qr_type == QRType.SILENT_PAYMENT_ADDRESS:
+                self.decoder = SilentPaymentAddressQrDecoder() # Single Segment SP address
+
             elif self.qr_type == QRType.SIGN_MESSAGE:
                 self.decoder = SignMessageQrDecoder() # Single Segment sign message request
 
@@ -290,7 +293,18 @@ class DecodeQR:
     @property
     def is_address(self):
         return self.qr_type == QRType.BITCOIN_ADDRESS
-        
+
+
+    @property
+    def is_silent_payment_address(self):
+        return self.qr_type == QRType.SILENT_PAYMENT_ADDRESS
+
+
+    def get_silent_payment_data(self):
+        if self.is_silent_payment_address:
+            return self.decoder.get_qr_data()
+        return None
+
 
     @property
     def is_sign_message(self):
@@ -389,6 +403,10 @@ class DecodeQR:
             # Bitcoin Address
             elif DecodeQR.is_bitcoin_address(s):
                 return QRType.BITCOIN_ADDRESS
+
+            # Silent Payment Address
+            elif DecodeQR.is_silent_payment_address(s):
+                return QRType.SILENT_PAYMENT_ADDRESS
 
             # message signing
             elif s.startswith("signmessage"):
@@ -520,6 +538,17 @@ class DecodeQR:
             return True
         else:
             return False
+
+
+    @staticmethod
+    def is_silent_payment_address(s):
+        """
+        Check if the string is a BIP-352 Silent Payment address.
+        SP addresses start with sp1 (mainnet) or tsp1 (testnet).
+        """
+        if re.search(r'^(sp1|tsp1)[a-z0-9]{100,120}$', s.lower()):
+            return True
+        return False
 
 
     @staticmethod
@@ -1168,7 +1197,52 @@ class GenericWalletQrDecoder(BaseSingleFrameQrDecoder):
 
 
 
-class MultiSigConfigFileQRDecoder(GenericWalletQrDecoder):    
+class MultiSigConfigFileQRDecoder(GenericWalletQrDecoder):
     def add(self, segment, qr_type=QRType.WALLET__CONFIGFILE):
         descriptor = DecodeQR.multisig_setup_file_to_descriptor(segment)
         return super().add(descriptor,qr_type=QRType.WALLET__CONFIGFILE)
+
+
+
+class SilentPaymentAddressQrDecoder(BaseSingleFrameQrDecoder):
+    """
+    Decodes a BIP-352 Silent Payment address.
+    Extracts B_scan, B_spend public keys and network.
+    """
+    def __init__(self):
+        super().__init__()
+        self.address = None
+        self.B_scan = None
+        self.B_spend = None
+        self.network = None
+
+
+    def add(self, segment, qr_type=QRType.SILENT_PAYMENT_ADDRESS):
+        from seedsigner.helpers.silent_payments import parse_silent_payment_address
+
+        try:
+            # Parse the SP address
+            B_scan, B_spend, network = parse_silent_payment_address(segment)
+
+            self.address = segment
+            self.B_scan = B_scan
+            self.B_spend = B_spend
+            self.network = network
+            self.complete = True
+            self.collected_segments = 1
+            return DecodeQRStatus.COMPLETE
+
+        except ValueError as e:
+            logger.debug(f"Invalid SP address: {e}")
+            return DecodeQRStatus.INVALID
+
+
+    def get_qr_data(self) -> dict:
+        if self.complete:
+            return {
+                "address": self.address,
+                "B_scan": self.B_scan,
+                "B_spend": self.B_spend,
+                "network": self.network,
+            }
+        return None

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -95,9 +95,10 @@ class PSBTParser():
         if rt == False:
             return False
 
-        # If we have a pending SP address, verify outputs
-        if self.pending_sp_address:
-            self._verify_sp_outputs()
+        # Try Silent Payment verification:
+        # - BIP-375: PSBT may contain embedded SP fields (no pre-scan needed)
+        # - Fallback: User may have scanned SP address before PSBT
+        self._verify_sp_outputs()
 
         return True
 

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -502,9 +502,17 @@ class PSBTParser():
             has_bip375_sp_fields,
             extract_sp_info_from_output,
             verify_sp_output_with_bip375,
+            # PSBTv2 detection
+            get_psbt_version,
+            is_psbt_v2,
         )
 
         seed_fingerprint = hexlify(self.root.child(0).fingerprint).decode()
+
+        # Log PSBT version for diagnostics
+        psbt_version = get_psbt_version(self.psbt)
+        if psbt_version >= 2:
+            logger.info(f"PSBTv{psbt_version} detected - BIP-375 fields stored in unknown dict")
 
         # =====================================================================
         # Priority 1: Try BIP-375 verification (PSBT contains SP fields + DLEQ)

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -485,6 +485,10 @@ class PSBTParser():
         """
         Verify that PSBT outputs match the expected Silent Payment derived address.
 
+        Verification priority:
+        1. BIP-375: If PSBT contains SP fields with DLEQ proofs, verify via DLEQ
+        2. Fallback: If user scanned SP address, re-derive and verify output
+
         Per BIP-352, we need to:
         1. Collect eligible input private keys
         2. Compute the expected SP output pubkey
@@ -494,16 +498,32 @@ class PSBTParser():
             compute_sp_output_pubkey,
             is_eligible_input,
             full_to_xonly_pubkey,
+            # BIP-375 functions
+            has_bip375_sp_fields,
+            extract_sp_info_from_output,
+            verify_sp_output_with_bip375,
         )
 
+        seed_fingerprint = hexlify(self.root.child(0).fingerprint).decode()
+
+        # =====================================================================
+        # Priority 1: Try BIP-375 verification (PSBT contains SP fields + DLEQ)
+        # =====================================================================
+        if has_bip375_sp_fields(self.psbt):
+            logger.info("BIP-375 SP fields detected in PSBT")
+            self._verify_sp_outputs_bip375(seed_fingerprint)
+            if self.sp_outputs:
+                return  # BIP-375 verification succeeded
+
+        # =====================================================================
+        # Priority 2: Fallback to user-scanned SP address verification
+        # =====================================================================
         if not self.pending_sp_address:
             return
 
         B_scan = self.pending_sp_address["B_scan"]
         B_spend = self.pending_sp_address["B_spend"]
         sp_address = self.pending_sp_address["address"]
-
-        seed_fingerprint = hexlify(self.root.child(0).fingerprint).decode()
 
         # Collect eligible input private keys and pubkeys
         input_privkeys = []
@@ -584,15 +604,88 @@ class PSBTParser():
                 output_xonly = script_pubkey.data[2:]
 
                 if output_xonly == expected_xonly:
-                    logger.info(f"SP output match found at index {i}")
+                    logger.info(f"SP output match found at index {i} (fallback verification)")
                     self.sp_outputs.append({
                         "output_index": i,
                         "address": sp_address,
                         "amount": vout.value,
                         "expected_pubkey": expected_xonly.hex(),
+                        "verification_method": "fallback",
                     })
 
                     # Update destination to show SP address instead of derived address
                     if i < len(self.destination_addresses):
                         # Replace the destination address with the SP address (truncated)
                         self.destination_addresses[i] = sp_address
+
+
+    def _verify_sp_outputs_bip375(self, seed_fingerprint: str):
+        """
+        Verify Silent Payment outputs using BIP-375 embedded PSBT fields.
+
+        This method checks for PSBT_OUT_SP_V0_INFO fields in outputs and
+        verifies them using DLEQ proofs from global or per-input fields.
+        """
+        from seedsigner.helpers.silent_payments import (
+            extract_sp_info_from_output,
+            verify_sp_output_with_bip375,
+            full_to_xonly_pubkey,
+            encode_silent_payment_address,
+        )
+
+        # Determine network for address encoding
+        network = "mainnet" if self.network == SettingsConstants.MAINNET else "testnet"
+
+        for i, out in enumerate(self.psbt.outputs):
+            # Check if this output has BIP-375 SP info
+            sp_info = extract_sp_info_from_output(out)
+            if not sp_info:
+                continue
+
+            B_scan, B_spend = sp_info
+            logger.debug(f"Output {i} has BIP-375 SP info")
+
+            # Try to verify using DLEQ proof
+            expected_xonly = verify_sp_output_with_bip375(
+                self.psbt,
+                i,
+                B_scan,
+                B_spend,
+                seed_fingerprint
+            )
+
+            if expected_xonly:
+                # Verify the output matches
+                vout = self.psbt.tx.vout[i]
+                script_pubkey = vout.script_pubkey
+
+                if script_pubkey.script_type() == "p2tr":
+                    if len(script_pubkey.data) == 34 and script_pubkey.data[0] == 0x51:
+                        output_xonly = script_pubkey.data[2:]
+
+                        if output_xonly == expected_xonly:
+                            # Encode SP address from B_scan and B_spend
+                            try:
+                                sp_address = encode_silent_payment_address(B_scan, B_spend, network)
+                            except Exception as e:
+                                logger.warning(f"Failed to encode SP address: {e}")
+                                sp_address = "sp1...(BIP-375 verified)"
+
+                            logger.info(f"BIP-375 SP output verified at index {i}")
+                            self.sp_outputs.append({
+                                "output_index": i,
+                                "address": sp_address,
+                                "amount": vout.value,
+                                "expected_pubkey": expected_xonly.hex(),
+                                "verification_method": "bip375",
+                                "B_scan": B_scan.hex(),
+                                "B_spend": B_spend.hex(),
+                            })
+
+                            # Update destination address
+                            if i < len(self.destination_addresses):
+                                self.destination_addresses[i] = sp_address
+                        else:
+                            logger.warning(f"BIP-375 output {i}: pubkey mismatch!")
+                else:
+                    logger.warning(f"BIP-375 output {i}: not a Taproot output")

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -20,10 +20,11 @@ class OPCODES:
 
 
 class PSBTParser():
-    def __init__(self, p: PSBT, seed: Seed, network: str = SettingsConstants.MAINNET):
+    def __init__(self, p: PSBT, seed: Seed, network: str = SettingsConstants.MAINNET, pending_sp_address: dict = None):
         self.psbt: PSBT = p
         self.seed = seed
         self.network = network
+        self.pending_sp_address = pending_sp_address
 
         self.policy = None
         self.spend_amount = 0
@@ -35,6 +36,9 @@ class PSBTParser():
         self.destination_addresses = []
         self.destination_amounts = []
         self.op_return_data: bytes = None
+
+        # BIP-352 Silent Payments: verified SP outputs
+        self.sp_outputs: list = []
 
         self.root = None
 
@@ -90,6 +94,10 @@ class PSBTParser():
         rt = self._parse_outputs()
         if rt == False:
             return False
+
+        # If we have a pending SP address, verify outputs
+        if self.pending_sp_address:
+            self._verify_sp_outputs()
 
         return True
 
@@ -471,3 +479,120 @@ class PSBTParser():
 
         for out in self.psbt.outputs:
             _fill_scope(out)
+
+
+    def _verify_sp_outputs(self):
+        """
+        Verify that PSBT outputs match the expected Silent Payment derived address.
+
+        Per BIP-352, we need to:
+        1. Collect eligible input private keys
+        2. Compute the expected SP output pubkey
+        3. Match against Taproot outputs in the PSBT
+        """
+        from seedsigner.helpers.silent_payments import (
+            compute_sp_output_pubkey,
+            is_eligible_input,
+            full_to_xonly_pubkey,
+        )
+
+        if not self.pending_sp_address:
+            return
+
+        B_scan = self.pending_sp_address["B_scan"]
+        B_spend = self.pending_sp_address["B_spend"]
+        sp_address = self.pending_sp_address["address"]
+
+        seed_fingerprint = hexlify(self.root.child(0).fingerprint).decode()
+
+        # Collect eligible input private keys and pubkeys
+        input_privkeys = []
+        input_pubkeys = []
+        outpoints = []
+
+        for i, inp in enumerate(self.psbt.inputs):
+            if not is_eligible_input(inp, seed_fingerprint):
+                logger.debug(f"Input {i} not eligible for SP computation")
+                continue
+
+            # Get derivation path and derive private key
+            derivation = None
+            is_taproot = False
+
+            if inp.taproot_bip32_derivations:
+                for pub, (leaf_hashes, der) in inp.taproot_bip32_derivations.items():
+                    if hexlify(der.fingerprint).decode() == seed_fingerprint:
+                        derivation = der.derivation
+                        is_taproot = True
+                        break
+            elif inp.bip32_derivations:
+                for pub, der in inp.bip32_derivations.items():
+                    if hexlify(der.fingerprint).decode() == seed_fingerprint:
+                        derivation = der.derivation
+                        break
+
+            if derivation is None:
+                logger.debug(f"Input {i}: no matching derivation found")
+                continue
+
+            # Derive the private key
+            derived_key = self.root.derive(derivation)
+            privkey_bytes = derived_key.key.secret
+
+            # Get public key
+            pubkey = derived_key.key.get_public_key().sec()
+
+            input_privkeys.append((privkey_bytes, is_taproot))
+            input_pubkeys.append(pubkey)
+
+            # Get outpoint (txid || vout)
+            vin = self.psbt.tx.vin[i]
+            txid = vin.txid  # already little-endian bytes
+            vout = vin.vout.to_bytes(4, 'little')
+            outpoints.append(txid + vout)
+
+        if not input_privkeys:
+            logger.warning("No eligible inputs found for SP computation")
+            return
+
+        # Find smallest outpoint
+        smallest_outpoint = min(outpoints)
+
+        # Compute expected SP output pubkey (k=0 for first output)
+        try:
+            expected_pubkey = compute_sp_output_pubkey(
+                input_privkeys,
+                input_pubkeys,
+                B_scan,
+                B_spend,
+                smallest_outpoint,
+                output_index=0
+            )
+            expected_xonly, _ = full_to_xonly_pubkey(expected_pubkey)
+        except Exception as e:
+            logger.error(f"Failed to compute SP output pubkey: {e}")
+            return
+
+        # Check each Taproot output for a match
+        for i, vout in enumerate(self.psbt.tx.vout):
+            script_pubkey = vout.script_pubkey
+            if script_pubkey.script_type() != "p2tr":
+                continue
+
+            # Extract x-only pubkey from p2tr script (OP_1 <32-byte-key>)
+            if len(script_pubkey.data) == 34 and script_pubkey.data[0] == 0x51:
+                output_xonly = script_pubkey.data[2:]
+
+                if output_xonly == expected_xonly:
+                    logger.info(f"SP output match found at index {i}")
+                    self.sp_outputs.append({
+                        "output_index": i,
+                        "address": sp_address,
+                        "amount": vout.value,
+                        "expected_pubkey": expected_xonly.hex(),
+                    })
+
+                    # Update destination to show SP address instead of derived address
+                    if i < len(self.destination_addresses):
+                        # Replace the destination address with the SP address (truncated)
+                        self.destination_addresses[i] = sp_address

--- a/src/seedsigner/models/qr_type.py
+++ b/src/seedsigner/models/qr_type.py
@@ -21,6 +21,7 @@ class QRType:
     XPUB__UR = "xpub__ur"
 
     BITCOIN_ADDRESS = "bitcoin_address"
+    SILENT_PAYMENT_ADDRESS = "silent_payment_address"
 
     SIGN_MESSAGE = "sign_message"
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -99,7 +99,8 @@ class PSBTOverviewView(View):
                 self.controller.psbt_parser = PSBTParser(
                     self.controller.psbt,
                     seed=self.controller.psbt_seed,
-                    network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+                    network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
+                    pending_sp_address=self.controller.pending_sp_address
                 )
             except Exception as e:
                 self.loading_screen.stop()
@@ -260,8 +261,14 @@ class PSBTAddressDetailsView(View):
             # Should not be able to get here
             raise Exception("Routing error")
 
+        address = psbt_parser.destination_addresses[self.address_num]
+        is_silent_payment = address.startswith("sp1") or address.startswith("tsp1")
+
         # TRANSLATOR_NOTE: Future-tense used to indicate that this transaction will send this amount, as opposed to "Send" on its own which could be misread as an instant command (e.g. "Send Now").
-        title = _("Will Send")
+        if is_silent_payment:
+            title = _("Silent Payment")
+        else:
+            title = _("Will Send")
         if psbt_parser.num_destinations > 1:
             title += f" (#{self.address_num + 1})"
 
@@ -276,8 +283,9 @@ class PSBTAddressDetailsView(View):
             PSBTAddressDetailsScreen,
             title=title,
             button_data=button_data,
-            address=psbt_parser.destination_addresses[self.address_num],
+            address=address,
             amount=psbt_parser.destination_amounts[self.address_num],
+            is_silent_payment=is_silent_payment,
         )
         
         if selected_menu_num == RET_CODE__BACK_BUTTON:

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -156,7 +156,14 @@ class ScanView(View):
                         message=qr_data["message"],
                     )
                 )
-            
+
+            elif self.decoder.is_silent_payment_address:
+                # BIP-352 Silent Payment address scanned
+                # Store it and prompt user to scan PSBT next
+                sp_data = self.decoder.get_silent_payment_data()
+                self.controller.pending_sp_address = sp_data
+                return Destination(SilentPaymentAddressScannedView, skip_current_view=True)
+
             else:
                 return Destination(NotYetImplementedView)
 
@@ -227,3 +234,44 @@ class ScanInvalidQRTypeView(View):
         )
 
         return Destination(MainMenuView, clear_history=True)
+
+
+
+class SilentPaymentAddressScannedView(View):
+    """
+    Shown after scanning a BIP-352 Silent Payment address.
+    Prompts the user to scan a PSBT next.
+
+    Flow explanation:
+    The coordinator wallet (BlueWallet, Sparrow, etc.) creates the PSBT with the
+    derived Taproot output. SeedSigner will independently verify the derivation
+    matches this SP address. This catches malicious/buggy coordinators that might
+    substitute a different address.
+    """
+    def run(self):
+        from seedsigner.gui.screens import LargeIconStatusScreen
+
+        sp_data = self.controller.pending_sp_address
+        if not sp_data:
+            return Destination(MainMenuView, clear_history=True)
+
+        # Truncate address for display
+        address = sp_data["address"]
+        truncated = f"{address[:12]}...{address[-8:]}"
+
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Silent Payment"),
+            status_headline=_("Address Received"),
+            text=_("Now scan transaction (PSBT) to verify and sign.") + f"\n\n{truncated}",
+            button_data=[ButtonOption(_("Scan Transaction")), ButtonOption(_("Cancel"))],
+            show_back_button=False,
+        )
+
+        if selected_menu_num == 0:
+            # Proceed to scan PSBT
+            return Destination(ScanPSBTView)
+        else:
+            # Cancel - clear the pending SP address
+            self.controller.pending_sp_address = None
+            return Destination(MainMenuView, clear_history=True)

--- a/tests/test_silent_payments.py
+++ b/tests/test_silent_payments.py
@@ -429,3 +429,70 @@ class TestSPAddressEncode(BaseTest):
         # Should match the known test vector address
         expected = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
         assert address == expected
+
+
+class TestPSBTv2Detection(BaseTest):
+    """Test PSBTv2 (BIP-370) detection."""
+
+    def test_get_psbt_version_v0(self):
+        """PSBTv0 (no version field) should return 0."""
+        from seedsigner.helpers.silent_payments import get_psbt_version
+
+        # Mock PSBT without version field
+        class MockPSBT:
+            unknown = {}
+
+        psbt = MockPSBT()
+        assert get_psbt_version(psbt) == 0
+
+    def test_get_psbt_version_no_unknown(self):
+        """PSBT without unknown dict should return 0."""
+        from seedsigner.helpers.silent_payments import get_psbt_version
+
+        class MockPSBT:
+            pass
+
+        psbt = MockPSBT()
+        assert get_psbt_version(psbt) == 0
+
+    def test_get_psbt_version_v2(self):
+        """PSBTv2 with version field should return 2."""
+        from seedsigner.helpers.silent_payments import get_psbt_version, PSBT_GLOBAL_VERSION
+
+        class MockPSBT:
+            unknown = {}
+
+        psbt = MockPSBT()
+        # BIP-370: PSBT_GLOBAL_VERSION is 0xFB, value is 32-bit LE unsigned int
+        psbt.unknown[bytes([PSBT_GLOBAL_VERSION])] = (2).to_bytes(4, 'little')
+
+        assert get_psbt_version(psbt) == 2
+
+    def test_is_psbt_v2(self):
+        """is_psbt_v2 should return True for v2, False for v0."""
+        from seedsigner.helpers.silent_payments import is_psbt_v2, PSBT_GLOBAL_VERSION
+
+        class MockPSBT:
+            unknown = {}
+
+        # v0
+        psbt_v0 = MockPSBT()
+        assert is_psbt_v2(psbt_v0) == False
+
+        # v2
+        psbt_v2 = MockPSBT()
+        psbt_v2.unknown = {bytes([PSBT_GLOBAL_VERSION]): (2).to_bytes(4, 'little')}
+        assert is_psbt_v2(psbt_v2) == True
+
+    def test_get_psbt_version_short_value(self):
+        """Version field with less than 4 bytes should return 0."""
+        from seedsigner.helpers.silent_payments import get_psbt_version, PSBT_GLOBAL_VERSION
+
+        class MockPSBT:
+            unknown = {}
+
+        psbt = MockPSBT()
+        # Invalid: only 3 bytes
+        psbt.unknown[bytes([PSBT_GLOBAL_VERSION])] = b'\x02\x00\x00'
+
+        assert get_psbt_version(psbt) == 0

--- a/tests/test_silent_payments.py
+++ b/tests/test_silent_payments.py
@@ -304,3 +304,128 @@ class TestIsEligibleInput(BaseTest):
         # - P2PKH, P2WPKH, P2SH-P2WPKH, P2TR (key path) are eligible
         # - Multisig and P2TR script path are NOT eligible
         pass
+
+
+class TestBIP375PSBTFields(BaseTest):
+    """Test BIP-375 PSBT field parsing."""
+
+    def test_psbt_field_constants(self):
+        """Verify BIP-375 field type constants match specification."""
+        from seedsigner.helpers.silent_payments import (
+            PSBT_GLOBAL_SP_ECDH_SHARE,
+            PSBT_GLOBAL_SP_DLEQ,
+            PSBT_IN_SP_ECDH_SHARE,
+            PSBT_IN_SP_DLEQ,
+            PSBT_OUT_SP_V0_INFO,
+        )
+
+        # Per BIP-375 specification
+        assert PSBT_GLOBAL_SP_ECDH_SHARE == 0x07
+        assert PSBT_GLOBAL_SP_DLEQ == 0x08
+        assert PSBT_IN_SP_ECDH_SHARE == 0x1d
+        assert PSBT_IN_SP_DLEQ == 0x1e
+        assert PSBT_OUT_SP_V0_INFO == 0x09
+
+    def test_has_bip375_fields_empty_psbt(self):
+        """Empty PSBT should not have BIP-375 fields."""
+        from seedsigner.helpers.silent_payments import has_bip375_sp_fields
+        from embit.psbt import PSBT
+
+        psbt = PSBT()
+        assert has_bip375_sp_fields(psbt) == False
+
+    def test_extract_sp_info_none_when_missing(self):
+        """Should return None when no SP info in output."""
+        from seedsigner.helpers.silent_payments import extract_sp_info_from_output
+        from embit.psbt import OutputScope
+
+        out = OutputScope()
+        result = extract_sp_info_from_output(out)
+        assert result is None
+
+
+class TestBIP374DLEQ(BaseTest):
+    """Test BIP-374 DLEQ proof verification."""
+
+    def test_dleq_proof_structure(self):
+        """Test DLEQ proof must be 64 bytes."""
+        from seedsigner.helpers.silent_payments import verify_dleq_proof
+
+        # Valid compressed pubkeys for test
+        A = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+        B = unhexlify("03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792")
+        C = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+
+        # Wrong length proof should fail
+        bad_proof = b'\x00' * 63
+        assert verify_dleq_proof(A, B, C, bad_proof) == False
+
+        bad_proof = b'\x00' * 65
+        assert verify_dleq_proof(A, B, C, bad_proof) == False
+
+    def test_dleq_invalid_s_value(self):
+        """DLEQ proof with s >= curve order should fail."""
+        from seedsigner.helpers.silent_payments import verify_dleq_proof, SECP256K1_ORDER
+
+        A = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+        B = unhexlify("03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792")
+        C = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+
+        # Create proof with s = curve order (invalid)
+        e = b'\x00' * 32
+        s = SECP256K1_ORDER.to_bytes(32, 'big')
+        invalid_proof = e + s
+
+        assert verify_dleq_proof(A, B, C, invalid_proof) == False
+
+
+class TestSPAddressEncode(BaseTest):
+    """Test Silent Payment address encoding."""
+
+    def test_encode_roundtrip(self):
+        """Encoding then decoding should return original keys."""
+        from seedsigner.helpers.silent_payments import (
+            parse_silent_payment_address,
+            encode_silent_payment_address,
+        )
+
+        # Known test keys
+        B_scan = unhexlify("0220bcfac5b99e04ad1a06ddfb016ee13582609d60b6291e98d01a9bc9a16c96d4")
+        B_spend = unhexlify("025cc9856d6f8375350e123978daac200c260cb5b5ae83106cab90484dcd8fcf36")
+
+        # Encode to address
+        address = encode_silent_payment_address(B_scan, B_spend, "mainnet")
+
+        # Should start with sp1
+        assert address.startswith("sp1")
+
+        # Decode back
+        decoded_scan, decoded_spend, network = parse_silent_payment_address(address)
+
+        assert decoded_scan == B_scan
+        assert decoded_spend == B_spend
+        assert network == "mainnet"
+
+    def test_encode_testnet(self):
+        """Testnet addresses should use tsp1 prefix."""
+        from seedsigner.helpers.silent_payments import encode_silent_payment_address
+
+        B_scan = unhexlify("0220bcfac5b99e04ad1a06ddfb016ee13582609d60b6291e98d01a9bc9a16c96d4")
+        B_spend = unhexlify("025cc9856d6f8375350e123978daac200c260cb5b5ae83106cab90484dcd8fcf36")
+
+        address = encode_silent_payment_address(B_scan, B_spend, "testnet")
+        assert address.startswith("tsp1")
+
+    def test_encode_matches_known_address(self):
+        """Encoding known keys should produce known address."""
+        from seedsigner.helpers.silent_payments import encode_silent_payment_address
+
+        # From test vector
+        B_scan = unhexlify("0220bcfac5b99e04ad1a06ddfb016ee13582609d60b6291e98d01a9bc9a16c96d4")
+        B_spend = unhexlify("025cc9856d6f8375350e123978daac200c260cb5b5ae83106cab90484dcd8fcf36")
+
+        address = encode_silent_payment_address(B_scan, B_spend, "mainnet")
+
+        # Should match the known test vector address
+        expected = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+        assert address == expected

--- a/tests/test_silent_payments.py
+++ b/tests/test_silent_payments.py
@@ -1,0 +1,306 @@
+"""
+Tests for BIP-352 Silent Payments implementation.
+
+Uses official test vectors from:
+https://github.com/bitcoin/bips/blob/master/bip-0352/send_and_receive_test_vectors.json
+"""
+
+import pytest
+from binascii import unhexlify
+
+from tests.base import BaseTest
+
+
+class TestBech32mDecode(BaseTest):
+    """Test Bech32m decoding for SP addresses."""
+
+    def test_mainnet_address_basic(self):
+        """Parse a mainnet SP address and extract components."""
+        from seedsigner.helpers.silent_payments import parse_silent_payment_address
+
+        # Known test vector SP address
+        address = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+
+        B_scan, B_spend, network = parse_silent_payment_address(address)
+
+        assert network == "mainnet"
+        assert len(B_scan) == 33
+        assert len(B_spend) == 33
+        # Verify they're valid compressed pubkeys
+        assert B_scan[0] in (0x02, 0x03)
+        assert B_spend[0] in (0x02, 0x03)
+
+    def test_mainnet_address_known_keys(self):
+        """Verify extracted keys match expected values."""
+        from seedsigner.helpers.silent_payments import parse_silent_payment_address
+
+        address = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+
+        B_scan, B_spend, network = parse_silent_payment_address(address)
+
+        # From test vectors
+        expected_scan = unhexlify("0220bcfac5b99e04ad1a06ddfb016ee13582609d60b6291e98d01a9bc9a16c96d4")
+        expected_spend = unhexlify("025cc9856d6f8375350e123978daac200c260cb5b5ae83106cab90484dcd8fcf36")
+
+        assert B_scan == expected_scan
+        assert B_spend == expected_spend
+
+    def test_invalid_checksum(self):
+        """Invalid checksum should raise ValueError."""
+        from seedsigner.helpers.silent_payments import parse_silent_payment_address
+
+        # Changed last valid character to corrupt checksum
+        address = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwa"
+
+        with pytest.raises(ValueError, match="Invalid checksum"):
+            parse_silent_payment_address(address)
+
+    def test_invalid_hrp(self):
+        """Non-SP HRP should raise ValueError."""
+        from seedsigner.helpers.silent_payments import parse_silent_payment_address
+
+        # bc1 is a regular bech32 address, not SP
+        # Note: bc1 uses bech32 (not bech32m) so it fails checksum first
+        with pytest.raises(ValueError, match="Invalid checksum"):
+            parse_silent_payment_address("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+
+    def test_testnet_hrp(self):
+        """Testnet addresses should be recognized."""
+        from seedsigner.helpers.silent_payments import bech32m_decode
+
+        # Test that sp prefix is valid
+        hrp, _ = bech32m_decode("sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv")
+        assert hrp == "sp"
+
+
+class TestTaggedHash(BaseTest):
+    """Test BIP-340 tagged hash implementation."""
+
+    def test_tagged_hash_deterministic(self):
+        """Same inputs should produce same outputs."""
+        from seedsigner.helpers.silent_payments import tagged_hash
+
+        data = b"test data"
+        result1 = tagged_hash("BIP0352/Inputs", data)
+        result2 = tagged_hash("BIP0352/Inputs", data)
+
+        assert result1 == result2
+        assert len(result1) == 32
+
+    def test_different_tags_different_output(self):
+        """Different tags should produce different hashes."""
+        from seedsigner.helpers.silent_payments import tagged_hash
+
+        data = b"test data"
+        result1 = tagged_hash("BIP0352/Inputs", data)
+        result2 = tagged_hash("BIP0352/SharedSecret", data)
+
+        assert result1 != result2
+
+
+class TestSumPublicKeys(BaseTest):
+    """Test public key summation."""
+
+    def test_sum_single_key(self):
+        """Summing a single key should return the same key."""
+        from seedsigner.helpers.silent_payments import sum_public_keys
+
+        pubkey = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+        result = sum_public_keys([pubkey])
+
+        assert result == pubkey
+
+    def test_sum_two_keys(self):
+        """Sum of two different pubkeys should produce a valid pubkey."""
+        from seedsigner.helpers.silent_payments import sum_public_keys
+
+        pk1 = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+        pk2 = unhexlify("03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792")
+
+        result = sum_public_keys([pk1, pk2])
+
+        # Result should be a valid 33-byte compressed pubkey
+        assert len(result) == 33
+        assert result[0] in (0x02, 0x03)
+        # Result should be different from both inputs
+        assert result != pk1
+        assert result != pk2
+
+    def test_sum_empty_raises(self):
+        """Empty list should raise ValueError."""
+        from seedsigner.helpers.silent_payments import sum_public_keys
+
+        with pytest.raises(ValueError, match="Cannot sum empty"):
+            sum_public_keys([])
+
+
+class TestComputeSPOutputPubkey(BaseTest):
+    """Test the core BIP-352 output pubkey computation."""
+
+    def test_simple_send_two_inputs(self):
+        """
+        Test Case 1 from BIP-352 test vectors:
+        Simple send with two P2PKH inputs
+        """
+        from seedsigner.helpers.silent_payments import (
+            compute_sp_output_pubkey,
+            parse_silent_payment_address,
+            full_to_xonly_pubkey,
+        )
+        from embit import ec
+
+        # Input private keys (from test vector)
+        privkey1 = unhexlify("eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1")
+        privkey2 = unhexlify("93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16")
+
+        # Derive public keys from private keys
+        pk1 = ec.PrivateKey(privkey1).get_public_key().sec()
+        pk2 = ec.PrivateKey(privkey2).get_public_key().sec()
+
+        # Recipient SP address
+        sp_address = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+        B_scan, B_spend, _ = parse_silent_payment_address(sp_address)
+
+        # Construct smallest outpoint (from test vector)
+        # txid must be little-endian
+        txid1 = unhexlify("f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16")[::-1]
+        vout1 = (0).to_bytes(4, 'little')
+        txid2 = unhexlify("a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d")[::-1]
+        vout2 = (0).to_bytes(4, 'little')
+
+        # Find smallest outpoint
+        outpoint1 = txid1 + vout1
+        outpoint2 = txid2 + vout2
+        smallest_outpoint = min(outpoint1, outpoint2)
+
+        # Compute output pubkey
+        input_privkeys = [(privkey1, False), (privkey2, False)]  # P2PKH, not taproot
+        input_pubkeys = [pk1, pk2]
+
+        result = compute_sp_output_pubkey(
+            input_privkeys,
+            input_pubkeys,
+            B_scan,
+            B_spend,
+            smallest_outpoint,
+            output_index=0
+        )
+
+        # Expected output (x-only, from test vector)
+        expected_xonly = unhexlify("3e9fce73d4e77a4809908e3c3a2e54ee147b9312dc5044a193d1fc85de46e3c1")
+
+        # Convert result to x-only for comparison
+        result_xonly, _ = full_to_xonly_pubkey(result)
+
+        assert result_xonly == expected_xonly
+
+    def test_two_inputs_same_tx_different_vout(self):
+        """
+        Test Case 3: Two inputs from same transaction (different vout)
+        This tests that the smallest outpoint logic works correctly with vout comparison.
+        """
+        from seedsigner.helpers.silent_payments import (
+            compute_sp_output_pubkey,
+            parse_silent_payment_address,
+            full_to_xonly_pubkey,
+        )
+        from embit import ec
+
+        # Input private keys
+        privkey1 = unhexlify("eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1")
+        privkey2 = unhexlify("93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16")
+
+        pk1 = ec.PrivateKey(privkey1).get_public_key().sec()
+        pk2 = ec.PrivateKey(privkey2).get_public_key().sec()
+
+        # Same SP address
+        sp_address = "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+        B_scan, B_spend, _ = parse_silent_payment_address(sp_address)
+
+        # Both inputs from same txid but different vouts (3 and 7)
+        txid = unhexlify("f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16")[::-1]
+        vout1 = (3).to_bytes(4, 'little')
+        vout2 = (7).to_bytes(4, 'little')
+
+        outpoint1 = txid + vout1
+        outpoint2 = txid + vout2
+        smallest_outpoint = min(outpoint1, outpoint2)  # vout=3 should be smaller
+
+        input_privkeys = [(privkey1, False), (privkey2, False)]
+        input_pubkeys = [pk1, pk2]
+
+        result = compute_sp_output_pubkey(
+            input_privkeys,
+            input_pubkeys,
+            B_scan,
+            B_spend,
+            smallest_outpoint,
+            output_index=0
+        )
+
+        # Expected output from test vector
+        expected_xonly = unhexlify("79e71baa2ba3fc66396de3a04f168c7bf24d6870ec88ca877754790c1db357b6")
+
+        result_xonly, _ = full_to_xonly_pubkey(result)
+
+        assert result_xonly == expected_xonly
+
+
+class TestXOnlyConversion(BaseTest):
+    """Test x-only pubkey conversion utilities."""
+
+    def test_full_to_xonly_even(self):
+        """Convert compressed pubkey with even Y to x-only."""
+        from seedsigner.helpers.silent_payments import full_to_xonly_pubkey
+
+        # Even Y (0x02 prefix)
+        full = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+        xonly, parity = full_to_xonly_pubkey(full)
+
+        assert len(xonly) == 32
+        assert parity == 0
+        assert xonly == full[1:]
+
+    def test_full_to_xonly_odd(self):
+        """Convert compressed pubkey with odd Y to x-only."""
+        from seedsigner.helpers.silent_payments import full_to_xonly_pubkey
+
+        # Odd Y (0x03 prefix)
+        full = unhexlify("03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792")
+        xonly, parity = full_to_xonly_pubkey(full)
+
+        assert len(xonly) == 32
+        assert parity == 1
+        assert xonly == full[1:]
+
+    def test_xonly_to_full(self):
+        """Convert x-only back to full compressed pubkey."""
+        from seedsigner.helpers.silent_payments import xonly_to_full_pubkey, full_to_xonly_pubkey
+
+        original = unhexlify("025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5")
+        xonly, parity = full_to_xonly_pubkey(original)
+        restored = xonly_to_full_pubkey(xonly, parity)
+
+        assert restored == original
+
+    def test_roundtrip_odd(self):
+        """Roundtrip conversion with odd Y."""
+        from seedsigner.helpers.silent_payments import xonly_to_full_pubkey, full_to_xonly_pubkey
+
+        original = unhexlify("03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792")
+        xonly, parity = full_to_xonly_pubkey(original)
+        restored = xonly_to_full_pubkey(xonly, parity)
+
+        assert restored == original
+
+
+class TestIsEligibleInput(BaseTest):
+    """Test input eligibility checking."""
+
+    def test_eligible_requirements(self):
+        """Document the eligibility requirements."""
+        # This is more of a documentation test
+        # Per BIP-352:
+        # - P2PKH, P2WPKH, P2SH-P2WPKH, P2TR (key path) are eligible
+        # - Multisig and P2TR script path are NOT eligible
+        pass


### PR DESCRIPTION
Addresses #569 (Silent Payments bounty)

## Description

Adds full Silent Payments send support, enabling SeedSigner to sign transactions to `sp1...` addresses while verifying the output derivation is correct.

**Key features:**
- **BIP-352 Silent Payments**: Parse, display, and verify `sp1...`/`tsp1...` addresses
- **BIP-375 PSBT support**: Full support for SP PSBT fields (PSBT_OUT_SP_V0_INFO, PSBT_GLOBAL_SP_ECDH_SHARE, PSBT_GLOBAL_SP_DLEQ)
- **BIP-374 DLEQ proofs**: Cryptographic verification that ECDH shared secret was computed correctly
- **Two verification workflows**:
      1. **Automatic (BIP-375)**: Coordinator includes proof data in PSBT → SeedSigner verifies via DLEQ
      2. **Manual**: User scans SP address first → SeedSigner re-derives and verifies the output
- **Dual verification**: When both methods are available, both are checked

**Why this matters:**
Without this, users see only a random `bc1p...` address with no way to confirm it corresponds to their intended `sp1...` recipient. Buggy, compromised, or MITM-attacked wallet software could substitute a different address. SeedSigner now independently verifies the derivation before signing.

**Demo video:**

https://github.com/user-attachments/assets/b077e300-2301-4e10-a6c9-1abb18adbae3

**Test tool:** https://github.com/FreeOnlineUser/bip375-test-tools
Generates valid BIP-375 PSBTs with fake inputs for testing the complete signing flow.

## Files Changed

- `src/seedsigner/helpers/silent_payments.py` - Core SP/DLEQ implementation
- `src/seedsigner/models/psbt_parser.py` - BIP-375 field extraction and verification
- `src/seedsigner/models/decode_qr.py` - SP address QR decoding
- `src/seedsigner/views/scan_views.py` - SP address scanning flow
- `src/seedsigner/views/psbt_views.py` - Display verified SP addresses
- `src/seedsigner/gui/screens/psbt_screens.py` - UI for SP verification status
- `docs/silent_payments.md` - User documentation
- `tests/test_silent_payments.py` - Comprehensive test suite

## Related BIPs

- [BIP-352: Silent Payments](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)
- [BIP-374: DLEQ Proofs](https://github.com/bitcoin/bips/blob/master/bip-0374.mediawiki)
- [BIP-375: Sending Silent Payments with PSBTs](https://github.com/bitcoin/bips/blob/master/bip-0375.mediawiki)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I've run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other
