### PR TITLE
ci: add .pot freshness and .mo compilation checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,26 @@ jobs:
           diff l10n/messages.pot.before l10n/messages.pot || \
             (echo "::error::l10n/messages.pot is out of date. Run 'python setup.py extract_messages' and commit the result." && exit 1)
 
+  mo-compilation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install Babel
+        run: pip install -r l10n/requirements-l10n.txt
+      - name: Verify .mo files are up to date
+        run: |
+          python setup.py compile_catalog
+          # Warn but don't fail — ca and nl currently have stale .mo files.
+          # TODO: change to 'exit 1' once the translations submodule is fixed.
+          git -C src/seedsigner/resources/seedsigner-translations diff --exit-code || \
+            echo "::warning::Compiled .mo files are out of date. Run 'python setup.py compile_catalog' and commit the results to the seedsigner-translations submodule."
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pot-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install Babel
+        run: pip install -r l10n/requirements-l10n.txt
+      - name: Verify messages.pot is up to date
+        run: |
+          cp l10n/messages.pot l10n/messages.pot.before
+          python setup.py extract_messages
+          # Strip POT-Creation-Date from both files before comparing — Babel
+          # always writes the current timestamp, which would cause a false diff.
+          sed -i '/^"POT-Creation-Date:/d' l10n/messages.pot.before l10n/messages.pot
+          diff l10n/messages.pot.before l10n/messages.pot || \
+            (echo "::error::l10n/messages.pot is out of date. Run 'python setup.py extract_messages' and commit the result." && exit 1)
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to SeedSigner
+
+## Localization
+
+SeedSigner uses [Babel](https://babel.pocoo.org/) to extract translatable strings into `l10n/messages.pot`. If you add or change any string wrapped with `_()`, `_mft()`, or `ButtonOption()`, you must regenerate the `.pot` file before pushing:
+
+```bash
+pip install -r l10n/requirements-l10n.txt   # one-time setup
+python setup.py extract_messages
+```
+
+CI will fail if `l10n/messages.pot` is out of date.
+
+For more details on the three translation wrapping techniques and the full localization workflow, see `l10n/README.md`.


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Two localization CI gaps called out as explicit TODOs in `l10n/README.md`:

1. **Line 272**: *"Github Action to auto-generate messages.pot and fail a PR update if out of date"* — a contributor can add or change translatable strings (`_()`, `_mft()`, `ButtonOption()`) and forget to regenerate `messages.pot`. Translators on Transifex never see the new strings until someone notices manually.

2. **Line 304**: *"Github Actions automation to regenerate/verify that *.mo files have been updated after *.po changes"* — currently there is no CI check that catches stale or broken `.mo` files in the translations submodule.

### Solution

Adds two new CI jobs to `tests.yml`:

**`pot-freshness`** — Copies the existing `messages.pot`, re-runs `python setup.py extract_messages`, strips the `POT-Creation-Date` timestamp from both files (Babel always writes the current time, which would cause a false diff), and diffs the two. Fails with a clear `::error::` message if the content changed.

**`mo-compilation`** — Runs `python setup.py compile_catalog` to recompile all `.mo` files from their `.po` sources, then diffs inside the translations submodule. Emits a `::warning::` annotation if any `.mo` file changed. Currently warns but does not fail, since `ca` and `nl` have stale `.mo` files at the pinned submodule commit. A TODO comment marks where to flip to `exit 1` once the submodule is fixed.

Both jobs run independently of the `test` matrix and only need Babel, so they are lightweight and fast.

Also creates `CONTRIBUTING.md` with a localization section explaining when and how to run `extract_messages` locally. No existing contributing guide was found in the repo.

Note: the translations submodule is moving toward not committing `.mo` files at all (commit `76c6f57` removed them, `.gitignore` excludes `*.mo`). Once the main repo bumps its submodule pointer past that commit, the mo-compilation check becomes a "does `compile_catalog` succeed" validation — still useful for catching malformed `.po` files.

### Additional Information

Verified locally three ways:
  - `python setup.py extract_messages` + timestamp-stripped diff: no false positives
  - Docker (`docker compose run`): both checks pass/warn as expected
  - `act`: jobs succeed end-to-end

### Screenshots

N/A — CI workflow changes, no UI modifications.

---

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Documentation
- [x] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I'm a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.