### PR TITLE
ci: add screenshot gallery GitHub Pages deploy

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,66 @@
+name: Screenshot Gallery
+
+on:
+  push:
+    branches:
+      - dev
+
+# Only allow one deployment at a time
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libzbar0
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r tests/requirements.txt
+          pip install .
+      - name: Generate screenshots
+        run: |
+          python -m pytest tests/screenshot_generator/generator.py \
+            --color=yes \
+            -vv
+      - name: Prepare for Jekyll
+        run: |
+          # Rename README.md to index.md so Jekyll renders each directory's
+          # landing page at the directory URL.
+          for readme in $(find seedsigner-screenshots -name README.md); do
+            mv "$readme" "$(dirname $readme)/index.md"
+          done
+          # Fix internal links to point to directories instead of README.md
+          find seedsigner-screenshots -name "index.md" -exec sed -i 's|/README.md|/|g;s|README.md|./|g' {} +
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: seedsigner-screenshots
+          destination: ./_site
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

The screenshot generator (`tests/screenshot_generator/generator.py`) already renders all views for every detected locale and produces gallery READMEs with translation completion percentages. CI runs it on every push and saves the output as artifacts. But there's no public-facing gallery — translators on Transifex can't see their work rendered visually.

### Solution

Adds a new workflow (`.github/workflows/screenshots.yml`) that:                                  

1. Triggers on push to `dev`                                                                     
2. Generates screenshots for all locales                                                         
3. Renames `README.md` to `index.md` and fixes internal links for clean directory URLs          
4. Builds HTML via `actions/jekyll-build-pages` (renders markdown + images)                      
5. Deploys to GitHub Pages via `actions/deploy-pages`                                            

The index page lists all detected locales with links to per-locale galleries. Each locale gallery shows translation completion percentage and all screenshot sections (Main Menu, Seed, PSBT, Tools, Settings, Misc Error views).

### Additional Information

- **GitHub Pages must be enabled by a maintainer**: Settings > Pages > Source: "GitHub Actions". The workflow will not deploy until this is done.
- Once enabled, the gallery will be reachable at `https://seedsigner.github.io/seedsigner/`      
- Tested on fork: https://krupakar-reddy-s.github.io/seedsigner/                                 
- This is a separate workflow from `tests.yml` — keeps deploy logic isolated and only triggers on `dev` pushes, not PRs.

### Screenshots

<img width="1710" height="1107" alt="Screenshot 2026-04-03 at 9 01 27 PM (2)" src="https://github.com/user-attachments/assets/128559d3-2701-40a1-9d28-62971a206b63" /><br>

<img width="1710" height="1107" alt="Screenshot 2026-04-03 at 9 01 36 PM (2)" src="https://github.com/user-attachments/assets/11535021-d400-47cd-b558-ceee5e614dc9" /><br>

<img width="1710" height="1107" alt="Screenshot 2026-04-03 at 9 01 43 PM (2)" src="https://github.com/user-attachments/assets/c57c9191-2267-477d-9be5-ad514bdbec8a" /><br>

<img width="1710" height="1107" alt="Screenshot 2026-04-03 at 9 02 07 PM (2)" src="https://github.com/user-attachments/assets/58acc9df-e699-4318-993b-1723b8ad57f9" /><br>


---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I’m a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.