### PR TITLE
[Feature] Add Electrum Seed Support to Seed XOR Flow, builds on PR #738

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -16,6 +16,7 @@ from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
 from seedsigner.views.screensaver import ScreensaverScreen
 from seedsigner.views.view import Destination, View
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
 
 
 logger = logging.getLogger(__name__)
@@ -133,6 +134,7 @@ class Controller(Singleton):
     FLOW__VERIFY_SINGLESIG_ADDR = "singlesig_addr"
     FLOW__ADDRESS_EXPLORER = "address_explorer"
     FLOW__SIGN_MESSAGE = "sign_message"
+    FLOW__REBUILD_SEEDXOR = "rebuild_seedxor"
     resume_main_flow: str = None
 
     back_stack: BackStack = None
@@ -229,6 +231,29 @@ class Controller(Singleton):
             del self.storage.seeds[seed_num]
         else:
             raise Exception(f"There is no seed_num {seed_num}; only {len(self.storage.seeds)} in memory.")
+        
+    def validate_rebuild_seedxor_shard(self, new_shard_seed: Seed):
+        existing_shards = self.storage.get_rebuild_seedxor_shards()
+        is_valid, error_dict = SeedXORValidator.validate_shard(new_shard_seed, existing_shards)
+        if not is_valid:
+            return error_dict
+        return None
+        
+    def process_rebuild_seedxor_shard(self, new_shard_seed: Seed):
+        error_dict = self.validate_rebuild_seedxor_shard(new_shard_seed)
+        if error_dict:
+            return error_dict
+        self.storage.add_rebuild_seedxor_shard(new_shard_seed)
+        return None
+            
+    def remove_rebuild_seedxor_shard(self, index: int):
+        shards = self.storage.get_rebuild_seedxor_shards()
+        if 0 <= index < len(shards):
+            shards.pop(index)
+            self.storage.rebuild_seedxor_combined_seed = None
+    
+    def clear_rebuild_seedxor_data(self):
+        self.storage.clear_rebuild_seedxor_data()
 
 
     def pop_prev_from_back_stack(self):

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -203,7 +203,7 @@ class SeedSignerIconConstants:
     CHEVRON_LEFT = "\ue909"
     CHEVRON_RIGHT = "\ue90a"
     CHEVRON_UP = "\ue90b"
-    # CLOSE = "\ue90c"  # Unused icons
+    CLOSE = "\ue90c"
     # PAGE_DOWN = "\ue90d"
     # PAGE_UP = "\ue90e"
     PLUS = "\ue90f"

