### PR TITLE
ci: add .pot freshness check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pot-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install Babel
+        run: pip install -r l10n/requirements-l10n.txt
+      - name: Verify messages.pot is up to date
+        run: |
+          cp l10n/messages.pot l10n/messages.pot.before
+          python setup.py extract_messages
+          # Strip POT-Creation-Date from both files before comparing — Babel
+          # always writes the current timestamp, which would cause a false diff.
+          sed -i '/^"POT-Creation-Date:/d' l10n/messages.pot.before l10n/messages.pot
+          diff l10n/messages.pot.before l10n/messages.pot || \
+            (echo "::error::l10n/messages.pot is out of date. Run 'python setup.py extract_messages' and commit the result." && exit 1)
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to SeedSigner
+
+## Localization
+
+SeedSigner uses [Babel](https://babel.pocoo.org/) to extract translatable strings into `l10n/messages.pot`. If you add or change any string wrapped with `_()`, `_mft()`, or `ButtonOption()`, you must regenerate the `.pot` file before pushing:
+
+```bash
+pip install -r l10n/requirements-l10n.txt   # one-time setup
+python setup.py extract_messages
+```
+
+CI will fail if `l10n/messages.pot` is out of date.
+
+For more details on the three translation wrapping techniques and the full localization workflow, see `l10n/README.md`.


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

`l10n/README.md` line 272 has an explicit TODO: *"Github Action to auto-generate messages.pot and fail a PR update if out of date"*. Currently, a contributor can add or change translatable strings (`_()`, `_mft()`, `ButtonOption()`) and forget to regenerate `messages.pot`. Translators on Transifex never see the new strings until someone notices manually.

### Solution

Adds a `pot-freshness` CI job to `tests.yml` that:

1. Copies the existing `messages.pot`
2. Re-runs `python setup.py extract_messages`                                                    
3. Strips the `POT-Creation-Date` timestamp from both files (Babel always writes the current time, which would cause a false diff)                                                            
5. Diffs the two — fails with a clear `::error::` message if the content changed

The job runs independently of the `test` matrix and only needs Babel, so it's lightweight and fast.                                                                                            
                                                                       
Also creates `CONTRIBUTING.md` with a localization section explaining when and how to run `extract_messages` locally. No existing contributing guide was found in the repo.

### Additional Information

Verified locally three ways:                                                                     
  - `python setup.py extract_messages` + timestamp-stripped diff: no false positives
  - Docker (`docker compose run`): pot-freshness check passes                                      
  - `act -j pot-freshness`: job succeeds end-to-end

### Screenshots

N/A — CI workflow change, no UI modifications.

---

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Documentation
- [x] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I’m a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.