### PR TITLE
[Screenshot] Update `IOTestScreen` to preserve "Clear" button for Screenshot Renderer

### DIFF
--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -144,7 +144,11 @@ class IOTestScreen(BaseTopNavScreen):
             outline_color=GUIConstants.ACCENT_COLOR,
             is_scrollable_text=False,  # Text has to dynamically update, can't use scrollable Button
         )
-        self.key2_button.text = " "  # but default state is empty
+        if not self.renderer.is_screenshot_generator:
+            # The button text should be empty for its initial state ("Clear" doesn't make
+            # any sense until a test image is captured). But the screenshot generator
+            # should show the text so its translation can be reviewed.
+            self.key2_button.text = " "
         self.components.append(self.key2_button)
 
         self.key1_button = IconButton(


### PR DESCRIPTION
## Description
This PR improves the IO Test Screenshot to show the "Clear" text on the button (Key 2).

Currently, the button remains blank because the screen is set up to show "Clear" only after an image is captured. However, [as noted by](https://t.me/seedsigner_new_devs/15639) @kdmukai, 'seeing the "Clear" text has an impact on reviewing if the translation fits the small box'.

### Implementation
- Added a condition in `IOTestScreen` to stop blanking out the text for the screenshot renderer

### Screenshots
#### Before:
<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/1daa729c-3e2a-4a93-b5fd-45db32955c1b" />

#### After:
<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/47b9cd87-260d-47d4-9ce2-4887fe841263" />

---

This pull request is categorized as a:

- [x] Code Refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] Other (Screenshot Generator)