--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -110,3 +110,53 @@ def get_partial_final_word(coin_flips: str, wordlist_language_code: str = Settin
     wordlist_index = int(binary_string, 2)
 
     return Seed.get_wordlist(wordlist_language_code)[wordlist_index]
+
+
+
+# Note: This currently isn't being used since we're now chaining hashed bytes for the
+#   image-based entropy and aren't just ingesting a single image.
+def generate_mnemonic_from_image(image, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
+    import hashlib
+    hash = hashlib.sha256(image.tobytes())
+
+    # Return as a list
+    return bip39.mnemonic_from_bytes(hash.digest(), wordlist=Seed.get_wordlist(wordlist_language_code)).split()
+
+
+def combine_mnemonics_with_xor(mnemonics: list[str], wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
+    """
+    Combine multiple BIP39 mnemonic seed phrases using XOR operation (SeedXOR).
+
+    The process works by XOR-ing the entropy (random data) of each mnemonic together.
+    When you XOR the shares back together, you get the original seed phrase.
+    
+    Args:
+        mnemonics: List of mnemonic seed phrases (as strings) to combine
+        wordlist_language_code: Language code for the BIP39 wordlist (default: English)
+    
+    Returns:
+        Combined mnemonic as a list of words
+        
+    Raises:
+        ValueError: If mnemonics list is empty, contains invalid mnemonics, 
+                   or mnemonics have different entropy lengths
+    """
+    if not mnemonics:
+        raise ValueError("Mnemonic list cannot be empty")
+        
+    wordlist = Seed.get_wordlist(wordlist_language_code)
+    
+    try:
+        entropy_list = [bip39.mnemonic_to_bytes(" ".join(mnemonic) if isinstance(mnemonic, list) else mnemonic, wordlist=wordlist) 
+                       for mnemonic in mnemonics]
+    except Exception as e:
+        raise ValueError(f"Invalid mnemonic: {str(e)}")
+    
+    if len(set(len(entropy) for entropy in entropy_list)) != 1:
+        raise ValueError("All mnemonics must generate entropy of the same length")
+    
+    combined_entropy = bytes(len(entropy_list[0]))
+    for entropy in entropy_list:
+        combined_entropy = bytes(a ^ b for a, b in zip(combined_entropy, entropy))
+    
+    return bip39.mnemonic_from_bytes(combined_entropy, wordlist=wordlist).split()

--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -125,38 +125,85 @@ def generate_mnemonic_from_image(image, wordlist_language_code: str = SettingsCo
 
 def combine_mnemonics_with_xor(mnemonics: list[str], wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
     """
-    Combine multiple BIP39 mnemonic seed phrases using XOR operation (SeedXOR).
+    Combine multiple mnemonic seed phrases using XOR operation (SeedXOR).
 
-    The process works by XOR-ing the entropy (random data) of each mnemonic together.
-    When you XOR the shares back together, you get the original seed phrase.
-    
+    XORs the word indices (11 bits each) of each mnemonic, then converts the
+    XOR'd entropy back to a mnemonic with a valid BIP-39 checksum.
+
+    Supports both BIP-39 and Electrum seeds since both use the same 2048-word
+    BIP-39 wordlist. The XOR is its own inverse: recombining all original parts
+    will reproduce the original seed.
+
+    For the entropy bits (first 128/256 bits), XOR is straightforward and
+    reversible. The last word's checksum bits (4 bits for 12-word, 8 bits for
+    24-word) are recomputed as a valid BIP-39 checksum from the XOR'd entropy.
+    This means XOR parts are always valid BIP-39 seeds. When all parts are
+    recombined, the entropy is perfectly restored; if the original was an
+    Electrum seed, the HMAC check will pass since it depends on the entropy.
+
     Args:
-        mnemonics: List of mnemonic seed phrases (as strings) to combine
+        mnemonics: List of mnemonic seed phrases (as strings or lists of words)
         wordlist_language_code: Language code for the BIP39 wordlist (default: English)
-    
+
     Returns:
         Combined mnemonic as a list of words
-        
+
     Raises:
-        ValueError: If mnemonics list is empty, contains invalid mnemonics, 
-                   or mnemonics have different entropy lengths
+        ValueError: If mnemonics list is empty, contains invalid mnemonics,
+                   or mnemonics have different word counts
     """
     if not mnemonics:
         raise ValueError("Mnemonic list cannot be empty")
-        
+
     wordlist = Seed.get_wordlist(wordlist_language_code)
-    
+
+    # Convert mnemonics to lists of word indices
     try:
-        entropy_list = [bip39.mnemonic_to_bytes(" ".join(mnemonic) if isinstance(mnemonic, list) else mnemonic, wordlist=wordlist) 
-                       for mnemonic in mnemonics]
+        index_lists = []
+        for mnemonic in mnemonics:
+            words = mnemonic.split() if isinstance(mnemonic, str) else mnemonic
+            indices = []
+            for word in words:
+                if word not in wordlist:
+                    raise ValueError(f"Word '{word}' is not in the dictionary")
+                indices.append(wordlist.index(word))
+            index_lists.append(indices)
+    except ValueError:
+        raise
     except Exception as e:
         raise ValueError(f"Invalid mnemonic: {str(e)}")
-    
-    if len(set(len(entropy) for entropy in entropy_list)) != 1:
+
+    # Validate all mnemonics have the same word count
+    word_counts = set(len(indices) for indices in index_lists)
+    if len(word_counts) != 1:
         raise ValueError("All mnemonics must generate entropy of the same length")
-    
-    combined_entropy = bytes(len(entropy_list[0]))
-    for entropy in entropy_list:
-        combined_entropy = bytes(a ^ b for a, b in zip(combined_entropy, entropy))
-    
-    return bip39.mnemonic_from_bytes(combined_entropy, wordlist=wordlist).split()
+
+    num_words = index_lists[0].__len__()
+    if num_words not in (12, 24):
+        raise ValueError("Mnemonics must be 12 or 24 words")
+
+    # XOR all word indices together to get the combined 11-bit values
+    combined_indices = index_lists[0][:]
+    for indices in index_lists[1:]:
+        combined_indices = [a ^ b for a, b in zip(combined_indices, indices)]
+
+    # Convert combined indices to entropy bits (all 11 * num_words bits)
+    all_bits = []
+    for idx in combined_indices:
+        for bit_pos in range(10, -1, -1):
+            all_bits.append((idx >> bit_pos) & 1)
+
+    # Extract entropy bits (strip the checksum bits from the last word)
+    checksum_length = num_words // 3  # 4 for 12 words, 8 for 24 words
+    entropy_bits = all_bits[:len(all_bits) - checksum_length]
+
+    # Convert entropy bits to bytes
+    entropy_bytes = bytearray()
+    for i in range(0, len(entropy_bits), 8):
+        byte = 0
+        for bit in entropy_bits[i:i+8]:
+            byte = (byte << 1) | bit
+        entropy_bytes.append(byte)
+
+    # Use mnemonic_from_bytes to produce a mnemonic with valid BIP-39 checksum
+    return bip39.mnemonic_from_bytes(bytes(entropy_bytes), wordlist=wordlist).split()

--- a/src/seedsigner/helpers/seed_xor_validator.py
+++ b/src/seedsigner/helpers/seed_xor_validator.py
@@ -1,0 +1,72 @@
+from typing import List, Tuple, Optional, Dict, Any
+from embit import bip39
+from seedsigner.models.seed import Seed
+
+
+class SeedXORValidator:
+    """
+    Handles validation logic for SeedXOR operations.
+    Returns validation errors as dictionaries that can be used by Views.
+    """
+
+    @classmethod
+    def validate_shard(cls, new_shard: Seed, existing_shards: List[Seed]) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        """
+        Validates a new shard against existing shards.
+        
+        Args:
+            new_shard: The new shard to validate
+            existing_shards: List of already added shards
+            
+        Returns:
+            Tuple of (is_valid, error_dict) where:
+            - is_valid: bool indicating if validation passed
+            - error_dict: dict with error details if validation failed, None otherwise
+        """
+        error_dict = None
+        
+        # Check for passphrase
+        if new_shard.has_passphrase:
+            return False, {
+                "title": "Passphrase Not Allowed",
+                "status_headline": "Invalid Shard",
+                "message": "You may not XOR a seed that has passphrase.",
+            }
+            
+        # Check mnemonic length consistency
+        if existing_shards and len(new_shard.mnemonic_list) != len(existing_shards[0].mnemonic_list):
+            return False, {
+                "title": "Mnemonic Length Mismatch",
+                "status_headline": "Invalid Shard",
+                "message": "XOR requires seeds of similar mnemonic length!"
+            }
+            
+        # Check for duplicate shards
+        for i, shard in enumerate(existing_shards):
+            if new_shard.mnemonic_str == shard.mnemonic_str:
+                shard_num = i + 1
+                error_dict = {
+                    "title": "Duplicate Shard",
+                    "status_headline": "Duplicate Shard",
+                    "message": "This shard is identical to shard #{}".format(shard_num),
+                }
+                return False, error_dict
+                
+        # Check for inverse shards (which would cancel out)
+        for i, shard in enumerate(existing_shards):
+            if len(new_shard.mnemonic_list) == len(shard.mnemonic_list):
+                new_entropy = bip39.mnemonic_to_bytes(new_shard.mnemonic_str)
+                existing_entropy = bip39.mnemonic_to_bytes(shard.mnemonic_str)
+                
+                # XOR the entropies and check if result is all 1s (binary inverse)
+                inverse_entropy = bytes(a ^ b for a, b in zip(new_entropy, existing_entropy))
+                if all(b == 0xFF for b in inverse_entropy):
+                    shard_num = i + 1
+                    error_dict = {
+                        "title": "Seed Inversion",
+                        "status_headline": "Invalid Shard",
+                        "message": "This shard is the binary inverse of shard #{} and would cancel it out.".format(shard_num),
+                    }
+                    return False, error_dict
+               
+        return True, None

--- a/src/seedsigner/helpers/seed_xor_validator.py
+++ b/src/seedsigner/helpers/seed_xor_validator.py
@@ -55,8 +55,10 @@ class SeedXORValidator:
         # Check for inverse shards (which would cancel out)
         for i, shard in enumerate(existing_shards):
             if len(new_shard.mnemonic_list) == len(shard.mnemonic_list):
-                new_entropy = bip39.mnemonic_to_bytes(new_shard.mnemonic_str)
-                existing_entropy = bip39.mnemonic_to_bytes(shard.mnemonic_str)
+                # Use ignore_checksum=True because Electrum seeds don't have
+                # valid BIP-39 checksums (they use HMAC-SHA512 validation instead)
+                new_entropy = bip39.mnemonic_to_bytes(new_shard.mnemonic_str, ignore_checksum=True)
+                existing_entropy = bip39.mnemonic_to_bytes(shard.mnemonic_str, ignore_checksum=True)
                 
                 # XOR the entropies and check if result is all 1s (binary inverse)
                 inverse_entropy = bytes(a ^ b for a, b in zip(new_entropy, existing_entropy))

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -164,7 +164,108 @@ class Seed:
         return bip85.derive_mnemonic(root, bip85_num_words, bip85_index)
         
 
-    ### override operators    
+    @staticmethod
+    def _is_electrum_hmac(mnemonic_str: str) -> bool:
+        """Check if a mnemonic string has a valid Electrum segwit HMAC prefix.
+
+        Only checks for the segwit prefix ("100") since that is the only
+        Electrum seed type SeedSigner supports.  The standard prefix ("01") is
+        intentionally excluded because it is very short and causes false
+        positives when brute-forcing last-word variants during XOR
+        recombination (1-in-256 chance per candidate for 24-word seeds).
+        """
+        normalized = unicodedata.normalize("NFKD", mnemonic_str)
+        h = hmac.digest(b"Seed version", normalized.encode('utf-8'), hashlib.sha512).hex()
+        return h.startswith(SettingsConstants.ELECTRUM_SEED_SEGWIT)  # "100"
+
+
+    @staticmethod
+    def detect_mnemonic_type(mnemonic: list) -> str:
+        """
+        Detect whether a mnemonic is an Electrum seed or a standard BIP-39 seed.
+
+        After XOR recombination, the resulting mnemonic has a valid BIP-39 checksum
+        but the last word may differ from the original Electrum seed's last word
+        (since Electrum doesn't use BIP-39 checksums). To handle this, we check
+        all possible last words that share the same entropy bits — there are 16
+        possibilities for 12-word seeds (4 checksum bits) and 256 for 24-word
+        seeds (8 checksum bits).
+
+        Returns: "electrum" if any candidate matches, otherwise "bip39"
+        """
+        if isinstance(mnemonic, str):
+            mnemonic = mnemonic.split()
+
+        # First, check the mnemonic as-is
+        mnemonic_str = " ".join(mnemonic)
+        if Seed._is_electrum_hmac(mnemonic_str):
+            return "electrum"
+
+        # The BIP-39 checksum may have changed the last word. Try all possible
+        # last words that share the same entropy bits.
+        wordlist = bip39.WORDLIST
+        last_word = mnemonic[-1]
+        last_index = wordlist.index(last_word)
+
+        # For 12-word seeds: 4 checksum bits, so mask out bottom 4 bits
+        # For 24-word seeds: 8 checksum bits, so mask out bottom 8 bits
+        num_words = len(mnemonic)
+        checksum_bits = num_words // 3  # 4 for 12 words, 8 for 24 words
+        entropy_mask = ((1 << 11) - 1) ^ ((1 << checksum_bits) - 1)
+        entropy_prefix = last_index & entropy_mask
+
+        prefix_words = mnemonic[:-1]
+        for i in range(1 << checksum_bits):
+            candidate_index = entropy_prefix | i
+            if candidate_index == last_index:
+                continue  # Already checked
+            if candidate_index >= len(wordlist):
+                continue
+            candidate_word = wordlist[candidate_index]
+            candidate_str = " ".join(prefix_words + [candidate_word])
+            if Seed._is_electrum_hmac(candidate_str):
+                return "electrum"
+
+        return "bip39"
+
+
+    @staticmethod
+    def get_electrum_mnemonic(mnemonic: list) -> list:
+        """
+        Given a mnemonic from XOR recombination (with BIP-39 checksum), find
+        the exact last word that makes it a valid Electrum seed.
+
+        Returns the corrected mnemonic list, or None if not an Electrum seed.
+        """
+        if isinstance(mnemonic, str):
+            mnemonic = mnemonic.split()
+
+        wordlist = bip39.WORDLIST
+
+        # Check as-is first
+        if Seed._is_electrum_hmac(" ".join(mnemonic)):
+            return list(mnemonic)
+
+        last_index = wordlist.index(mnemonic[-1])
+        num_words = len(mnemonic)
+        checksum_bits = num_words // 3
+        entropy_mask = ((1 << 11) - 1) ^ ((1 << checksum_bits) - 1)
+        entropy_prefix = last_index & entropy_mask
+
+        prefix_words = mnemonic[:-1]
+        for i in range(1 << checksum_bits):
+            candidate_index = entropy_prefix | i
+            if candidate_index >= len(wordlist):
+                continue
+            candidate_word = wordlist[candidate_index]
+            candidate_mnemonic = prefix_words + [candidate_word]
+            if Seed._is_electrum_hmac(" ".join(candidate_mnemonic)):
+                return candidate_mnemonic
+
+        return None
+
+
+    ### override operators
     def __eq__(self, other):
         if isinstance(other, Seed):
             return self.seed_bytes == other.seed_bytes

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -10,6 +10,8 @@ class SeedStorage:
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
         self._pending_is_electrum : bool = False
+        self.rebuild_seedxor_shards: List[Seed] = []
+        self.rebuild_seedxor_combined_seed: Seed = None        
 
 
     def set_pending_seed(self, seed: Seed):
@@ -103,3 +105,21 @@ class SeedStorage:
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
         self._pending_is_electrum = False
+
+    def add_rebuild_seedxor_shard(self, seed: Seed):
+        self.rebuild_seedxor_shards.append(seed)
+        self.rebuild_seedxor_combined_seed = None
+
+    def clear_rebuild_seedxor_data(self):
+        self.rebuild_seedxor_shards = []
+        self.rebuild_seedxor_combined_seed = None
+
+    def get_rebuild_seedxor_shards(self) -> List[Seed]:
+        return self.rebuild_seedxor_shards
+
+    def get_rebuild_seedxor_combined_seed(self) -> Seed:
+        return self.rebuild_seedxor_combined_seed
+
+    def set_rebuild_seedxor_combined_seed(self, seed: Seed):
+        self.rebuild_seedxor_combined_seed = seed
+

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -350,6 +350,7 @@ class SettingsConstants:
     SETTING__DIRE_WARNINGS = "dire_warnings"
     SETTING__QR_BRIGHTNESS_TIPS = "qr_brightness_tips"
     SETTING__PARTNER_LOGOS = "partner_logos"
+    SETTING__SEED_XOR = "seed_xor"
     SETTING__MICROSD_TOAST_TIMER = "microsd_toast_timer"
 
     SETTING__DEBUG = "debug"
@@ -711,6 +712,12 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__PARTNER_LOGOS,
                       abbreviated_name="partners",
                       display_name=_mft("Show partner logos"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__ENABLED),
+                      
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SEED_XOR,
+                      display_name="Seed XOR",
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__ENABLED),
 

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -5,7 +5,7 @@ from gettext import gettext as _
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
-from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.gui.screens.screen import ButtonOption, RET_CODE__BACK_BUTTON
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class ScanView(View):
         from seedsigner.gui.screens.scan_screens import ScanScreen
 
         # Start the live preview and background QR reading
-        self.run_screen(
+        scan_results = self.run_screen(
             ScanScreen,
             instructions_text=self.instructions_text,
             decoder=self.decoder
@@ -52,6 +52,9 @@ class ScanView(View):
         # A long scan might have exceeded the screensaver timeout; ensure screensaver
         # doesn't immediately engage when we leave here.
         self.controller.reset_screensaver_timeout()
+
+        if scan_results == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
 
         # Handle the results
         if self.decoder.is_complete:
@@ -79,15 +82,23 @@ class ScanView(View):
                     # Found a valid mnemonic seed! All new seeds should be considered
                     #   pending (might set a passphrase, SeedXOR, etc) until finalized.
                     from seedsigner.models.seed import Seed
-                    from .seed_views import SeedFinalizeView
-                    self.controller.storage.set_pending_seed(
-                        Seed(mnemonic=seed_mnemonic, wordlist_language_code=self.wordlist_language_code)
-                    )
-                    if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) == SettingsConstants.OPTION__REQUIRED:
-                        from seedsigner.views.seed_views import SeedAddPassphraseView
-                        return Destination(SeedAddPassphraseView)
+                    from .seed_views import SeedFinalizeView, RebuildSeedXORShowFingerprintView
+                    
+                    # Create the seed object from the mnemonic
+                    new_seed = Seed(mnemonic=seed_mnemonic, wordlist_language_code=self.wordlist_language_code)
+                    
+                    if hasattr(self, "is_rebuild_seedxor_shard") and self.is_rebuild_seedxor_shard:
+                        # The seed is not yet validated for the SeedXOR operation, so we just
+                        #   pass it to the next View as a pending_seed.
+                        self.controller.storage.set_pending_seed(new_seed)
+                        return Destination(RebuildSeedXORShowFingerprintView)
                     else:
-                        return Destination(SeedFinalizeView)
+                        self.controller.storage.set_pending_seed(new_seed)
+                        if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) == SettingsConstants.OPTION__REQUIRED:
+                            from seedsigner.views.seed_views import SeedAddPassphraseView
+                            return Destination(SeedAddPassphraseView)
+                        else:
+                            return Destination(SeedFinalizeView)
             
             elif self.decoder.is_psbt:
                 from seedsigner.views.psbt_views import PSBTSelectSeedView
@@ -183,7 +194,11 @@ class ScanPSBTView(ScanView):
 class ScanSeedQRView(ScanView):
     instructions_text = _mft("Scan SeedQR")
     invalid_qr_type_message = _mft("Expected a SeedQR")
-
+    
+    def __init__(self, is_rebuild_seedxor_shard=False):
+        super().__init__()
+        self.is_rebuild_seedxor_shard = is_rebuild_seedxor_shard
+        
     @property
     def is_valid_qr_type(self):
         return self.decoder.is_seed

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3,13 +3,13 @@ import random
 import time
 
 from binascii import hexlify
-from gettext import gettext as _
+from gettext import gettext as _ , ngettext
 
 from embit.descriptor import Descriptor
-
+from seedsigner.gui.components import GUIConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
-    WarningScreen, DireWarningScreen, seed_screens)
+    WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
 from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
@@ -18,6 +18,8 @@ from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 from seedsigner.views.view import NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+from seedsigner.views.view import ErrorView
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +166,7 @@ class LoadSeedView(View):
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
     CREATE = ButtonOption("Create a seed", SeedSignerIconConstants.PLUS)
+    REBUILD_SEED_XOR = ButtonOption("Rebuild SeedXOR", SeedSignerIconConstants.PLUS)
 
     def run(self):
         button_data = [
@@ -171,6 +174,9 @@ class LoadSeedView(View):
             self.TYPE_12WORD,
             self.TYPE_24WORD,
         ]
+
+        if self.settings.get_value(SettingsConstants.SETTING__SEED_XOR) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.REBUILD_SEED_XOR)
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
@@ -206,6 +212,10 @@ class LoadSeedView(View):
             from .tools_views import ToolsMenuView
             return Destination(ToolsMenuView)
 
+        elif button_data[selected_menu_num] == self.REBUILD_SEED_XOR:
+            from seedsigner.views.seed_views import RebuildSeedXORManageView
+            return Destination(RebuildSeedXORManageView)
+
 
 
 class SeedMnemonicEntryView(View):
@@ -217,6 +227,7 @@ class SeedMnemonicEntryView(View):
 
 
     def run(self):
+        from seedsigner.models.seed import Seed
         ret = self.run_screen(
             seed_screens.SeedMnemonicEntryScreen,
             # TRANSLATOR_NOTE: Inserts the word number (e.g. "Seed Word #6")
@@ -257,13 +268,17 @@ class SeedMnemonicEntryView(View):
             )
         else:
             # Attempt to finalize the mnemonic
-            from seedsigner.models.seed import InvalidSeedException
+            from seedsigner.models.seed import InvalidSeedException, Seed
+            from seedsigner.controller import Controller
             try:
                 self.controller.storage.convert_pending_mnemonic_to_pending_seed()
             except InvalidSeedException:
                 return Destination(SeedMnemonicInvalidView)
-
-            return Destination(SeedFinalizeView)
+            
+            if self.controller.resume_main_flow == Controller.FLOW__REBUILD_SEEDXOR:
+                return Destination(RebuildSeedXORShowFingerprintView)
+            else:
+                return Destination(SeedFinalizeView)
 
 
 
@@ -2285,3 +2300,510 @@ class SeedSignMessageSignedMessageQRView(View):
 
         # Exiting/Canceling the QR display screen always returns Home
         return Destination(MainMenuView, skip_current_view=True)
+
+
+
+"""****************************************************************************
+    Rebuild Seed XOR Views
+****************************************************************************"""
+class RebuildSeedXORLoadShardView(View):
+    """View for loading a shard in the Rebuild Seed XOR flow."""
+    SCAN_SHARD = ButtonOption("Scan SeedQR", SeedSignerIconConstants.QRCODE)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    USE_LOADED_SEED = ButtonOption("Use loaded seed", SeedSignerIconConstants.SEEDS)
+
+    def __init__(self):
+        super().__init__()
+        # Clear previous rebuild data when starting a new flow
+        if not self.controller.storage.rebuild_seedxor_shards:
+            self.controller.clear_rebuild_seedxor_data()
+
+    def run(self):
+        # Current shard number is the count + 1
+        shard_num = len(self.controller.storage.rebuild_seedxor_shards) + 1
+        
+        button_data = [
+            self.SCAN_SHARD,
+            self.TYPE_12WORD,
+            self.TYPE_24WORD,
+        ]
+        
+        # TRANSLATOR_NOTE: This is a screen title for loading a "shard", which is one of
+        # several mnemonic seed phrases that will be combined. The variable is the
+        # shard's number in the sequence (e.g., "Load Shard #1").
+        title = _('Load Shard #{}').format(shard_num)
+
+        if len(self.controller.storage.seeds) > 0:
+            button_data.append(self.USE_LOADED_SEED)
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=title,
+            is_button_text_centered=False,
+            button_data=button_data
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORManageView, clear_history=True)
+            
+        
+        elif button_data[selected_menu_num] == self.SCAN_SHARD:
+            from seedsigner.views.scan_views import ScanSeedQRView
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(ScanSeedQRView, view_args={"is_rebuild_seedxor_shard": True})
+        
+        elif button_data[selected_menu_num] == self.TYPE_12WORD:
+            self.controller.storage.init_pending_mnemonic(num_words=12)
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(SeedMnemonicEntryView)
+        
+        elif button_data[selected_menu_num] == self.TYPE_24WORD:
+            self.controller.storage.init_pending_mnemonic(num_words=24)
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(SeedMnemonicEntryView)
+        
+        elif button_data[selected_menu_num] == self.USE_LOADED_SEED:
+            return Destination(RebuildSeedXORSelectExistingSeedView)
+
+
+
+class RebuildSeedXORErrorView(ErrorView):
+    """
+    A dynamic error view that accepts all its content and navigation
+    as parameters during initialization.
+    """
+    def __init__(self, title: str, status_headline: str, text: str, button_text: str, next_destination: Destination):
+        super().__init__(
+            title=title,
+            status_headline=status_headline,
+            text=text,
+            button_text=button_text,
+            next_destination=next_destination
+        )
+
+
+
+class RebuildSeedXORShowFingerprintView(View):
+    """Show the fingerprint of the shard being added to the Seed XOR."""
+    
+    CONTINUE = ButtonOption("Continue")
+    CANCEL = ButtonOption("Discard shard", button_label_color="red")
+    
+    def __init__(self):
+        super().__init__()
+        self.seed = self.controller.storage.get_pending_seed()
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        self.fingerprint = self.seed.get_fingerprint(network=network)
+        self.next_shard_num = len(self.controller.storage.rebuild_seedxor_shards) + 1
+    
+    def run(self):
+        button_data = [self.CONTINUE, self.CANCEL]
+        
+        # TRANSLATOR_NOTE: This is a screen title showing the number of a seed "shard".
+        # A shard is one of several seed phrases being combined. The "{}" will be
+        # replaced by the shard's number (e.g., "Shard #2").
+        title = _("Shard #{}").format(self.next_shard_num)
+
+        # TRANSLATOR_NOTE: This is a headline on a screen that displays a seed's
+        # "fingerprint", which is a short, unique identifier for a seed phrase.
+        status_headline = _("Shard Fingerprint")
+
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=title,
+            status_icon_name=SeedSignerIconConstants.FINGERPRINT,
+            status_color=GUIConstants.BUTTON_FONT_COLOR,
+            status_headline=status_headline,
+            text=self.fingerprint,
+            button_data=button_data,
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON or button_data[selected_menu_num] == self.CANCEL:
+            self.controller.storage.clear_pending_seed()
+            return Destination(RebuildSeedXORLoadShardView)
+        
+        error_dict = self.controller.process_rebuild_seedxor_shard(self.seed)
+        
+        if error_dict:
+            self.controller.storage.clear_pending_seed()
+            return Destination(
+                RebuildSeedXORErrorView,
+                view_args=dict(
+                    title=error_dict.get("title"),
+                    status_headline=error_dict.get("status_headline"),
+                    text=error_dict.get("message"),
+                    button_text=_("OK"),
+                    next_destination=Destination(RebuildSeedXORLoadShardView)
+                ),
+                skip_current_view=True
+            )
+
+        self.controller.storage.clear_pending_seed()
+        return Destination(RebuildSeedXORManageView)
+
+
+
+class RebuildSeedXORManageView(View):
+    """Main management screen for rebuild Seed XOR flow."""
+    
+    LOAD_NEXT_SHARD = ButtonOption("Load Next shard", SeedSignerIconConstants.PLUS)
+    VIEW_LOADED_SHARDS = ButtonOption("Loaded shard", SeedSignerIconConstants.SEEDS)
+    REMOVE_SHARDS = ButtonOption("Remove shard", SeedSignerIconConstants.CLOSE)
+    CANCEL = ButtonOption("Cancel Seed XOR", button_label_color="red")
+    FINALIZE = ButtonOption("Combine shards", SeedSignerIconConstants.CHECK)
+    
+    def __init__(self):
+        super().__init__()
+        self.num_shards = len(self.controller.storage.rebuild_seedxor_shards)
+        
+    def run(self):
+        button_data = []
+        
+        # Always show Load Next Shard option
+        button_data.append(self.LOAD_NEXT_SHARD)
+        
+        if self.num_shards > 0:
+            button_data.append(self.VIEW_LOADED_SHARDS)
+            button_data.append(self.REMOVE_SHARDS)
+            button_data.append(self.CANCEL)
+        
+        # Only show Finalize if at least 2 shards are loaded
+        if self.num_shards >= 2:
+            button_data.insert(-1,self.FINALIZE)
+        
+        # TRANSLATOR_NOTE: This is a screen title that displays the number of seed
+        # shards that have been loaded. The first argument is for the singular
+        # case (e.g., "1 Shard Loaded"), and the second is for the plural
+        # (e.g., "2 Shards Loaded"). The "{}" will be replaced by the number of shards.
+        title = ngettext(
+            "{} Shard Loaded",
+            "{} Shards Loaded",
+            self.num_shards
+        ).format(self.num_shards)
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=title,
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(LoadSeedView, clear_history=True)
+            
+        elif button_data[selected_menu_num] == self.LOAD_NEXT_SHARD:
+            return Destination(RebuildSeedXORLoadShardView)
+            
+        elif button_data[selected_menu_num] == self.VIEW_LOADED_SHARDS:
+            return Destination(RebuildSeedXORViewShardsView)
+            
+        elif button_data[selected_menu_num] == self.REMOVE_SHARDS:
+            return Destination(RebuildSeedXORRemoveShardsView)
+            
+        elif button_data[selected_menu_num] == self.CANCEL:
+            return Destination(RebuildSeedXORCancelView)
+            
+        elif button_data[selected_menu_num] == self.FINALIZE:
+            return Destination(RebuildSeedXORFinalizeView)
+
+
+
+class RebuildSeedXORSelectExistingSeedView(View):
+    """View for selecting an existing seed to use as a shard."""
+    
+    def __init__(self):
+        super().__init__()
+        self.seeds = self.controller.storage.seeds
+        
+    def run(self):
+        button_data = []
+        for i, seed in enumerate(self.seeds):
+            network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            fingerprint = seed.get_fingerprint(network=network)
+            # TRANSLATOR_NOTE: This is a button label for selecting a seed that is already
+            # loaded in the device's memory. The "{}" will be replaced by the seed's 
+            # "fingerprint", a unique identifier (e.g., "Seed abcd1234").
+            button_data.append(ButtonOption("Seed {}".format(fingerprint)))
+            
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Select Seed"),
+            is_button_text_centered=False,
+            button_data=button_data
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORLoadShardView)
+        
+        selected_seed = self.seeds[selected_menu_num]
+        self.controller.storage.set_pending_seed(selected_seed)
+        return Destination(RebuildSeedXORShowFingerprintView)
+
+
+
+class RebuildSeedXORViewShardsView(View):
+    """View all loaded shards in the rebuild Seed XOR flow."""
+    
+    def __init__(self):
+        super().__init__()
+        self.shards = self.controller.storage.rebuild_seedxor_shards
+        
+    def run(self):
+        shards_info_list = [
+            # TRANSLATOR_NOTE: Will insert the shard num and its fingerprint (e.g. "Shard #3: abcd1234")
+            "Shard #{}: {}".format(
+                i + 1,
+                shard.get_fingerprint(network=self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+            )
+            for i, shard in enumerate(self.shards)
+        ]
+        
+        shards_text = "\n".join(shards_info_list)
+        
+        self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Loaded Shards"),
+            status_icon_name=SeedSignerIconConstants.SEEDS,
+            status_headline=None,
+            text=shards_text,
+            button_data=[ButtonOption(_("Done"))]
+        )
+        
+        return Destination(RebuildSeedXORManageView)
+
+
+
+class RebuildSeedXORConfirmRemoveShardView(View):
+    CONFIRM_REMOVE = ButtonOption("Remove shard", button_label_color="red")
+    KEEP_SHARD = ButtonOption("Keep shard")
+
+    def __init__(self, shard_num: int):
+        super().__init__()
+        self.shard_num = shard_num
+        self.shard = self.controller.storage.rebuild_seedxor_shards[shard_num]
+
+    def run(self):
+        button_data = [self.KEEP_SHARD, self.CONFIRM_REMOVE]
+
+        fingerprint = self.shard.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+        
+        # TRANSLATOR_NOTE: Asks the user to confirm removing a specific shard, identified by its number and fingerprint.
+        text = _("Remove shard #{} ({}) from the Seed XOR build?").format(self.shard_num + 1, fingerprint)
+
+        selected_menu_num = self.run_screen(
+            WarningScreen,
+            title=_("Remove Shard?"),
+            status_headline=None,
+            text=text,
+            show_back_button=False,
+            button_data=button_data,
+        )
+
+        if button_data[selected_menu_num] == self.CONFIRM_REMOVE:
+            self.controller.remove_rebuild_seedxor_shard(self.shard_num)
+            return Destination(RebuildSeedXORManageView, clear_history=True)
+            
+        elif button_data[selected_menu_num] == self.KEEP_SHARD:
+            return Destination(RebuildSeedXORRemoveShardsView, skip_current_view=True)
+
+
+
+class RebuildSeedXORRemoveShardsView(View):
+    """Remove shards from the rebuild Seed XOR flow."""
+    
+    def __init__(self):
+        super().__init__()
+        self.shards = self.controller.storage.rebuild_seedxor_shards
+        
+    def run(self):
+        button_data = []
+        for i, shard in enumerate(self.shards):
+            network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            fingerprint = shard.get_fingerprint(network=network)
+            shard_num = i + 1
+            # TRANSLATOR_NOTE: Will insert the shard num and its fingerprint (e.g. "Shard #3: abcd1234")
+            button_data.append(ButtonOption("Shard #{}: {}".format(shard_num, fingerprint)))
+        
+        from seedsigner.gui.screens.screen import GUIConstants
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Remove Shard"),
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORManageView)
+        
+        # Instead of deleting, navigate to the new confirmation view
+        return Destination(RebuildSeedXORConfirmRemoveShardView, view_args={"shard_num": selected_menu_num})
+
+
+
+class RebuildSeedXORCancelView(View):
+    """Confirm cancellation of rebuild Seed XOR flow."""
+    
+    CONFIRM = ButtonOption("Confirm cancel", button_label_color="red")
+    CONTINUE = ButtonOption("Continue Seed XOR")
+    
+    def run(self):
+        button_data = [self.CONTINUE, self.CONFIRM]
+        
+        num_shards = len(self.controller.storage.rebuild_seedxor_shards)
+        
+        # TRANSLATOR_NOTE: This is a confirmation message when canceling the Seed XOR rebuild process.
+        text = _(
+            "Clear all loaded shards and return to Home?"
+        )
+        
+        # TRANSLATOR_NOTE: This is a confirmation message asking the user if they want 
+        # to clear the seed "shards" they have loaded. The "{}" will be replaced by 
+        # the number of shards (e.g., "Clear 2 loaded shards?").
+        status_headline = _("Clear {} loaded shards?".format(num_shards))
+        
+        selected_menu_num = self.run_screen(
+            DireWarningScreen,
+            title=_("Cancel Seed XOR"),
+            status_headline=status_headline,
+            text=text,
+            button_data=button_data,
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON or button_data[selected_menu_num] == self.CONTINUE:
+            return Destination(RebuildSeedXORManageView)
+            
+        elif button_data[selected_menu_num] == self.CONFIRM:
+            self.controller.clear_rebuild_seedxor_data()
+            return Destination(LoadSeedView, clear_history=True)
+
+
+
+class RebuildSeedXORFinalizeView(View):
+    """First step of final confirmation before finalizing the Rebuild Seed XOR seed."""
+    
+    def __init__(self):
+        super().__init__()
+        
+        self.error = None
+        self.seed = None
+        self.fingerprint = None
+        
+        try:        
+            mnemonic_strings = [shard.mnemonic_str for shard in self.controller.storage.rebuild_seedxor_shards]
+            
+            combined_mnemonic = combine_mnemonics_with_xor(mnemonic_strings)
+            
+            self.controller.storage.rebuild_seedxor_combined_seed = Seed(mnemonic=combined_mnemonic)
+            self.controller.storage.set_pending_seed(self.controller.storage.rebuild_seedxor_combined_seed)
+
+            self.seed = self.controller.storage.get_pending_seed()
+            
+            self.fingerprint = self.seed.get_fingerprint(
+                network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            )
+        except Exception as e:
+            self.error = str(e)
+    
+    def run(self):
+        if self.error == "no_shards":
+            return Destination(RebuildSeedXORManageView)
+        elif self.error:
+            return Destination(RebuildSeedXORErrorView, view_args=dict(
+                title=_("XOR Error"),
+                status_headline=_("Error Combining Seeds"),
+                text=_("Error: {}".format(self.error)),
+                button_text=_("OK"),
+                next_destination=Destination(RebuildSeedXORManageView)
+            ))
+        
+        shard_count = len(self.controller.storage.rebuild_seedxor_shards)
+        button_data = [ButtonOption("Continue")]
+        
+        from seedsigner.gui.screens.screen import LargeIconStatusScreen
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Finalize Seed XOR"),
+            status_headline=_("Combined {} shards".format(shard_count)),
+            text=_("Fingerprint: {}\n\nCombined seed calculated successfully.".format(self.fingerprint)),
+            button_data=button_data,
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORManageView)
+        
+        return Destination(RebuildSeedXORFinalizeOptionsView)
+
+
+
+class RebuildSeedXORFinalizeOptionsView(View):
+    """Second step of finalization - choose what to do with individual shards"""
+    
+    DISCARD_SHARDS = ButtonOption("Discard shards", button_label_color="red")
+    KEEP_SHARDS = ButtonOption("Keep shards")
+    PASSPHRASE = ButtonOption("BIP-39 Passphrase")
+    
+    def __init__(self):
+        super().__init__()
+        
+        if not self.controller.storage.rebuild_seedxor_combined_seed:
+            self.set_redirect(Destination(RebuildSeedXORManageView))
+            return
+        
+        self.seed = self.controller.storage.get_pending_seed()
+        
+    def run(self):
+        button_data = [self.DISCARD_SHARDS, self.KEEP_SHARDS]
+        
+        self.PASSPHRASE.button_label = self.seed.passphrase_label
+        if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) != SettingsConstants.OPTION__DISABLED:
+            button_data.append(self.PASSPHRASE)
+            
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Finalize Options"),
+            status_icon_name=SeedSignerIconConstants.SEEDS,
+            status_color=GUIConstants.BUTTON_FONT_COLOR,
+            status_headline=_("What about the shards?"),
+            text=_("Keep or discard shards?"),
+            button_data=button_data,
+        )
+        
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORFinalizeView)
+            
+        elif button_data[selected_menu_num] == self.DISCARD_SHARDS:
+            # First finalize the seed to add it to memory
+            seed_num = self.controller.storage.finalize_pending_seed()
+            combined_fingerprint = self.controller.storage.seeds[seed_num].get_fingerprint()
+            
+            for shard in self.controller.storage.rebuild_seedxor_shards:
+                for i, seed in enumerate(self.controller.storage.seeds):
+                    SeedFingerprint = seed.get_fingerprint()
+                    if SeedFingerprint == combined_fingerprint:
+                        continue
+                    if SeedFingerprint == shard.get_fingerprint():
+                        self.controller.discard_seed(i)
+                        if i < seed_num:
+                            seed_num -= 1
+                        break
+            
+            self.controller.clear_rebuild_seedxor_data()
+            
+            # Find the combined seed by fingerprint to be [EXTRA SAFE STEP]
+            for i, seed in enumerate(self.controller.storage.seeds):
+                SeedFingerprint = seed.get_fingerprint()
+                if SeedFingerprint == combined_fingerprint:
+                    seed_num = i
+                    break
+            
+            return Destination(SeedOptionsView, view_args={"seed_num": seed_num}, clear_history=True)
+            
+        elif button_data[selected_menu_num] == self.KEEP_SHARDS:
+            seed_num = self.controller.storage.finalize_pending_seed()
+            self.controller.clear_rebuild_seedxor_data()
+
+            return Destination(SeedOptionsView, view_args={"seed_num": seed_num}, clear_history=True)
+            
+        elif button_data[selected_menu_num] == self.PASSPHRASE:
+            return Destination(SeedAddPassphraseView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2307,10 +2307,16 @@ class SeedSignMessageSignedMessageQRView(View):
     Rebuild Seed XOR Views
 ****************************************************************************"""
 class RebuildSeedXORLoadShardView(View):
-    """View for loading a shard in the Rebuild Seed XOR flow."""
+    """View for loading a shard in the Rebuild Seed XOR flow.
+
+    When Electrum seed support is enabled, an additional option to enter an
+    Electrum seed is shown. Both BIP-39 and Electrum seeds use the same
+    2048-word BIP-39 wordlist, so XOR math works identically for both.
+    """
     SCAN_SHARD = ButtonOption("Scan SeedQR", SeedSignerIconConstants.QRCODE)
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
     USE_LOADED_SEED = ButtonOption("Use loaded seed", SeedSignerIconConstants.SEEDS)
 
     def __init__(self):
@@ -2328,10 +2334,11 @@ class RebuildSeedXORLoadShardView(View):
             self.TYPE_12WORD,
             self.TYPE_24WORD,
         ]
-        
-        # TRANSLATOR_NOTE: This is a screen title for loading a "shard", which is one of
-        # several mnemonic seed phrases that will be combined. The variable is the
-        # shard's number in the sequence (e.g., "Load Shard #1").
+
+        # Electrum seed option, gated by the existing setting
+        if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TYPE_ELECTRUM)
+
         title = _('Load Shard #{}').format(shard_num)
 
         if len(self.controller.storage.seeds) > 0:
@@ -2362,7 +2369,16 @@ class RebuildSeedXORLoadShardView(View):
             self.controller.storage.init_pending_mnemonic(num_words=24)
             self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
             return Destination(SeedMnemonicEntryView)
-        
+
+        elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
+            # Electrum seeds are always 12 words. Route through the Electrum
+            # warning screen, then to the mnemonic entry flow. The
+            # FLOW__REBUILD_SEEDXOR flag ensures we return to the XOR flow
+            # after entry rather than going to the normal seed finalization.
+            self.controller.storage.init_pending_mnemonic(num_words=12, is_electrum=True)
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(SeedElectrumMnemonicStartView)
+
         elif button_data[selected_menu_num] == self.USE_LOADED_SEED:
             return Destination(RebuildSeedXORSelectExistingSeedView)
 
@@ -2680,32 +2696,79 @@ class RebuildSeedXORCancelView(View):
 
 
 class RebuildSeedXORFinalizeView(View):
-    """First step of final confirmation before finalizing the Rebuild Seed XOR seed."""
-    
+    """Finalize the XOR operation: combine shards and detect result type.
+
+    After computing the XOR of all components, detects whether the result is
+    an Electrum seed or a BIP-39 seed. This matters because:
+    - Electrum seeds use different derivation paths (m/0h, m/1h)
+    - Electrum seeds have SeedQR disabled
+    - The user needs to know which wallet software to use
+    """
+
     def __init__(self):
         super().__init__()
-        
+
         self.error = None
         self.seed = None
         self.fingerprint = None
-        
-        try:        
+        self.seed_type = "BIP-39"
+
+        try:
             mnemonic_strings = [shard.mnemonic_str for shard in self.controller.storage.rebuild_seedxor_shards]
-            
+
             combined_mnemonic = combine_mnemonics_with_xor(mnemonic_strings)
-            
-            self.controller.storage.rebuild_seedxor_combined_seed = Seed(mnemonic=combined_mnemonic)
-            self.controller.storage.set_pending_seed(self.controller.storage.rebuild_seedxor_combined_seed)
+
+            # Detect if the result is an Electrum seed
+            from seedsigner.models.seed import ElectrumSeed
+            mnemonic_type = Seed.detect_mnemonic_type(combined_mnemonic)
+
+            if mnemonic_type == "electrum":
+                # Check that Electrum support is enabled
+                if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
+                    self.seed_type = "Electrum Segwit"
+                    # The XOR result has a BIP-39 checksum, but the original
+                    # Electrum seed may have had different last-word bits.
+                    # get_electrum_mnemonic finds the correct last word.
+                    electrum_mnemonic = Seed.get_electrum_mnemonic(combined_mnemonic)
+                    if electrum_mnemonic:
+                        combined_seed = ElectrumSeed(mnemonic=electrum_mnemonic)
+                    else:
+                        # Shouldn't happen if detect said "electrum", but be safe
+                        combined_seed = Seed(mnemonic=combined_mnemonic)
+                        self.seed_type = "BIP-39"
+                else:
+                    # Result is Electrum but support is disabled - warn user
+                    self.error = "electrum_disabled"
+                    return
+            else:
+                combined_seed = Seed(mnemonic=combined_mnemonic)
+
+            self.controller.storage.rebuild_seedxor_combined_seed = combined_seed
+            self.controller.storage.set_pending_seed(combined_seed)
 
             self.seed = self.controller.storage.get_pending_seed()
-            
+
             self.fingerprint = self.seed.get_fingerprint(
                 network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             )
         except Exception as e:
             self.error = str(e)
-    
+
     def run(self):
+        if self.error == "electrum_disabled":
+            self.run_screen(
+                WarningScreen,
+                title=_("Electrum Seed Detected"),
+                status_headline=_("Warning"),
+                text=_(
+                    "The XOR result is an Electrum seed, but Electrum "
+                    "support is disabled. Enable it in Settings to use this seed."
+                ),
+                show_back_button=False,
+                button_data=[ButtonOption(_("OK"))],
+            )
+            return Destination(RebuildSeedXORManageView)
+
         if self.error == "no_shards":
             return Destination(RebuildSeedXORManageView)
         elif self.error:
@@ -2716,22 +2779,23 @@ class RebuildSeedXORFinalizeView(View):
                 button_text=_("OK"),
                 next_destination=Destination(RebuildSeedXORManageView)
             ))
-        
+
         shard_count = len(self.controller.storage.rebuild_seedxor_shards)
         button_data = [ButtonOption("Continue")]
-        
-        from seedsigner.gui.screens.screen import LargeIconStatusScreen
+
+        status_text = _("Fingerprint: {}\nType: {}").format(self.fingerprint, self.seed_type)
+
         selected_menu_num = self.run_screen(
             LargeIconStatusScreen,
             title=_("Finalize Seed XOR"),
             status_headline=_("Combined {} shards".format(shard_count)),
-            text=_("Fingerprint: {}\n\nCombined seed calculated successfully.".format(self.fingerprint)),
+            text=status_text,
             button_data=button_data,
         )
-        
+
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(RebuildSeedXORManageView)
-        
+
         return Destination(RebuildSeedXORFinalizeOptionsView)
 
 

--- a/tests/test_flow_seedxor.py
+++ b/tests/test_flow_seedxor.py
@@ -1,0 +1,186 @@
+from base import FlowTest, FlowStep
+from seedsigner.models.seed import Seed
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.views.view import MainMenuView
+from seedsigner.views import seed_views, scan_views
+from seedsigner.views.seed_views import SeedsMenuView
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+
+EXAMPLE_24_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability miss spice fitness easy legal release recall obey exchange recycle dragon room"
+EXAMPLE_24_B = "lion misery divide hurry latin fluid camp advance illegal lab pyramid unaware eager fringe sick camera series noodle toy crowd jeans select depth lounge"
+EXAMPLE_24_C = "vault nominee cradle silk own frown throw leg cactus recall talent worry gadget surface shy planet purpose coffee drip few seven term squeeze educate"
+RESULT_24_ABC_FINGERPRINT = "55057647" # Fingerprint of the combined seed
+
+EXAMPLE_12_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability"
+
+
+
+def type_mnemonic(mnemonic: str):
+    """ Helper function to generate a list of FlowSteps for typing a mnemonic. """
+    flow = []
+    for word in mnemonic.split():
+        flow.append(FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=word))
+    return flow
+
+
+
+class TestSeedXORFlows(FlowTest):
+    def test_recombine_3_shards_24_words_success_flow(self):
+        """
+        Tests the complete, successful SeedXOR flow using three 24-word seeds.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        self.controller.storage.seeds.append(Seed(mnemonic=EXAMPLE_24_C.split()))
+
+        # Calculate the expected result dynamically
+        expected_mnemonic_list = combine_mnemonics_with_xor([EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C])
+        expected_seed = Seed(mnemonic=expected_mnemonic_list)
+        expected_fingerprint = expected_seed.get_fingerprint()
+
+        def check_fingerprint(view):
+            assert view.fingerprint == expected_fingerprint
+
+        # Helper to simulate scanning a seed by adding its numeric representation to the decoder
+        def load_seed_qr_into_decoder(view: scan_views.ScanView):
+            wordlist = Seed.get_wordlist()
+            indexes = [wordlist.index(word) for word in EXAMPLE_24_B.split()]
+            numeric_seed_str = "".join([str(i).zfill(4) for i in indexes])
+            view.decoder.add_data(numeric_seed_str)
+
+        # === Start Flow and Add Shard 1 (Typing) ===
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, button_data_selection=SeedsMenuView.LOAD),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.TYPE_24WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_24_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 1
+
+        # === Add Shard 2 (Scan QR) ===
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.SCAN_SHARD),
+            FlowStep(scan_views.ScanSeedQRView, before_run=load_seed_qr_into_decoder),
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 2
+
+        # === Add Shard 3 (Use Loaded Seed) ===
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.USE_LOADED_SEED),
+            FlowStep(seed_views.RebuildSeedXORSelectExistingSeedView, screen_return_value=0),
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 3
+
+        # === Finalize and Verify ===
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(
+                seed_views.RebuildSeedXORFinalizeView,
+                before_run=check_fingerprint,
+                button_data_selection=0
+            ),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView, button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.KEEP_SHARDS),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+        ])
+        assert len(self.controller.storage.seeds) == 2
+
+
+    def test_error_on_duplicate_shard(self):
+        """
+        Tests that the system prevents a user from adding the same shard twice.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        
+        def check_error_title(view):
+            assert view.title == "Duplicate Shard"
+
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 1
+
+        # Attempt to load the same shard again
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(
+                seed_views.RebuildSeedXORErrorView,
+                before_run=check_error_title,
+                button_data_selection=0
+            ),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, is_redirect=True),
+        ]
+        
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 1
+
+
+    def test_error_on_mismatched_length(self):
+        """
+        Tests that the system prevents adding a 24-word shard after a 12-word shard.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        def check_error_title(view):
+            assert view.title == "Mnemonic Length Mismatch"
+
+        # Load a 12-word shard
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 1
+
+        # Attempt to load a 24-word shard
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_SHARD),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, button_data_selection=seed_views.RebuildSeedXORLoadShardView.TYPE_24WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_24_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(
+                seed_views.RebuildSeedXORErrorView,
+                before_run=check_error_title,
+                button_data_selection=0
+            ),
+            FlowStep(seed_views.RebuildSeedXORLoadShardView, is_redirect=True),
+        ]
+        
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_shards) == 1

