### PR TITLE
Bump Pillow version to 10.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 embit==0.8.0
-Pillow==10.0.1
+Pillow==10.3.0
 pyzbar @ git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03
 qrcode==7.3.1
 urtypes==1.0.1


### PR DESCRIPTION
## Description

Fixes #870.

Pillow 10.0.1 is currently used in the SeedSigner dev environment, which is affected by [CVE-2024-28219](https://github.com/advisories/GHSA-44wm-f244-xhp3), but SeedSigner-OS repo [points to Pillow 10.3.0](https://github.com/SeedSigner/seedsigner-os/blob/main/opt/external-packages/python-pillow-ep/python-pillow_ep.mk).

This PR is a simple change to bump the Pillow version in our repo to match the version SeedSigner-OS uses since PR https://github.com/SeedSigner/seedsigner-os/pull/95 got merged.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other

