### PR TITLE
[Feature] Import legacy AES-256 encrypted seed backups via QR code

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -658,7 +658,8 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
 
 
     def __post_init__(self):
-        self.title = _("BIP-39 Passphrase")
+        if not self.title or self.title == "Screen Title":
+            self.title = _("BIP-39 Passphrase")
         super().__post_init__()
 
         keys_lower = "abcdefghijklmnopqrstuvwxyz"

--- a/src/seedsigner/helpers/aes_decrypt.py
+++ b/src/seedsigner/helpers/aes_decrypt.py
@@ -1,0 +1,225 @@
+import base64
+import hashlib
+import struct
+
+
+class DecryptionError(Exception):
+    """Raised for any decryption failure (bad passphrase, corrupt data, padding error, etc.)."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Minimal pure-Python AES-256-CBC decryption (no external dependencies).
+#
+# Only decryption is implemented — encryption is not needed.  Lookup tables
+# are precomputed at import time to avoid per-byte GF(2^8) multiplication
+# in the hot loop (important on Pi Zero).
+# ---------------------------------------------------------------------------
+
+# AES S-box
+_SBOX = (
+    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16,
+)
+
+# Inverse S-box (for decryption)
+_INV_SBOX = tuple(_SBOX.index(i) for i in range(256))
+
+# Round constants
+_RCON = (0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80,0x1b,0x36)
+
+
+def _gmul(a, b):
+    """Galois field multiplication in GF(2^8)."""
+    p = 0
+    for _ in range(8):
+        if b & 1:
+            p ^= a
+        hi = a & 0x80
+        a = (a << 1) & 0xff
+        if hi:
+            a ^= 0x1b
+        b >>= 1
+    return p
+
+
+# Precomputed multiplication tables for InvMixColumns constants.
+# Each table maps byte value (0-255) to its product with the constant.
+# This replaces per-byte _gmul calls in the hot loop with O(1) lookups.
+_MUL9  = tuple(_gmul(i, 0x09) for i in range(256))
+_MUL11 = tuple(_gmul(i, 0x0b) for i in range(256))
+_MUL13 = tuple(_gmul(i, 0x0d) for i in range(256))
+_MUL14 = tuple(_gmul(i, 0x0e) for i in range(256))
+
+
+def _key_expansion(key: bytes) -> list:
+    """Expand 256-bit key into 60 32-bit round key words."""
+    nk = 8  # AES-256: 8 words in key
+    nr = 14  # AES-256: 14 rounds
+    w = list(struct.unpack('>8I', key))
+    for i in range(nk, 4 * (nr + 1)):
+        t = w[i - 1]
+        if i % nk == 0:
+            # RotWord + SubWord + Rcon
+            t = ((t << 8) | (t >> 24)) & 0xffffffff
+            t = (_SBOX[(t >> 24) & 0xff] << 24 |
+                 _SBOX[(t >> 16) & 0xff] << 16 |
+                 _SBOX[(t >> 8) & 0xff] << 8 |
+                 _SBOX[t & 0xff])
+            t ^= _RCON[i // nk - 1] << 24
+        elif i % nk == 4:
+            t = (_SBOX[(t >> 24) & 0xff] << 24 |
+                 _SBOX[(t >> 16) & 0xff] << 16 |
+                 _SBOX[(t >> 8) & 0xff] << 8 |
+                 _SBOX[t & 0xff])
+        w.append(w[i - nk] ^ t)
+    return w
+
+
+def _inv_cipher_block(block: bytes, rk: list) -> bytes:
+    """Decrypt one 16-byte AES block (AES-256, 14 rounds)."""
+    nr = 14
+    s = list(block)
+
+    # AddRoundKey (round nr)
+    for c in range(4):
+        w = rk[nr * 4 + c]
+        s[c * 4 + 0] ^= (w >> 24) & 0xff
+        s[c * 4 + 1] ^= (w >> 16) & 0xff
+        s[c * 4 + 2] ^= (w >> 8) & 0xff
+        s[c * 4 + 3] ^= w & 0xff
+
+    for rnd in range(nr - 1, 0, -1):
+        # InvShiftRows
+        s[0*4+1], s[1*4+1], s[2*4+1], s[3*4+1] = s[3*4+1], s[0*4+1], s[1*4+1], s[2*4+1]
+        s[0*4+2], s[1*4+2], s[2*4+2], s[3*4+2] = s[2*4+2], s[3*4+2], s[0*4+2], s[1*4+2]
+        s[0*4+3], s[1*4+3], s[2*4+3], s[3*4+3] = s[1*4+3], s[2*4+3], s[3*4+3], s[0*4+3]
+
+        # InvSubBytes
+        s = [_INV_SBOX[b] for b in s]
+
+        # AddRoundKey
+        for c in range(4):
+            w = rk[rnd * 4 + c]
+            s[c * 4 + 0] ^= (w >> 24) & 0xff
+            s[c * 4 + 1] ^= (w >> 16) & 0xff
+            s[c * 4 + 2] ^= (w >> 8) & 0xff
+            s[c * 4 + 3] ^= w & 0xff
+
+        # InvMixColumns (using precomputed lookup tables)
+        ns = list(s)
+        for c in range(4):
+            i = c * 4
+            a0, a1, a2, a3 = s[i], s[i+1], s[i+2], s[i+3]
+            ns[i]   = _MUL14[a0] ^ _MUL11[a1] ^ _MUL13[a2] ^ _MUL9[a3]
+            ns[i+1] = _MUL9[a0]  ^ _MUL14[a1] ^ _MUL11[a2] ^ _MUL13[a3]
+            ns[i+2] = _MUL13[a0] ^ _MUL9[a1]  ^ _MUL14[a2] ^ _MUL11[a3]
+            ns[i+3] = _MUL11[a0] ^ _MUL13[a1] ^ _MUL9[a2]  ^ _MUL14[a3]
+        s = ns
+
+    # Final round (no InvMixColumns)
+    # InvShiftRows
+    s[0*4+1], s[1*4+1], s[2*4+1], s[3*4+1] = s[3*4+1], s[0*4+1], s[1*4+1], s[2*4+1]
+    s[0*4+2], s[1*4+2], s[2*4+2], s[3*4+2] = s[2*4+2], s[3*4+2], s[0*4+2], s[1*4+2]
+    s[0*4+3], s[1*4+3], s[2*4+3], s[3*4+3] = s[1*4+3], s[2*4+3], s[3*4+3], s[0*4+3]
+
+    # InvSubBytes
+    s = [_INV_SBOX[b] for b in s]
+
+    # AddRoundKey (round 0)
+    for c in range(4):
+        w = rk[c]
+        s[c * 4 + 0] ^= (w >> 24) & 0xff
+        s[c * 4 + 1] ^= (w >> 16) & 0xff
+        s[c * 4 + 2] ^= (w >> 8) & 0xff
+        s[c * 4 + 3] ^= w & 0xff
+
+    return bytes(s)
+
+
+def _aes256_cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
+    """AES-256-CBC decryption with PKCS#7 unpadding."""
+    rk = _key_expansion(key)
+    blocks = [ciphertext[i:i+16] for i in range(0, len(ciphertext), 16)]
+    plaintext = bytearray()
+    prev = iv
+    for block in blocks:
+        decrypted = _inv_cipher_block(block, rk)
+        plaintext.extend(b ^ p for b, p in zip(decrypted, prev))
+        prev = block
+
+    # PKCS#7 unpadding
+    if not plaintext:
+        raise DecryptionError("Empty plaintext")
+    pad_len = plaintext[-1]
+    if pad_len < 1 or pad_len > 16:
+        raise DecryptionError("Invalid PKCS#7 padding")
+    if plaintext[-pad_len:] != bytes([pad_len]) * pad_len:
+        raise DecryptionError("Invalid PKCS#7 padding")
+    return bytes(plaintext[:-pad_len])
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def decrypt_openssl_aes256cbc(data_b64: str, passphrase: str) -> str:
+    """
+    Decrypts OpenSSL-compatible AES-256-CBC data (base64, starts with "U2FsdGVkX1").
+    Matches: openssl enc -aes-256-cbc -pbkdf2 [-iter N] -base64
+
+    The PBKDF2 iteration count is not stored in the ciphertext, so we try
+    common values: 10 000 (OpenSSL default when -iter is omitted) and
+    100 000 (commonly recommended).  The first one that yields valid
+    PKCS#7 padding and UTF-8 plaintext wins.
+
+    Returns plaintext UTF-8 string (the mnemonic).
+    Raises DecryptionError on any failure.
+    """
+    try:
+        # 1. Base64-decode
+        data = base64.b64decode(data_b64.strip())
+
+        # 2. Verify magic header
+        if len(data) < 16 or data[:8] != b'Salted__':
+            raise DecryptionError("Invalid OpenSSL magic header (expected 'Salted__')")
+
+        # 3. Extract salt + ciphertext
+        salt = data[8:16]
+        ciphertext = data[16:]
+
+        if len(ciphertext) % 16 != 0:
+            raise DecryptionError("Ciphertext length not multiple of AES block size (16)")
+
+        # 4. Try PBKDF2 with common iteration counts
+        passphrase_bytes = passphrase.encode('utf-8')
+        for iterations in (10_000, 100_000):
+            try:
+                derived = hashlib.pbkdf2_hmac(
+                    'sha256', passphrase_bytes, salt, iterations, dklen=48
+                )
+                plaintext_bytes = _aes256_cbc_decrypt(derived[:32], derived[32:48], ciphertext)
+                return plaintext_bytes.decode('utf-8')
+            except (DecryptionError, UnicodeDecodeError):
+                continue
+
+        raise DecryptionError("Decryption failed for all supported iteration counts")
+
+    except Exception as e:
+        if isinstance(e, DecryptionError):
+            raise
+        raise DecryptionError(f"Decryption failed: {str(e)}") from e

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -80,7 +80,10 @@ class DecodeQR:
                 self.decoder = BBQRPsbtQrDecoder() # BBQr Decoder
 
             elif self.qr_type in [QRType.SEED__SEEDQR, QRType.SEED__COMPACTSEEDQR, QRType.SEED__MNEMONIC, QRType.SEED__FOUR_LETTER_MNEMONIC, QRType.SEED__UR2]:
-                self.decoder = SeedQrDecoder(wordlist_language_code=self.wordlist_language_code)          
+                self.decoder = SeedQrDecoder(wordlist_language_code=self.wordlist_language_code)
+
+            elif self.qr_type == QRType.SEED__ENCRYPTED:
+                self.decoder = EncryptedSeedQrDecoder()      
 
             elif self.qr_type == QRType.SETTINGS:
                 self.decoder = SettingsQrDecoder()  # Settings config
@@ -254,7 +257,6 @@ class DecodeQR:
     def is_complete(self) -> bool:
         return self.complete
 
-
     @property
     def is_invalid(self) -> bool:
         return self.qr_type == QRType.INVALID
@@ -281,6 +283,14 @@ class DecodeQR:
             QRType.SEED__FOUR_LETTER_MNEMONIC,
         ]
     
+    @property
+    def is_encrypted_seed(self):
+        return self.qr_type == QRType.SEED__ENCRYPTED
+
+    def get_encrypted_seed_data(self):
+        if self.is_encrypted_seed:
+            return self.decoder.get_encrypted_data()
+        return None
 
     @property
     def is_json(self):
@@ -381,6 +391,10 @@ class DecodeQR:
 
             elif "sortedmulti" in s:
                 return QRType.WALLET__GENERIC
