### PR TITLE
[Screenshot] Improve IOTestScreen to preserve "Clear" button

### DIFF
--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -144,7 +144,6 @@ class IOTestScreen(BaseTopNavScreen):
             outline_color=GUIConstants.ACCENT_COLOR,
             is_scrollable_text=False,  # Text has to dynamically update, can't use scrollable Button
         )
-        self.key2_button.text = " "  # but default state is empty
         self.components.append(self.key2_button)
 
         self.key1_button = IconButton(
@@ -179,6 +178,7 @@ class IOTestScreen(BaseTopNavScreen):
             height=msg_height,
             screen_y=int((self.canvas_height - msg_height)/ 2),
         )
+        self.key2_button.text = " "  # Default to blank; only show "Clear" after a camera capture
         while True:
             input = self.hw_inputs.wait_for(keys=HardwareButtonsConstants.ALL_KEYS)
 


### PR DESCRIPTION
## Description

This PR improves the IO Test Screenshot to show the "Clear" text on the button (Key 2).

The button text was being blanked in `__post_init__`, so the screenshot generator always rendered it empty. However, [as noted by](https://t.me/seedsigner_new_devs/15639) @kdmukai, 'seeing the "Clear" text has an impact on reviewing if the translation fits the small box'.

### Implementation
- Moved the `key2_button.text = " "` reset from `__post_init__` to `_run()`, so the screenshot captures the "Clear" text while the runtime behavior remains unchanged.

I originally implemented this improvement in #879, but quickly realised this approach is significantly cleaner.

### Screenshots
#### Before:
<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/1daa729c-3e2a-4a93-b5fd-45db32955c1b" />

#### After:
<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/47b9cd87-260d-47d4-9ce2-4887fe841263" />

---

This pull request is categorized as a:

- [x] Code refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [x] Other (Screenshot Generator)
