### PR TITLE
chore: bump version to 0.8.7

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: seedsigner 0.8.6\n"
+"Project-Id-Version: seedsigner 0.8.7\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-19 19:13+0000\n"
+"POT-Creation-Date: 2026-03-05 22:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Build an offline, airgapped Bitcoin signing device for less than 
 name = "seedsigner"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.6"
+version = "0.8.7"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/SeedSigner/seedsigner/issues"

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -100,7 +100,7 @@ class Controller(Singleton):
         rather than at the top in order avoid circular imports.
     """
 
-    VERSION = "0.8.6"
+    VERSION = "0.8.7"
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.


### PR DESCRIPTION
## Description

Bumped version to `0.8.7`!

### Additional Information

- Also regenerated `messages.pot` so it picks up `0.8.7` as the project version.

### Screenshots

<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/14116295-a25d-44e6-bc89-55211c2a7b9d" />

---

This pull request is categorized as a:

- [x] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] Yes

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand
