### PR TITLE
[l10n] Finalize v0.8.7 languages

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -130,7 +130,7 @@ class SettingsConstants:
         LOCALE__DUTCH: "Nederlands",
 
         # --------- Beta languages ------------------------------------------------------
-        LOCALE__CZECH: "Čeština",
+        LOCALE__CZECH: "(beta) Čeština",
         LOCALE__CHINESE_SIMPLIFIED: "(beta) 简体中文 (Chinese Simplified)",
         LOCALE__HINDI: "(beta) हिन्दी (Hindi)",
         LOCALE__INDONESIAN: "(beta) Indonesia (Indonesian)",

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -130,11 +130,23 @@ class SettingsConstants:
         LOCALE__DUTCH: "Nederlands",
 
         # --------- Beta languages ------------------------------------------------------
+        LOCALE__CZECH: "Čeština",
         LOCALE__CHINESE_SIMPLIFIED: "(beta) 简体中文 (Chinese Simplified)",
         LOCALE__HINDI: "(beta) हिन्दी (Hindi)",
+        LOCALE__INDONESIAN: "(beta) Indonesia (Indonesian)",
         LOCALE__JAPANESE: "(beta) 日本語 (Japanese)",
         LOCALE__KOREAN: "(beta) 한국어 (Korean)",
+        LOCALE__PERSIAN: "(beta) فارسی (Persian)",
+        LOCALE__POLISH: "(beta) Polski",
+        LOCALE__PORTUGUESE_BR: "(beta) Português (Brasil)",
         LOCALE__THAI: "(beta) ไทย (Thai)",
+        LOCALE__VIETNAMESE: "(beta) Tiếng Việt (Vietnamese)",
+
+        # --------- In Progress Languages -----------------------------------------------
+        LOCALE__GREEK: "(incomplete) Ελληνικά (Greek)",  # OpenSans includes Greek chars
+        LOCALE__NORWEGIAN: "(incomplete) Norsk (Norwegian)",
+        LOCALE__RUSSIAN: "(incomplete) русский (Russian)",  # OpenSans includes cyrillic chars
+        LOCALE__TURKISH: "(incomplete) Türkçe (Turkish)",
 
         # --------- Placeholders / Coming soon ------------------------------------------
         # Commented out options require explicit additional font support.
@@ -142,18 +154,15 @@ class SettingsConstants:
         LOCALE__ARABIC: "العربية (Arabic)",
         # LOCALE__BENGALI: "বাংলা (Bengali)",
         LOCALE__BULGARIAN: "български (Bulgarian)",  # OpenSans includes cyrillic chars
-        LOCALE__CZECH: "čeština",
         # LOCALE__CHINESE_TRADITIONAL: "繁體中文 (Chinese Traditional)",
         LOCALE__DANISH: "Dansk",
         LOCALE__ESTONIAN: "Eesti",
         # LOCALE__EGYPTIAN: "مصرى (Egyptian)",
         LOCALE__GAELIC: "Gaeilge",
-        LOCALE__GREEK: "Ελληνικά (Greek)",  # OpenSans includes Greek chars
         # LOCALE__GUJARATI: "ગુજરાતી (Gujarati)",
         LOCALE__HAUSA: "Hausa",
         # LOCALE__HEBREW: "עברית (Hebrew)",
         LOCALE__CROATIAN: "Hrvatski",
-        LOCALE__INDONESIAN: "Indonesia",
         LOCALE__JAVANESE: "Jawa (Javanese)",
         # LOCALE__LAO: "ລາວ (Lao)",
         LOCALE__LATVIAN: "Latviešu",
@@ -162,14 +171,9 @@ class SettingsConstants:
         LOCALE__MALAY: "Melayu",
         LOCALE__MALTESE: "Malti",
         # LOCALE__MARATHI: "मराठी (Marathi)",
-        LOCALE__NORWEGIAN: "Norsk",
-        LOCALE__PERSIAN: "فارسی (Persian)",
-        LOCALE__POLISH: "Polski",
-        LOCALE__PORTUGUESE_BR: "Português (Brasil)",
         LOCALE__PORTUGUESE_PT: "Português (Portugal)",
         # LOCALE__PUNJABI: "ਪੰਜਾਬੀ (Punjabi)",
         LOCALE__ROMANIAN: "Română",
-        LOCALE__RUSSIAN: "русский (Russian)",  # OpenSans includes cyrillic chars
         LOCALE__SLOVAK: "Slovenčina",
         LOCALE__SLOVENIAN: "Slovenščina",
         LOCALE__FINNISH: "Suomi",
@@ -177,10 +181,8 @@ class SettingsConstants:
         LOCALE__TAGALOG: "Tagalog",
         # LOCALE__TAMIL: "தமிழ் (Tamil)",
         # LOCALE__TELUGU: "తెలుగు (Telugu)",
-        LOCALE__TURKISH: "Türkçe",
         LOCALE__UKRANIAN: "українська (Ukranian)",   # OpenSans includes cyrillic chars
         # LOCALE__URDU: "اردو (Urdu)",
-        LOCALE__VIETNAMESE: "Tiếng Việt (Vietnamese)",
     }
 
 


### PR DESCRIPTION
## Description

Activates the list of languages for v0.8.7. 

Verified that the screenshot generator produces screenshots for each activated language when their .po and .mo files are available to the local system.

The new languages each require a new PR in the translations repo. If translation files are not detected for a given language, it will not appear in the language selection list in the UI. 

---

This pull request is categorized as a:
- [x] New feature

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand
