### PR TITLE
Update the PR template: Set more explicit expectations re: tests, our slow pace, "@" mentions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,16 @@
 ## Description
 
-_Describe the change simply. Provide a reason for the change._
+<i>
 
-_Include screenshots of any new or modified screens (or at least explain why they were omitted)_
+* What is the problem or issue you're addressing here?
+  * Include any relevant background info, links to resources, BIPs, etc.
+* What is your solution?
+  * Include key tech details to help reviewers understand your changes and rationale.
+* Any tradeoffs to discuss, follow-up steps, etc?
+
+</i>
+
+---
 
 This pull request is categorized as a:
 
@@ -12,21 +20,45 @@ This pull request is categorized as a:
 - [ ] Documentation
 - [ ] Other
 
+---
+
 ## Checklist
 
-- [ ] I’ve run `pytest` and made sure all unit tests pass before submitting the PR
-
-If you modified or added functionality/workflow, did you add new unit tests?
-
-- [ ] No, I’m a fool
-- [ ] Yes
+<b>I ran `pytest` locally</b>
+- [ ] All tests passed before submitting the PR
+- [ ] I couldn't run the tests
 - [ ] N/A
 
-I have tested this PR on the following platforms/os:
 
+<b>I included screenshots of any new or modified screens</b>
+Should be part of the PR description above.
+- [ ] Yes
+- [ ] No (explain why they were omitted)
+- [ ] N/A
+
+
+<b>I added or updated tests</b>
+Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
+- [ ] Yes
+- [ ] No, I’m a fool
+- [ ] N/A
+
+
+<b>I tested this PR hands-on on the following platform(s):</b>
 - [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
 - [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
-- [ ] Other
+- [ ] Emulator
 
 
-Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
+<b>I have reviewed these notes:</b>
+* Keep your changes limited in scope.
+* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
+* The more complicated the PR, the harder it is to review, test, and merge.
+* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
+* Please only "@" mention a contributor if their input is truly needed to enable further progress.
+
+- [ ] I understand
+
+---
+
+Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,31 @@
 ## Description
 
-<i>
+### Problem or Issue being addressed
 
-* What is the problem or issue you're addressing here?
-  * Include any relevant background info, links to resources, BIPs, etc.
-* What is your solution?
-  * Include key tech details to help reviewers understand your changes and rationale.
-* Any tradeoffs to discuss, follow-up steps, etc?
+<!--
+Describe the problem this PR solves.
+Include background context, links to relevant issues, BIPs, discussions, etc.
+-->
 
-</i>
+### Solution
+
+<!--
+Describe your approach and key technical implementation details.
+Explain why this approach was chosen.
+-->
+
+### Additional Information
+
+<!--
+Tradeoffs, follow-ups, limitations, or anything reviewers should be aware of.
+-->
+
+### Screenshots
+
+<!--
+Include screenshots for any new or modified screens.
+If omitted, explain why.
+-->
 
 ---
 
@@ -24,33 +41,39 @@ This pull request is categorized as a:
 
 ## Checklist
 
-<b>I ran `pytest` locally</b>
+#### I ran `pytest` locally
 - [ ] All tests passed before submitting the PR
 - [ ] I couldn't run the tests
 - [ ] N/A
 
+---
 
-<b>I included screenshots of any new or modified screens</b>
+#### I included screenshots of any new or modified screens
+
 Should be part of the PR description above.
 - [ ] Yes
-- [ ] No (explain why they were omitted)
+- [ ] No
 - [ ] N/A
 
+---
 
-<b>I added or updated tests</b>
+#### I added or updated tests
+
 Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
 - [ ] Yes
 - [ ] No, I’m a fool
 - [ ] N/A
 
+---
 
-<b>I tested this PR hands-on on the following platform(s):</b>
-- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
+#### I tested this PR hands-on on the following platform(s):
+- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
 - [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
 - [ ] Emulator
 
+---
 
-<b>I have reviewed these notes:</b>
+#### I have reviewed these notes:
 * Keep your changes limited in scope.
 * If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
 * The more complicated the PR, the harder it is to review, test, and merge.


### PR DESCRIPTION
## Description

Goal is to evolve the PR template to be a bit more explicit about our expectations, esp around new tests. I've also found that I sort of disagree with the original instruction to "Describe the change simply" and would instead aim for "Describe the change thoroughly." So I provided a more detailed outline.

Reformatted the checklist for consistency (and obv my own kind of fussiness).

More detailed notes section at the end with a new "I understand" checkbox to try to do a better job of setting expectations (we're SLOW!) and also establish my opinionated preferred etiquette with respect to "@" mentioning contributors for their attention.

That is a particular pet peeve of mine* and it's fair to say that I haven't always communicated that point as effectively / patiently / humanely as I should have. "Tough love" for devs who already know me because we're actively talking on telegram is one thing, but being that way with a complete stranger, devoid of any context isn't great.

Including this in the notes provides a "tap the sign" point of reference that can be highlighted with less bile.

And at the bottom, the link to join our Devs' Telegram group provides another outlet for contributors who feel like their progress is stuck or being ignored.

---

_*(Why do I feel so strongly about it? I feel it in myself how limited my attention and quality focus time can be. I want our contributors to be able to invest their focus on the PRs that they deem most interesting or important. Even taking 10-20 min to triage random requests for your time burns some of that precious, limited resource. I've also felt myself shut down a bit when too much of it piles up. If I can't respond to everyone... I'll respond to... no one?)_

---

This pull request is categorized as a:
- [x] Documentation
- [x] Other

## Checklist
`pytest` N/A

If you modified or added functionality/workflow, did you add new unit tests?
- [x] N/A

I have tested this PR on the following platforms/os:
N/A