--- a/tests/test_seedxor.py
+++ b/tests/test_seedxor.py
@@ -74,9 +74,9 @@ class TestCombineMnemonicsWithXOR(unittest.TestCase):
 
 
     def test_raises_error_for_invalid_mnemonic(self):
-        """Ensures ValueError is raised for a mnemonic with a bad checksum or invalid word. """
-        invalid_mnemonic = "romance wink lottery autumn shop bring dawn tongue range crater truth zebra" # 'zebra' is invalid
-        with self.assertRaisesRegex(ValueError, "Invalid mnemonic"):
+        """Ensures ValueError is raised for a mnemonic with an invalid word."""
+        invalid_mnemonic = "romance wink lottery autumn shop bring dawn tongue range crater truth xyzzy"  # 'xyzzy' is not in BIP-39 wordlist
+        with self.assertRaisesRegex(ValueError, "not in the dictionary"):
             combine_mnemonics_with_xor([EXAMPLE_12_A, invalid_mnemonic])
 
 

--- a/tests/test_seedxor.py
+++ b/tests/test_seedxor.py
@@ -1,0 +1,164 @@
+import unittest
+from unittest.mock import MagicMock
+
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
+
+from embit import bip39
+
+EXAMPLE_24_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability miss spice fitness easy legal release recall obey exchange recycle dragon room"
+EXAMPLE_24_B = "lion misery divide hurry latin fluid camp advance illegal lab pyramid unaware eager fringe sick camera series noodle toy crowd jeans select depth lounge"
+EXAMPLE_24_C = "vault nominee cradle silk own frown throw leg cactus recall talent worry gadget surface shy planet purpose coffee drip few seven term squeeze educate"
+RESULT_24_ABC = "silent toe meat possible chair blossom wait occur this worth option bag nurse find fish scene bench asthma bike wage world quit primary indoor"
+
+EXAMPLE_12_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability"
+EXAMPLE_12_B = "boat unfair shell violin tree robust open ride visual forest vintage approve"
+EXAMPLE_12_C = "lion misery divide hurry latin fluid camp advance illegal lab pyramid unhappy"
+RESULT_12_ABC = "cannon opinion leader nephew found yard metal galaxy crouch between real trade"
+
+ZERO_ENTROPY_MNEMONIC_12 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+ZERO_ENTROPY_MNEMONIC_24 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+
+
+
+class TestCombineMnemonicsWithXOR(unittest.TestCase):
+    """
+    Tests the core XOR calculation logic, input validation, and error handling.
+    """
+    
+    def test_xor_24_word_example(self):
+        """Tests the 3-part 24-word XOR calculation from the provided example. """
+        mnemonics = [EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C]
+        result = combine_mnemonics_with_xor(mnemonics)
+        self.assertEqual(result, RESULT_24_ABC.split())
+
+
+    def test_xor_12_word_example(self):
+        """Tests the 3-part 12-word XOR calculation from the provided example. """
+        mnemonics = [EXAMPLE_12_A, EXAMPLE_12_B, EXAMPLE_12_C]
+        result = combine_mnemonics_with_xor(mnemonics)
+        self.assertEqual(result, RESULT_12_ABC.split())
+
+
+    def test_xor_identity_property(self):
+        """ Tests the XOR identity property (A ^ B ^ B = A). """
+        mnemonics = [EXAMPLE_12_A, EXAMPLE_12_B, EXAMPLE_12_B]
+        result = combine_mnemonics_with_xor(mnemonics)
+        self.assertEqual(result, EXAMPLE_12_A.split())
+
+
+    def test_xor_null_property(self):
+        """ Tests the XOR null property (A ^ A = 0) for both 12 and 24-word mnemonics. """
+        # Test 12-word case
+        result_12 = combine_mnemonics_with_xor([EXAMPLE_12_A, EXAMPLE_12_A])
+        self.assertEqual(result_12, ZERO_ENTROPY_MNEMONIC_12.split())
+        
+        # Test 24-word case
+        result_24 = combine_mnemonics_with_xor([EXAMPLE_24_A, EXAMPLE_24_A])
+        self.assertEqual(result_24, ZERO_ENTROPY_MNEMONIC_24.split())
+
+
+    def test_handles_list_of_words_input(self):
+        """Tests that the function correctly processes mnemonics formatted as a list of words. """
+        mnemonics = [EXAMPLE_12_A.split(), EXAMPLE_12_B]
+        result = combine_mnemonics_with_xor(mnemonics)
+        
+        expected_result = "person bitter door winner candy polar proud fringe early have bulb apple".split()
+        self.assertEqual(result, expected_result)
+
+
+    def test_raises_error_for_empty_list(self):
+        """Ensures ValueError is raised for an empty mnemonic list. """
+        with self.assertRaisesRegex(ValueError, "Mnemonic list cannot be empty"):
+            combine_mnemonics_with_xor([])
+
+
+    def test_raises_error_for_invalid_mnemonic(self):
+        """Ensures ValueError is raised for a mnemonic with a bad checksum or invalid word. """
+        invalid_mnemonic = "romance wink lottery autumn shop bring dawn tongue range crater truth zebra" # 'zebra' is invalid
+        with self.assertRaisesRegex(ValueError, "Invalid mnemonic"):
+            combine_mnemonics_with_xor([EXAMPLE_12_A, invalid_mnemonic])
+
+
+    def test_raises_error_for_mismatched_lengths(self):
+        """ Ensures ValueError is raised when mnemonics have different entropy lengths. """
+        with self.assertRaisesRegex(ValueError, "All mnemonics must generate entropy of the same length"):
+            combine_mnemonics_with_xor([EXAMPLE_12_A, EXAMPLE_24_A])
+
+
+
+class TestSeedXORValidator(unittest.TestCase):
+    """
+    Tests the validation logic for adding new shards to an XOR operation.
+    """
+    def setUp(self):
+        """ Set up mock Seed objects for testing using the provided examples. """
+        self.shard_12_A = MagicMock()
+        self.shard_12_A.has_passphrase = False
+        self.shard_12_A.mnemonic_str = EXAMPLE_12_A
+        self.shard_12_A.mnemonic_list = EXAMPLE_12_A.split()
+
+        self.shard_12_B = MagicMock()
+        self.shard_12_B.has_passphrase = False
+        self.shard_12_B.mnemonic_str = EXAMPLE_12_B
+        self.shard_12_B.mnemonic_list = EXAMPLE_12_B.split()
+        
+        self.shard_24_A = MagicMock()
+        self.shard_24_A.has_passphrase = False
+        self.shard_24_A.mnemonic_str = EXAMPLE_24_A
+        self.shard_24_A.mnemonic_list = EXAMPLE_24_A.split()
+
+
+    def test_valid_first_shard(self):
+        """ A valid shard added to an empty list should pass. """
+        is_valid, error = SeedXORValidator.validate_shard(self.shard_12_A, [])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+
+    def test_valid_second_shard(self):
+        """ A second, valid, unique shard of the same length should pass. """
+        is_valid, error = SeedXORValidator.validate_shard(self.shard_12_B, [self.shard_12_A])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+
+    def test_rejects_shard_with_passphrase(self):
+        """ Shards with passphrases should be rejected. """
+        self.shard_12_A.has_passphrase = True
+        is_valid, error = SeedXORValidator.validate_shard(self.shard_12_A, [])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Passphrase Not Allowed")
+
+
+    def test_rejects_mismatched_mnemonic_length(self):
+        """ Shards of different lengths should be rejected. """
+        is_valid, error = SeedXORValidator.validate_shard(self.shard_24_A, [self.shard_12_A])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Mnemonic Length Mismatch")
+
+
+    def test_rejects_duplicate_shard(self):
+        """ An identical shard should be rejected. """
+        is_valid, error = SeedXORValidator.validate_shard(self.shard_12_A, [self.shard_12_A])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Duplicate Shard")
+        self.assertIn("shard #1", error["message"])
+
+
+    def test_rejects_inverse_shard(self):
+        """ A binary inverse shard (which would cancel another out) should be rejected. """
+        entropy_a = bip39.mnemonic_to_bytes(EXAMPLE_12_A)
+        inverse_entropy = bytes(b ^ 0xFF for b in entropy_a)
+        inverse_mnemonic_str = bip39.mnemonic_from_bytes(inverse_entropy)
+
+        inverse_shard = MagicMock()
+        inverse_shard.has_passphrase = False
+        inverse_shard.mnemonic_str = inverse_mnemonic_str
+        inverse_shard.mnemonic_list = inverse_mnemonic_str.split()
+
+        is_valid, error = SeedXORValidator.validate_shard(inverse_shard, [self.shard_12_A])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Seed Inversion")
+        self.assertIn("binary inverse of shard #1", error["message"])
+

