### PR TITLE
ADD: BIP47 (m/47') derivation path support for message signing

### DIFF
--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -143,6 +143,7 @@ def parse_derivation_path(derivation_path: str) -> dict:
     lookups = {
         "script_types": {
             "44h": SettingsConstants.LEGACY_P2PKH,
+            "47h": SettingsConstants.LEGACY_P2PKH,
             "49h": SettingsConstants.NESTED_SEGWIT,
             "84h": SettingsConstants.NATIVE_SEGWIT,
             "86h": SettingsConstants.TAPROOT,

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -498,6 +498,7 @@ class TestSeedFlows(FlowTest):
 class TestMessageSigningFlows(FlowTest):
     MAINNET_DERIVATION_PATH = "m/84h/0h/0h/0/0"
     TESTNET_DERIVATION_PATH = "m/84h/1h/0h/0/0"
+    BIP47_DERIVATION_PATH = "m/47h/0h/0h/0/0"
     CUSTOM_DERIVATION_PATH = "m/99h/0/0"
     SHORT_MESSAGE = "I attest that I control this bitcoin address blah blah blah"
     NO_WHITESPACE_MESSAGE = """{"height":841407,"lightning_bolt12":"lno1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}"""
@@ -532,6 +533,10 @@ class TestMessageSigningFlows(FlowTest):
 
     def load_no_whitespace_message_into_decoder(self, view: View):
         self.load_signmessage_into_decoder(view, self.MAINNET_DERIVATION_PATH, self.NO_WHITESPACE_MESSAGE)
+
+
+    def load_bip47_message_into_decoder(self, view: View):
+        self.load_signmessage_into_decoder(view, self.BIP47_DERIVATION_PATH, self.SHORT_MESSAGE)
 
 
     def load_custom_derivation_into_decoder(self, view: View):
@@ -629,6 +634,28 @@ class TestMessageSigningFlows(FlowTest):
             FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
             FlowStep(scan_views.ScanView, before_run=self.load_no_whitespace_message_into_decoder),  # simulate read message QR; ret val is ignored
             FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmAddressView, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
+
+
+    def test_sign_message_bip47_flow(self):
+        """
+        Should sign a message using a BIP47 derivation path (m/47h/0h/0h/0/0).
+        This enables Auth47 challenge signing and PayNym claim signing.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_bip47_message_into_decoder),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
             FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
             FlowStep(seed_views.SeedSignMessageConfirmAddressView, screen_return_value=0),
             FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),


### PR DESCRIPTION
## Summary

Adds `47h` (BIP47) to the recognized purpose bytes in `parse_derivation_path()`, enabling message signing with BIP47 identity keys through the existing `signmessage` flow.

**Why:** BIP47 payment codes, PayNym identities, and Auth47 authentication all require signing messages with keys derived at `m/47'/0'/0'`. The signing primitive (`sign_message()`) already accepts any derivation path — the only blocker was the policy gate in the derivation path parser rejecting unrecognized purpose bytes.

**What changed:**
- `src/seedsigner/helpers/embit_utils.py`: Added `"47h": SettingsConstants.LEGACY_P2PKH` to the `script_types` lookup in `parse_derivation_path()`. BIP47 v1/v2 notification addresses are P2PKH, so the address displayed on the confirmation screen is the correct notification address.
- `tests/test_flows_seed.py`: Added `test_sign_message_bip47_flow` covering the full signing flow with a BIP47 derivation path (`m/47h/0h/0h/0/0`).

**What this enables:**
- Auth47 challenge signing — coordinator formats `signmessage m/47h/0h/0h/0/0 ascii:<challenge>`, SeedSigner signs, coordinator POSTs response
- PayNym claim/follow proofs — same signing mechanism with PayNym API tokens
- BIP47 identity message signing — general-purpose signing with payment code keys

**What this does NOT change:**
- No new QR types, views, or cryptographic code
- No changes to the signing primitive
- All existing tests pass unchanged

Context: https://gist.github.com/arkfile/7a320dbb4377c5e1b65250b2049e941d