### PR TITLE
fix(l10n): mark missing strings for translation

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -1,14 +1,14 @@
 # Translations template for seedsigner.
-# Copyright (C) 2025 ORGANIZATION
+# Copyright (C) 2026 ORGANIZATION
 # This file is distributed under the same license as the seedsigner project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-14 05:46-0600\n"
+"POT-Creation-Date: 2026-02-16 21:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,19 +141,21 @@ msgstr[1] ""
 msgid "{} change"
 msgstr ""
 
+#. Describes the address type (change or receive)
 #: src/seedsigner/gui/screens/psbt_screens.py
-#: src/seedsigner/models/settings_definition.py
-#: src/seedsigner/views/seed_views.py
-msgid "Multisig"
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "change address"
 msgstr ""
 
+#. Describes the address type (change or receive)
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Change"
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "receive address"
 msgstr ""
 
-#. Abbreviation for receive address
+#. Symbol for index number, e.g. "address #3"
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Addr"
+msgid "#"
 msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
@@ -238,14 +240,6 @@ msgid ""
 msgstr ""
 
 #: src/seedsigner/gui/screens/screen.py
-msgid "Powering Off"
-msgstr ""
-
-#: src/seedsigner/gui/screens/screen.py
-msgid "Please wait about 30 seconds before disconnecting power."
-msgstr ""
-
-#: src/seedsigner/gui/screens/screen.py
 msgid "Just Unplug It"
 msgstr ""
 
@@ -262,17 +256,6 @@ msgstr ""
 #: src/seedsigner/gui/screens/tools_screens.py
 #: src/seedsigner/views/seed_views.py
 msgid "fingerprint"
-msgstr ""
-
-#: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/seed_views.py
-msgid "Backup Seed"
-msgstr ""
-
-#. Additional explainer for the two seed backup options (mnemonic phrase and
-#. SeedQR).
-#: src/seedsigner/gui/screens/seed_screens.py
-msgid "Backups do not include your passphrase."
 msgstr ""
 
 #. Displays the page number and total: (e.g. page 1 of 6)
@@ -390,16 +373,6 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Address Verified"
-msgstr ""
-
-#. Describes the address type (change or receive)
-#: src/seedsigner/gui/screens/seed_screens.py
-msgid "change address"
-msgstr ""
-
-#. Describes the address type (change or receive)
-#: src/seedsigner/gui/screens/seed_screens.py
-msgid "receive address"
 msgstr ""
 
 #. Describes the address index (e.g. "index 7")
@@ -597,10 +570,6 @@ msgstr ""
 msgid "Next {}"
 msgstr ""
 
-#: src/seedsigner/hardware/camera.py
-msgid "Camera error. Check camera connections."
-msgstr ""
-
 #: src/seedsigner/models/settings_definition.py
 msgid "Enabled"
 msgstr ""
@@ -701,6 +670,11 @@ msgid "Single Sig"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
+#: src/seedsigner/views/seed_views.py
+msgid "Multisig"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
 msgid "Native Segwit"
 msgstr ""
 
@@ -718,6 +692,17 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Custom Derivation"
+msgstr ""
+
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr ""
+
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
 msgstr ""
 
 #. Terminology used by Electrum seeds; equivalent to BIP-39 passphrase
@@ -747,10 +732,6 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "QR code density"
-msgstr ""
-
-#: src/seedsigner/models/settings_definition.py
-msgid "Xpub export"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
@@ -791,6 +772,10 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Native Segwit only"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
@@ -917,7 +902,7 @@ msgid "Self-Transfer"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Verify Multisig Addr"
+msgid "Verify multisig addr"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
@@ -955,7 +940,7 @@ msgid "Approve transaction"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Select diff seed"
+msgid "Select different seed"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
@@ -1068,7 +1053,7 @@ msgid "Create a seed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Load A Seed"
+msgid "Load a Seed"
 msgstr ""
 
 #. Inserts the word number (e.g. "Seed Word #6")
@@ -1138,7 +1123,7 @@ msgid "Discard Seed?"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Electrum warning"
+msgid "Electrum Warning"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1147,10 +1132,6 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Scan transaction"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Verify addr"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
@@ -1175,6 +1156,10 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Export as SeedQR"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Backup Seed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1352,6 +1337,10 @@ msgid "Return to transaction"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+msgid "Verify addr"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
 msgid "Signing messages for custom derivation paths not supported"
 msgstr ""
 
@@ -1369,6 +1358,24 @@ msgstr ""
 
 #: src/seedsigner/views/settings_views.py
 msgid "Dev Options"
+msgstr ""
+
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr ""
+
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr ""
+
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
 msgstr ""
 
 #: src/seedsigner/views/settings_views.py
@@ -1404,7 +1411,7 @@ msgid "24 words"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
-msgid "Mnemonic Length?"
+msgid "Mnemonic Length"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
@@ -1419,10 +1426,6 @@ msgstr ""
 #. Inserts the number of dice rolls needed for a 24-word mnemonic
 #: src/seedsigner/views/tools_views.py
 msgid "24 words ({} rolls)"
-msgstr ""
-
-#: src/seedsigner/views/tools_views.py
-msgid "Mnemonic Length"
 msgstr ""
 
 #. Label to gather entropy through coin tosses
@@ -1531,9 +1534,9 @@ msgstr ""
 msgid "Change Setting"
 msgstr ""
 
