### PR TITLE
fix: Replaced `os.popen()` with Python's inbuilt file handling

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import os
 import time
 
 from gettext import gettext as _
@@ -148,9 +147,12 @@ class ToolsImageEntropyMnemonicLengthView(View):
 
             # Build in some hardware-level uniqueness via CPU unique Serial num
             try:
-                stream = os.popen("cat /proc/cpuinfo | grep Serial")
-                output = stream.read()
-                serial_num = output.split(":")[-1].strip().encode('utf-8')
+                serial_num = b''
+                with open("/proc/cpuinfo", "r") as f:
+                    for line in f:
+                        if "Serial" in line:
+                            serial_num = line.split(":")[-1].strip().encode('utf-8')
+                            break
                 serial_hash = hashlib.sha256(serial_num)
                 hash_bytes = serial_hash.digest()
             except Exception as e:


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

<!--
Describe the problem this PR solves.
Include background context, links to relevant issues, BIPs, discussions, etc.
-->
Resolves SeedSigner/seedsigner#856

In `tools_views.py`, the entropy generation logic uses `os.popen("cat /proc/cpuinfo | grep Serial")` to gather the CPU serial number for mixing into the seed entropy hash. `os.popen()` implicitly spawns a shell, which is unnecessary here since the data can be read directly via Python's built-in file I/O.
### Solution

<!--
Describe your approach and key technical implementation details.
Explain why this approach was chosen.
-->
Replaced the `os.popen()` call with native Python file I/O using `open("/proc/cpuinfo", "r")`. This reads the file line by line and extracts the Serial field without spawning any external processes (`cat`, `grep`) or a shell.

Also removed the now-unused `import os` at the top of the file, as no other code in the file depends on it.

### Additional Information

- The new implementation selects the first `Serial` entry (via `break`), whereas the previous os.popen approach would effectively select the last one. In practice, cpuinfo contains only a single `Serial` field, so the behavior is equivalent on all current hardware. 
- The existing `try/except` block is preserved, so on non-Raspberry Pi hardware (or any system without `cpuinfo`), the code gracefully falls back to `hash_bytes = b'0'` as before. 
- `os.popen()` is not strictly deprecated but is discouraged in favor of `subprocess.run()` or native file I/O. Since we're simply reading a local file, native file I/O is the simplest and most direct approach — no shell or subprocess needed.

<!--
Tradeoffs, follow-ups, limitations, or anything reviewers should be aware of.
-->

### Screenshots
N/A
<!--
Include screenshots for any new or modified screens.
If omitted, explain why.
-->

---

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I’m a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.