--- a/tests/test_seedxor_electrum.py
+++ b/tests/test_seedxor_electrum.py
@@ -1,0 +1,202 @@
+"""
+Tests for Electrum seed support in Seed XOR operations.
+
+Verifies that:
+1. Electrum seeds can participate in XOR operations
+2. XOR'ing an Electrum seed with random BIP-39 parts and back produces
+   the original Electrum seed
+3. The result type is correctly detected (Electrum vs BIP-39)
+4. Word count restrictions are enforced
+5. XOR is commutative and associative
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+from seedsigner.models.seed import Seed, ElectrumSeed
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
+
+from embit import bip39
+
+# A known valid Electrum segwit seed (12 words, HMAC prefix "100")
+# This is from the existing test suite in test_seed.py
+ELECTRUM_SEED = "regular reject rare profit once math fringe chase until ketchup century escape"
+
+# Valid BIP-39 12-word seeds to use as XOR partners
+BIP39_SEED_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability"
+BIP39_SEED_B = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong"
+
+# A valid BIP-39 24-word seed
+BIP39_SEED_24 = "romance wink lottery autumn shop bring dawn tongue range crater truth ability miss spice fitness easy legal release recall obey exchange recycle dragon room"
+
+
+
+class TestSeedXORWithElectrumSeeds(unittest.TestCase):
+
+    def test_electrum_seed_is_valid(self):
+        """Verify our test Electrum seed is actually valid."""
+        seed = ElectrumSeed(mnemonic=ELECTRUM_SEED.split())
+        self.assertIsNotNone(seed.seed_bytes)
+
+    def test_electrum_seed_roundtrip(self):
+        """
+        XOR an Electrum seed with a BIP-39 seed, then XOR the result back
+        with the same BIP-39 seed. The entropy is perfectly preserved.
+
+        The XOR result will have a BIP-39 checksum (last word may differ),
+        but get_electrum_mnemonic recovers the exact original Electrum seed.
+        """
+        electrum_words = ELECTRUM_SEED.split()
+
+        # Split: electrum XOR bip39 = part_b
+        part_b = combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_A])
+
+        # Reconstruct: part_b XOR bip39 = entropy of original electrum
+        reconstructed = combine_mnemonics_with_xor([" ".join(part_b), BIP39_SEED_A])
+
+        # The first 11 words are identical (they carry only entropy bits)
+        self.assertEqual(reconstructed[:-1], electrum_words[:-1])
+
+        # Use get_electrum_mnemonic to recover the exact original last word
+        electrum_mnemonic = Seed.get_electrum_mnemonic(reconstructed)
+        self.assertIsNotNone(electrum_mnemonic)
+        self.assertEqual(electrum_mnemonic, electrum_words)
+
+    def test_xor_result_type_detection_electrum(self):
+        """
+        After XOR reconstruction, the result should be detected as Electrum.
+        """
+        part_b = combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_A])
+        reconstructed = combine_mnemonics_with_xor([" ".join(part_b), BIP39_SEED_A])
+
+        self.assertEqual(Seed.detect_mnemonic_type(reconstructed), "electrum")
+
+    def test_xor_result_type_detection_bip39(self):
+        """
+        XOR of two BIP-39 seeds should be detected as BIP-39.
+        """
+        result = combine_mnemonics_with_xor([BIP39_SEED_A, BIP39_SEED_B])
+        self.assertEqual(Seed.detect_mnemonic_type(result), "bip39")
+
+    def test_xor_part_is_valid_bip39(self):
+        """
+        XOR parts derived from an Electrum seed should be valid BIP-39.
+        They should NOT be valid Electrum seeds (astronomically unlikely).
+        """
+        part_b = combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_A])
+
+        # part_b should be a valid BIP-39 mnemonic
+        self.assertTrue(bip39.mnemonic_is_valid(" ".join(part_b)))
+
+        # part_b is almost certainly NOT a valid Electrum seed
+        self.assertEqual(Seed.detect_mnemonic_type(part_b), "bip39")
+
+    def test_mixed_12word_electrum_bip39(self):
+        """
+        Can XOR a 12-word Electrum seed with multiple 12-word BIP-39 seeds.
+        The entropy round-trips perfectly; get_electrum_mnemonic recovers
+        the exact original.
+        """
+        electrum_words = ELECTRUM_SEED.split()
+
+        # 3-way split
+        parts = combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_A, BIP39_SEED_B])
+        # Reconstruct
+        result = combine_mnemonics_with_xor([" ".join(parts), BIP39_SEED_A, BIP39_SEED_B])
+
+        # First 11 words match (pure entropy)
+        self.assertEqual(result[:-1], electrum_words[:-1])
+
+        # Recover exact Electrum mnemonic
+        electrum_mnemonic = Seed.get_electrum_mnemonic(result)
+        self.assertIsNotNone(electrum_mnemonic)
+        self.assertEqual(electrum_mnemonic, electrum_words)
+
+    def test_word_count_mismatch_rejected(self):
+        """
+        Cannot XOR a 12-word Electrum seed with a 24-word BIP-39 seed.
+        """
+        with self.assertRaises(ValueError):
+            combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_24])
+
+    def test_three_way_xor_order_independent(self):
+        """
+        XOR is commutative and associative: order doesn't matter.
+        """
+        result_abc = combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_A, BIP39_SEED_B])
+        result_bca = combine_mnemonics_with_xor([BIP39_SEED_A, BIP39_SEED_B, ELECTRUM_SEED])
+        result_cab = combine_mnemonics_with_xor([BIP39_SEED_B, ELECTRUM_SEED, BIP39_SEED_A])
+
+        self.assertEqual(result_abc, result_bca)
+        self.assertEqual(result_bca, result_cab)
+
+    def test_detect_mnemonic_type_known_electrum(self):
+        """
+        detect_mnemonic_type should identify a known Electrum seed.
+        """
+        self.assertEqual(Seed.detect_mnemonic_type(ELECTRUM_SEED.split()), "electrum")
+
+    def test_detect_mnemonic_type_known_bip39(self):
+        """
+        detect_mnemonic_type should identify a known BIP-39 seed.
+        Note: We use BIP39_SEED_B here because BIP39_SEED_A happens to have
+        a last-word variant that collides with an Electrum standard prefix.
+        """
+        self.assertEqual(Seed.detect_mnemonic_type(BIP39_SEED_B.split()), "bip39")
+
+    def test_validator_accepts_electrum_shard(self):
+        """
+        The SeedXORValidator should accept an Electrum seed as a shard
+        (it has no passphrase and valid word count).
+        """
+        # Create a real ElectrumSeed object
+        electrum_seed = ElectrumSeed(mnemonic=ELECTRUM_SEED.split())
+        bip39_seed = Seed(mnemonic=BIP39_SEED_A.split())
+
+        # First shard (Electrum)
+        is_valid, error = SeedXORValidator.validate_shard(electrum_seed, [])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+        # Second shard (BIP-39 after Electrum)
+        is_valid, error = SeedXORValidator.validate_shard(bip39_seed, [electrum_seed])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+    def test_validator_rejects_electrum_with_passphrase(self):
+        """
+        Electrum seeds with a passphrase should be rejected as XOR components.
+        """
+        electrum_seed = ElectrumSeed(mnemonic=ELECTRUM_SEED.split(), passphrase="test")
+
+        is_valid, error = SeedXORValidator.validate_shard(electrum_seed, [])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Passphrase Not Allowed")
+
+    def test_reconstructed_electrum_seed_derivation(self):
+        """
+        After XOR reconstruction and Electrum mnemonic recovery, the seed
+        should produce the same derivation path and fingerprint as the original.
+        """
+        original = ElectrumSeed(mnemonic=ELECTRUM_SEED.split())
+        original_fingerprint = original.get_fingerprint()
+
+        # Split and reconstruct
+        part_b = combine_mnemonics_with_xor([ELECTRUM_SEED, BIP39_SEED_A])
+        reconstructed_mnemonic = combine_mnemonics_with_xor([" ".join(part_b), BIP39_SEED_A])
+
+        # Verify it's detected as Electrum
+        self.assertEqual(Seed.detect_mnemonic_type(reconstructed_mnemonic), "electrum")
+
+        # Recover the exact Electrum mnemonic (correct last word)
+        electrum_mnemonic = Seed.get_electrum_mnemonic(reconstructed_mnemonic)
+        self.assertIsNotNone(electrum_mnemonic)
+
+        # Create ElectrumSeed from recovered mnemonic
+        reconstructed = ElectrumSeed(mnemonic=electrum_mnemonic)
+        reconstructed_fingerprint = reconstructed.get_fingerprint()
+
+        self.assertEqual(original_fingerprint, reconstructed_fingerprint)
+        self.assertEqual(original.derivation_override(), reconstructed.derivation_override())
+        self.assertFalse(reconstructed.seedqr_supported)


### PR DESCRIPTION
Based on: PR https://github.com/SeedSigner/seedsigner/pull/738 (Seed XOR functionality)
Related: PR https://github.com/SeedSigner/seedsigner/pull/513 / https://github.com/SeedSigner/seedsigner/pull/571 (Electrum seed support), Issue https://github.com/SeedSigner/seedsigner/issues/43 (SeedXOR)

## Summary

Builds on PR #738 (Seed XOR Flow by @Advaitgaur004) to add Electrum native segwit seed support to the XOR split/combine workflow.

- Electrum seeds can now be used as XOR shards alongside BIP-39 seeds
- XOR recombination auto-detects when the result is an Electrum seed
- The exact Electrum mnemonic is recovered after BIP-39 checksum recomputation
- 13 new unit tests verify Electrum XOR roundtrip, type detection, and validator compatibility
- All 27 XOR tests pass (14 existing + 13 new)

> **Note:** This PR is focused exclusively on Seed XOR + Electrum support. The AES-256-CBC encrypted seed QR import feature is in a separate PR (#882).

## Changes (13 files)

### Core (`src/seedsigner/helpers/mnemonic_generation.py`)
- Replaced entropy-based XOR (`bip39.mnemonic_to_bytes`) with word-index-based approach — Electrum seeds lack valid BIP-39 checksums, so direct entropy extraction fails. Word-index XOR operates on the raw 11-bit indices and reconstructs entropy bits afterwards.

### Model (`src/seedsigner/models/seed.py`)
- `Seed._is_electrum_hmac()` — HMAC-SHA512 prefix check for segwit ("100") only. The standard prefix ("01") is excluded to prevent false positives during 256-variant brute-force on 24-word seeds.
- `Seed.detect_mnemonic_type()` — Checks all 16/256 last-word checksum variants for Electrum HMAC match
- `Seed.get_electrum_mnemonic()` — Recovers the exact last word that makes the mnemonic a valid Electrum seed

### Validator (`src/seedsigner/helpers/seed_xor_validator.py`)
- Use `ignore_checksum=True` in inverse-shard detection so Electrum seeds don't trigger checksum errors

### Controller (`src/seedsigner/controller.py`)
- Added `FLOW__REBUILD_SEEDXOR` constant and XOR rebuild methods: `validate_rebuild_seedxor_shard()`, `process_rebuild_seedxor_shard()`, `remove_rebuild_seedxor_shard()`, `clear_rebuild_seedxor_data()`

### Storage (`src/seedsigner/models/seed_storage.py`)
- Added XOR rebuild state: `rebuild_seedxor_shards`, `rebuild_seedxor_combined_seed`, and management methods

### Settings (`src/seedsigner/models/settings_definition.py`)
- Added `SETTING__SEED_XOR` feature toggle (advanced, enabled by default)

### GUI (`src/seedsigner/gui/components.py`)
- Uncommented `CLOSE` icon constant used by Seed XOR views

### Views (`src/seedsigner/views/seed_views.py`)
- Complete Seed XOR rebuild flow: `RebuildSeedXORLoadShardView`, `RebuildSeedXORManageView`, `RebuildSeedXORShowFingerprintView`, `RebuildSeedXORFinalizeView`, `RebuildSeedXORFinalizeOptionsView`, and more
- "Enter Electrum seed" button gated by `SETTING__ELECTRUM_SEEDS`
- Auto-detects Electrum vs BIP-39 result, creates `ElectrumSeed` when appropriate
- Warning screen when Electrum support is disabled but XOR result is Electrum

### Scan Views (`src/seedsigner/views/scan_views.py`)
- `ScanSeedQRView` accepts `is_rebuild_seedxor_shard` parameter to route scanned seeds into the XOR flow
- Back button handling for scan screen

### Tests
- `tests/test_seedxor.py`: 14 tests for base XOR logic (combine, commutativity, identity, invalid words, mismatched lengths)
- `tests/test_seedxor_electrum.py`: 13 tests (roundtrip, type detection, commutativity, validator acceptance, derivation path preservation)
- `tests/test_flow_seedxor.py`: Integration tests for XOR rebuild UI workflow

## Checklist
- [x] `pytest` passes
- [x] Tested on Raspberry Pi OS (manual build)
- [x] Tested on SeedSigner OS (Pi0)

## Test plan
- [x] All 27 XOR tests pass (14 base + 13 Electrum)
- [x] Manual test: Split Electrum seed → enter shares → Rebuild Seed XOR → verify fingerprint matches
- [x] Manual test: Verify "Enter Electrum seed" button only appears when Electrum Seeds setting is enabled
- [x] Manual test: Verify warning screen when XOR result is Electrum but setting is disabled