-#. Inserts mainnet/testnet/regtest and derivation path
+#. "network" will be mainnet/testnet/regtest.
 #: src/seedsigner/views/view.py
-msgid "Current network setting ({}) doesn't match {}."
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
 msgstr ""
 
 #: src/seedsigner/views/view.py

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -299,7 +299,9 @@ class SettingsConstants:
     MICROSD_TOAST_TIMER_FOREVER = "inf"
     ALL_MICROSD_TOAST_TIMERS = [
         (MICROSD_TOAST_TIMER_DISABLED, _mft("Disabled")),
+        # TRANSLATOR_NOTE: MicroSD notification duration setting - Display notification for 5 seconds
         (MICROSD_TOAST_TIMER_FIVE_SECONDS, _mft("5 seconds")),
+        # TRANSLATOR_NOTE: MicroSD notification duration setting - Display notification until the SD card is removed
         (MICROSD_TOAST_TIMER_FOREVER, _mft("Until SD removed"))
     ]
 
@@ -670,7 +672,7 @@ class SettingsDefinition:
         
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__MICROSD_TOAST_TIMER,
-                      display_name=_mft("MicroSD toast timer"),
+                      display_name=_mft("MicroSD notification duration"),
                       type=SettingsConstants.TYPE__SELECT_1,
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.ALL_MICROSD_TOAST_TIMERS,

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -298,9 +298,9 @@ class SettingsConstants:
     MICROSD_TOAST_TIMER_FIVE_SECONDS = "E"
     MICROSD_TOAST_TIMER_FOREVER = "inf"
     ALL_MICROSD_TOAST_TIMERS = [
-        (MICROSD_TOAST_TIMER_DISABLED, "Disabled"),
-        (MICROSD_TOAST_TIMER_FIVE_SECONDS, "5 seconds"),
-        (MICROSD_TOAST_TIMER_FOREVER, "Until SD removed")
+        (MICROSD_TOAST_TIMER_DISABLED, _mft("Disabled")),
+        (MICROSD_TOAST_TIMER_FIVE_SECONDS, _mft("5 seconds")),
+        (MICROSD_TOAST_TIMER_FOREVER, _mft("Until SD removed"))
     ]
 
     WORDLIST_LANGUAGE__ENGLISH = "en"
@@ -670,7 +670,7 @@ class SettingsDefinition:
         
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__MICROSD_TOAST_TIMER,
-                      display_name="MicroSD toast timer",
+                      display_name=_mft("MicroSD toast timer"),
                       type=SettingsConstants.TYPE__SELECT_1,
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.ALL_MICROSD_TOAST_TIMERS,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -352,7 +352,7 @@ class NetworkMismatchErrorView(ErrorView):
 
         # TRANSLATOR_NOTE: Inserts mainnet/testnet/regtest and derivation path
         self.text = _("Current network setting ({}) doesn't match {}.").format(
-            self.settings.get_value_display_name(SettingsConstants.SETTING__NETWORK),
+            _(self.settings.get_value_display_name(SettingsConstants.SETTING__NETWORK)),
             self.derivation_path,
         )
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -350,10 +350,12 @@ class NetworkMismatchErrorView(ErrorView):
         self.next_destination = Destination(SettingsEntryUpdateSelectionView, view_args=dict(attr_name=SettingsConstants.SETTING__NETWORK), clear_history=True)
         super().__post_init__()
 
-        # TRANSLATOR_NOTE: Inserts mainnet/testnet/regtest and derivation path
-        self.text = _("Current network setting ({}) doesn't match {}.").format(
-            _(self.settings.get_value_display_name(SettingsConstants.SETTING__NETWORK)),
-            self.derivation_path,
+        network = _(self.settings.get_value_display_name(SettingsConstants.SETTING__NETWORK))
+
+        # TRANSLATOR_NOTE: "network" will be mainnet/testnet/regtest.
+        self.text = _("Current network setting ({network}) doesn't match {derivation_path}.").format(
+            network=network,
+            derivation_path=self.derivation_path,
         )
 
 


### PR DESCRIPTION
## Description

This PR marks previously unmarked user facing strings for translation. I noticed these issues while reviewing the Hindi translations in https://github.com/SeedSigner/seedsigner-translations/pull/54.

### Summary of Changes

- Rename "MicroSD toast timer" to "MicroSD notification duration" for a better UX
- Mark MicroSD toast timer related settings constants with `_mft()` so they are included in translation extraction
- Wrap the network setting display value with `gettext` (`_()`) in `NetworkMismatchErrorView`
- Update `messages.pot` to include these strings, along with other recent changes already merged into `dev`

### Screens affected (Hindi screenshots)

#### Missing strings in MicroSD Toast Timer (now, "MicroSD notification duration")
<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/c79f7378-d887-489f-90d3-24d45c1e58df" />


#### NetworkMismatchErrorView

Before: Network value rendered without translation
<img width="240" height="240" alt="NetworkMismatchErrorView" src="https://github.com/user-attachments/assets/1a92dd5e-fb4a-4fc7-9ebc-51fcca145127" />

After: Network value correctly translated
<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/c5f30b4f-db68-430d-b0f4-c05b3258c23c" />

---

This pull request is categorized as a:

- [x] Bug fix (`l10n`)

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Other (Screenshot Generator)