+            
+            # Encrypted seed QR (OpenSSL AES-256-CBC base64)
+            if s.startswith("U2FsdGVkX1"):
+                return QRType.SEED__ENCRYPTED
 
             # Seed
             if re.search(r'\d{48,96}', s):
@@ -925,7 +939,23 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
             return True
         return False
 
+class EncryptedSeedQrDecoder(BaseSingleFrameQrDecoder):
+    """Decodes a single frame containing a base64-encoded OpenSSL AES-256-CBC encrypted mnemonic."""
 
+    def __init__(self):
+        super().__init__()
+        self.encrypted_data = None
+
+    def add(self, segment, qr_type=QRType.SEED__ENCRYPTED):
+        self.encrypted_data = segment.strip()
+        self.complete = True
+        self.collected_segments = 1
+        return DecodeQRStatus.COMPLETE
+
+    def get_encrypted_data(self) -> str:
+        if self.complete:
+            return self.encrypted_data
+        return None
 
 class SettingsQrDecoder(BaseSingleFrameQrDecoder):
     """

--- a/src/seedsigner/models/qr_type.py
+++ b/src/seedsigner/models/qr_type.py
@@ -13,7 +13,7 @@ class QRType:
     SEED__UR2 = "seed__ur2"
     SEED__MNEMONIC = "seed__mnemonic"
     SEED__FOUR_LETTER_MNEMONIC = "seed__four_letter_mnemonic"
-
+    SEED__ENCRYPTED = "seed__encrypted"
     SETTINGS = "settings"
 
     XPUB = "xpub"

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -345,6 +345,7 @@ class SettingsConstants:
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
+    SETTING__ENCRYPTED_SEEDS = "encrypted_seeds"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
     SETTING__DIRE_WARNINGS = "dire_warnings"
@@ -672,7 +673,15 @@ class SettingsDefinition:
                       help_text=_mft("Native Segwit only"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
-        
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__ENCRYPTED_SEEDS,
+                      abbreviated_name="enc_seeds",
+                      display_name=_mft("Encrypted seeds"),
+                      help_text=_mft("Import AES-256-CBC encrypted seed QRs"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__MICROSD_TOAST_TIMER,
                       display_name=_mft("MicroSD notification duration"),

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -5,7 +5,7 @@ from gettext import gettext as _
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
-from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.gui.screens.screen import ButtonOption, RET_CODE__BACK_BUTTON
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class ScanView(View):
         from seedsigner.gui.screens.scan_screens import ScanScreen
 
         # Start the live preview and background QR reading
-        self.run_screen(
+        scan_results = self.run_screen(
             ScanScreen,
             instructions_text=self.instructions_text,
             decoder=self.decoder
@@ -52,6 +52,9 @@ class ScanView(View):
         # A long scan might have exceeded the screensaver timeout; ensure screensaver
         # doesn't immediately engage when we leave here.
         self.controller.reset_screensaver_timeout()
+
+        if scan_results == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
 
         # Handle the results
         if self.decoder.is_complete:
@@ -88,7 +91,15 @@ class ScanView(View):
                         return Destination(SeedAddPassphraseView)
                     else:
                         return Destination(SeedFinalizeView)
-            
+
+            elif self.decoder.is_encrypted_seed:
+                from .seed_views import EncryptedSeedPassphraseView
+                if self.settings.get_value(SettingsConstants.SETTING__ENCRYPTED_SEEDS) == SettingsConstants.OPTION__DISABLED:
+                    from .view import OptionDisabledView
+                    return Destination(OptionDisabledView, view_args=dict(settings_attr=SettingsConstants.SETTING__ENCRYPTED_SEEDS))
+                encrypted_data = self.decoder.get_encrypted_seed_data()
+                return Destination(EncryptedSeedPassphraseView, view_args=dict(encrypted_data=encrypted_data))
+
             elif self.decoder.is_psbt:
                 from seedsigner.views.psbt_views import PSBTSelectSeedView
                 psbt = self.decoder.get_psbt()

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -7,9 +7,10 @@ from gettext import gettext as _
 
 from embit.descriptor import Descriptor
 
-from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
+from seedsigner.gui.components import GUIConstants, FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens)
+from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
@@ -452,9 +453,99 @@ class SeedReviewPassphraseView(View):
         elif button_data[selected_menu_num] == self.DONE:
             seed_num = self.controller.storage.finalize_pending_seed()
             return Destination(SeedOptionsView, view_args={"seed_num": seed_num}, clear_history=True)
-            
 
-            
+
+class EncryptedSeedPassphraseView(View):
+    def __init__(self, encrypted_data: str):
+        super().__init__()
+        self.encrypted_data = encrypted_data
+
+    def run(self):
+        ret_dict = self.run_screen(
+            seed_screens.SeedAddPassphraseScreen,
+            passphrase="",
+            title=_("Decryption Passphrase"),
+        )
+        if ret_dict == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        passphrase = ret_dict["passphrase"]
+        if not passphrase:
+            return Destination(EncryptedSeedPassphraseView,
+                               view_args=dict(encrypted_data=self.encrypted_data))
+
+        return Destination(EncryptedSeedDecryptView,
+                           view_args=dict(encrypted_data=self.encrypted_data, passphrase=passphrase))
+
+
+class EncryptedSeedDecryptView(View):
+    def __init__(self, encrypted_data: str, passphrase: str):
+        super().__init__()
+        self.encrypted_data = encrypted_data
+        self.passphrase = passphrase
+
+    def run(self):
+        from seedsigner.helpers.aes_decrypt import decrypt_openssl_aes256cbc, DecryptionError
+
+        try:
+            plaintext = decrypt_openssl_aes256cbc(self.encrypted_data, self.passphrase)
+        except DecryptionError:
+            return Destination(EncryptedSeedDecryptionFailedView,
+                               view_args=dict(encrypted_data=self.encrypted_data))
+
+        # Validate length
+        mnemonic_list = plaintext.strip().split()
+        if len(mnemonic_list) not in (12, 24):
+            return Destination(EncryptedSeedDecryptionFailedView,
+                               view_args=dict(encrypted_data=self.encrypted_data))
+
+        # Try BIP39 → Electrum
+        from seedsigner.models.seed import Seed, ElectrumSeed, InvalidSeedException
+        seed = None
+        try:
+            seed = Seed(mnemonic=mnemonic_list, wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
+        except InvalidSeedException:
+            if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
+                try:
+                    seed = ElectrumSeed(mnemonic=mnemonic_list)
+                except InvalidSeedException:
+                    pass
+
+        if seed is None:
+            return Destination(EncryptedSeedDecryptionFailedView,
+                               view_args=dict(encrypted_data=self.encrypted_data))
+
+        self.controller.storage.set_pending_seed(seed)
+        if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) == SettingsConstants.OPTION__REQUIRED:
+            return Destination(SeedAddPassphraseView)
+        return Destination(SeedFinalizeView)
+
+
+class EncryptedSeedDecryptionFailedView(View):
+    RETRY = ButtonOption(_mft("Try Again"))
+    DISCARD = ButtonOption(_mft("Discard"))
+
+    def __init__(self, encrypted_data: str):
+        super().__init__()
+        self.encrypted_data = encrypted_data
+
+    def run(self):
+        button_data = [self.RETRY, self.DISCARD]
+        selected_menu_num = self.run_screen(
+            DireWarningScreen,
+            title=_("Decryption Failed"),
+            status_icon_name=SeedSignerIconConstants.ERROR,
+            status_headline=None,
+            text=_("Wrong passphrase or invalid seed data."),
+            show_back_button=False,
+            button_data=button_data,
+        )
+        if button_data[selected_menu_num] == self.RETRY:
+            return Destination(EncryptedSeedPassphraseView,
+                               view_args=dict(encrypted_data=self.encrypted_data))
+        return Destination(MainMenuView)
+
+
 class SeedDiscardView(View):
     KEEP = ButtonOption("Keep seed")
     DISCARD = ButtonOption("Discard", button_label_color="red")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import os
+import platform
+import sys
+from unittest.mock import MagicMock
+
+# Global mocks for hardware modules not available on dev machines.
+# The project's tests/base.py mocks SeedSigner-level modules; these mock
+# the underlying RPi hardware so that imports succeed before base.py runs.
+sys.modules['RPi'] = MagicMock()
+sys.modules['RPi.GPIO'] = MagicMock()
+sys.modules['board'] = MagicMock()
+sys.modules['digitalio'] = MagicMock()
+sys.modules['adafruit_ssd1306'] = MagicMock()
+sys.modules['spidev'] = MagicMock()
+sys.modules['smbus'] = MagicMock()
+sys.modules['smbus2'] = MagicMock()
+sys.modules['gpiozero'] = MagicMock()
+sys.modules['numpy'] = MagicMock()
+
+# On macOS with Homebrew, ctypes.util.find_library('zbar') returns None even
+# when the library is installed, because Homebrew ARM installs to /opt/homebrew
+# which is outside the default library search paths. Patch find_library so that
+# pyzbar can find the shared library during tests.
+if platform.system() == 'Darwin':
+    import ctypes.util
+    _orig_find_library = ctypes.util.find_library
+    def _patched_find_library(name):
+        result = _orig_find_library(name)
+        if result is None and name == 'zbar':
+            # Try Homebrew ARM and Intel paths
+            for path in ['/opt/homebrew/lib/libzbar.dylib', '/usr/local/lib/libzbar.dylib']:
+                if os.path.exists(path):
+                    return path
+        return result
+    ctypes.util.find_library = _patched_find_library

--- a/tests/test_aes_decrypt.py
+++ b/tests/test_aes_decrypt.py
@@ -77,3 +77,10 @@ def test_decrypt_short_input():
     """Very short/invalid input raises DecryptionError"""
     with pytest.raises(DecryptionError):
         decrypt_openssl_aes256cbc("U2FsdGVkX1short", "pass")
+
+
+def test_decrypt_hardcoded_vector():
+    """Pre-computed OpenSSL vector — no openssl binary needed at test time."""
+    encrypted = "U2FsdGVkX1+5ER21G7dz8fbBzXbp4p3LiMqJuwXOJN29f+1djh0nhJovkaPluB7Vcm9yr9g5Ss65pFvt+UQTsiYiEwJSiL9D08dn5AXmI5UmPR2WJuBQD14tEMrX/eXXVNLtG3Gy7qbiJkidJepX0w=="
+    result = decrypt_openssl_aes256cbc(encrypted, "TestVector2026")
+    assert result == "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"

--- a/tests/test_aes_decrypt.py
+++ b/tests/test_aes_decrypt.py
@@ -1,0 +1,79 @@
+import pytest
+import subprocess
+import base64
+
+from seedsigner.helpers.aes_decrypt import decrypt_openssl_aes256cbc, DecryptionError
+
+
+def _get_test_vector(mnemonic: str, passphrase: str) -> str:
+    """Generate exact OpenSSL-compatible encrypted string using system openssl."""
+    cmd = [
+        'openssl', 'enc', '-aes-256-cbc', '-pbkdf2', '-iter', '100000',
+        '-base64', '-pass', f'pass:{passphrase}'
+    ]
+    try:
+        result = subprocess.run(cmd, input=mnemonic.encode('utf-8'), capture_output=True, check=True)
+        return result.stdout.decode('utf-8').strip()
+    except FileNotFoundError:
+        pytest.skip("openssl command not found. Install with: brew install openssl")
+    except subprocess.CalledProcessError:
+        pytest.fail("Failed to generate test vector with openssl")
+
+
+def test_decrypt_success():
+    """Test successful decryption with 12-word BIP39 mnemonic"""
+    mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    passphrase = "TestPass123!"
+
+    encrypted_b64 = _get_test_vector(mnemonic, passphrase)
+    result = decrypt_openssl_aes256cbc(encrypted_b64, passphrase)
+    assert result.strip() == mnemonic
+
+
+def test_decrypt_24_word_success():
+    """Test successful decryption with 24-word BIP39 mnemonic"""
+    mnemonic = ("abandon " * 23 + "art").strip()
+    passphrase = "MySuperSecretPassphrase2025"
+
+    encrypted_b64 = _get_test_vector(mnemonic, passphrase)
+    result = decrypt_openssl_aes256cbc(encrypted_b64, passphrase)
+    assert result.strip() == mnemonic
+
+
+def test_decrypt_wrong_passphrase():
+    """Wrong passphrase must raise DecryptionError"""
+    mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    passphrase = "TestPass123!"
+    encrypted_b64 = _get_test_vector(mnemonic, passphrase)
+
+    with pytest.raises(DecryptionError):
+        decrypt_openssl_aes256cbc(encrypted_b64, "WrongPassphrase!!!")
+
+
+def test_decrypt_corrupt_data():
+    """Corrupted data raises DecryptionError"""
+    with pytest.raises(DecryptionError):
+        decrypt_openssl_aes256cbc("U2FsdGVkX1thisisnotvalidbase64garbage", "pass")
+
+
+def test_decrypt_missing_header():
+    """Missing 'Salted__' header raises DecryptionError"""
+    data = base64.b64encode(b"not_salted_data_here").decode()
+    with pytest.raises(DecryptionError, match="Invalid OpenSSL magic header"):
+        decrypt_openssl_aes256cbc(data, "pass")
+
+
+def test_decrypt_invalid_padding():
+    """Invalid padding raises DecryptionError"""
+    salt = b"12345678"
+    bad_data = b'Salted__' + salt + b'\x00' * 48   # guaranteed bad padding
+    bad_b64 = base64.b64encode(bad_data).decode()
+
+    with pytest.raises(DecryptionError):
+        decrypt_openssl_aes256cbc(bad_b64, "pass")
+
+
+def test_decrypt_short_input():
+    """Very short/invalid input raises DecryptionError"""
+    with pytest.raises(DecryptionError):
+        decrypt_openssl_aes256cbc("U2FsdGVkX1short", "pass")

--- a/tests/test_encrypted_seed_qr.py
+++ b/tests/test_encrypted_seed_qr.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
+from seedsigner.models.qr_type import QRType
+
+
+def test_detect_encrypted_seed_qr():
+    """Strings starting with U2FsdGVkX1 are correctly detected"""
+    decoder = DecodeQR()
+
+    sample = "U2FsdGVkX1+randomstuffhere1234567890abcdef=="
+    qr_type = decoder.detect_segment_type(sample)
+
+    assert qr_type == QRType.SEED__ENCRYPTED
+
+
+def test_encrypted_seed_decoder():
+    """EncryptedSeedQrDecoder stores and returns data correctly"""
+    from seedsigner.models.decode_qr import EncryptedSeedQrDecoder
+
+    decoder = EncryptedSeedQrDecoder()
+    encrypted_data = "U2FsdGVkX1thisisatestencryptedseeddata=="
+
+    status = decoder.add(encrypted_data)
+
+    assert status == DecodeQRStatus.COMPLETE
+    assert decoder.complete is True
+    assert decoder.get_encrypted_data() == encrypted_data
+
+
+def test_decode_qr_encrypted_properties():
+    """DecodeQR exposes is_encrypted_seed and get_encrypted_seed_data"""
+    decode_qr = DecodeQR()
+    encrypted_str = "U2FsdGVkX1testdata1234567890abcdef"
+
+    decode_qr.add_data(encrypted_str)
+
+    assert decode_qr.is_encrypted_seed is True
+    assert decode_qr.get_encrypted_seed_data() == encrypted_str
+
+
+def test_full_encrypted_seed_flow():
+    """Full integration test: decrypt → validate → set pending seed → SeedFinalizeView"""
+    from seedsigner.views.seed_views import EncryptedSeedDecryptView
+    from seedsigner.models.settings_definition import SettingsConstants
+
+    mock_decrypt = MagicMock(return_value="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+    mock_seed_instance = MagicMock()
+    mock_seed_class = MagicMock(return_value=mock_seed_instance)
+    mock_finalize_view = MagicMock()
+
+    settings_mock = MagicMock()
+    settings_mock.get_value.side_effect = lambda key: {
+        SettingsConstants.SETTING__ELECTRUM_SEEDS: SettingsConstants.OPTION__DISABLED,
+        SettingsConstants.SETTING__PASSPHRASE: SettingsConstants.OPTION__DISABLED,
+        SettingsConstants.SETTING__WORDLIST_LANGUAGE: "en",
+    }.get(key)
+
+    with patch('seedsigner.helpers.aes_decrypt.decrypt_openssl_aes256cbc', mock_decrypt):
+        with patch('seedsigner.models.seed.Seed', mock_seed_class):
+            with patch('seedsigner.views.seed_views.SeedFinalizeView', mock_finalize_view):
+                view = EncryptedSeedDecryptView(
+                    encrypted_data="U2FsdGVkX1dummyencrypteddata",
+                    passphrase="TestPass123!"
+                )
+                view.settings = settings_mock
+                view.controller = MagicMock()
+                view.controller.storage = MagicMock()
+
+                destination = view.run()
+
+    mock_decrypt.assert_called_once()
+    mock_seed_class.assert_called_once()
+    assert destination.View_cls == mock_finalize_view   # ← this is the correct attribute in SeedSigner


### PR DESCRIPTION
## Summary

Scan a QR code containing an OpenSSL-compatible AES-256-CBC encrypted seed backup, decrypt it with a user-provided passphrase, validate as BIP-39 or Electrum mnemonic, and import as a seed.

> **Note:** This PR is focused exclusively on encrypted seed QR import. The Seed XOR rebuild flow and Electrum XOR support are in a separate PR (#884).

## Workflow

1. Scan QR code (auto-detects `U2FsdGVkX1` / `Salted__` prefix)
2. Prompt for decryption passphrase
3. Decrypt, validate as BIP-39 or Electrum mnemonic
4. Import as a seed

Activated via **Settings > Advanced > Encrypted seeds** (`SETTING__ENCRYPTED_SEEDS`, disabled by default).

## Changes (10 files)

### Core (`src/seedsigner/helpers/aes_decrypt.py`) — New
- Pure-Python AES-256-CBC decryptor (no `pyaes` dependency)
- Precomputed InvMixColumns lookup tables for Pi Zero performance
- PBKDF2 key derivation with auto-detection of 10,000 and 100,000 iterations
- `decrypt_openssl_aes256cbc()` and `DecryptionError` exception

### QR Detection (`src/seedsigner/models/decode_qr.py`, `qr_type.py`)
- Add `QRType.SEED__ENCRYPTED` constant
- Add `EncryptedSeedQrDecoder` for base64-encoded encrypted seed QRs
- Auto-detect encrypted QRs by `U2FsdGVkX1` prefix

### Settings (`src/seedsigner/models/settings_definition.py`)
- Add `SETTING__ENCRYPTED_SEEDS` toggle (advanced, disabled by default)

### Views (`src/seedsigner/views/seed_views.py`)
- `EncryptedSeedPassphraseView` — Passphrase entry screen
- `EncryptedSeedDecryptView` — Decryption + BIP-39/Electrum validation
- `EncryptedSeedDecryptionFailedView` — Retry/discard on failure

### Scan (`src/seedsigner/views/scan_views.py`)
- Route encrypted QR scans to decryption flow
- Check `SETTING__ENCRYPTED_SEEDS` toggle
- Add back button support for scan screen

### GUI (`src/seedsigner/gui/screens/seed_screens.py`)
- Fix `SeedAddPassphraseScreen` to preserve custom title ("Decryption Passphrase")

### Tests
- `tests/test_aes_decrypt.py` — AES-256-CBC unit tests
- `tests/test_encrypted_seed_qr.py` — Encrypted QR integration tests
- `tests/conftest.py` — Shared test fixtures

## Legacy Workflow (reference)

```bash
# Encrypt
openssl enc -aes-256-cbc -pbkdf2 -iter 100000 -in seed.txt -out seed.enc
qrencode -r seed.enc -o seedenc.png

# Decrypt (verify)
cat seed.enc | openssl aes-256-cbc -a -d -pbkdf2
```

## Checklist
- [x] `pytest` passes
- [x] Tested on Raspberry Pi OS (manual build)
- [x] Tested on SeedSigner OS (Pi0)

## Test plan
- [x] All 11 tests pass (AES unit + encrypted QR integration)
- [x] Manual test: Scan encrypted seed QR → enter passphrase → verify seed imports correctly
- [x] Manual test: Wrong passphrase → "Decryption Failed" → retry works
- [x] Manual test: Feature disabled → OptionDisabledView shown