### PR TITLE
[Bugfix] Back Navigation in Seed Entry Views

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -226,11 +226,10 @@ class SeedMnemonicEntryView(View):
         )
 
         if ret == RET_CODE__BACK_BUTTON:
-            if self.cur_word_index > 0:
-                return Destination(BackStackView)
-            else:
+            # Only need to discard when exiting from the very first word
+            if self.cur_word_index == 0:
                 self.controller.storage.discard_pending_mnemonic()
-                return Destination(BackStackView)
+            return Destination(BackStackView)
         
         # ret will be our new mnemonic word
         self.controller.storage.update_pending_mnemonic(ret, self.cur_word_index)
@@ -331,9 +330,6 @@ class SeedFinalizeView(View):
             fingerprint=self.fingerprint,
             button_data=button_data,
         )
-
-        if selected_menu_num == RET_CODE__BACK_BUTTON:
-            return Destination(BackStackView)
 
         if button_data[selected_menu_num] == self.FINALIZE:
             seed_num = self.controller.storage.finalize_pending_seed()

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -230,7 +230,7 @@ class SeedMnemonicEntryView(View):
                 return Destination(BackStackView)
             else:
                 self.controller.storage.discard_pending_mnemonic()
-                return Destination(MainMenuView)
+                return Destination(BackStackView)
         
         # ret will be our new mnemonic word
         self.controller.storage.update_pending_mnemonic(ret, self.cur_word_index)
@@ -332,15 +332,15 @@ class SeedFinalizeView(View):
             button_data=button_data,
         )
 
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
         if button_data[selected_menu_num] == self.FINALIZE:
             seed_num = self.controller.storage.finalize_pending_seed()
             return Destination(SeedOptionsView, view_args={"seed_num": seed_num}, clear_history=True)
 
         elif button_data[selected_menu_num] == self.PASSPHRASE:
             return Destination(SeedAddPassphraseView)
-
-        elif selected_menu_num == RET_CODE__BACK_BUTTON:
-            return Destination(BackStackView)
 
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -227,8 +227,8 @@ class SeedMnemonicEntryView(View):
 
         if ret == RET_CODE__BACK_BUTTON:
             # This handles two possible scenarios:
-            # 1. Backing out of the first word cancels the mnemonic entry process; 
-                 return to whichever `View` routed us here initially.
+            # 1. Backing out of the first word cancels the mnemonic entry process;
+            #    return to whichever `View` routed us here initially.
             # 2. Backing out of the current word returns to the previous word.
             if self.cur_word_index == 0:
                 self.controller.storage.discard_pending_mnemonic()

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -226,7 +226,10 @@ class SeedMnemonicEntryView(View):
         )
 
         if ret == RET_CODE__BACK_BUTTON:
-            # Only need to discard when exiting from the very first word
+            # RET_CODE__BACK_BUTTON can happen in two ways here:
+            # 1. Backing out of the very first word completely aborts the mnemonic entry.
+            # 2. Backing out of a subsequent word just returns to the previous word.
+            # In both cases we return to BackStackView, but for case #1 we must also discard.
             if self.cur_word_index == 0:
                 self.controller.storage.discard_pending_mnemonic()
             return Destination(BackStackView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -226,10 +226,10 @@ class SeedMnemonicEntryView(View):
         )
 
         if ret == RET_CODE__BACK_BUTTON:
-            # RET_CODE__BACK_BUTTON can happen in two ways here:
-            # 1. Backing out of the very first word completely aborts the mnemonic entry.
-            # 2. Backing out of a subsequent word just returns to the previous word.
-            # In both cases we return to BackStackView, but for case #1 we must also discard.
+            # This handles two possible scenarios:
+            # 1. Backing out of the first word cancels the mnemonic entry process; 
+                 return to whichever `View` routed us here initially.
+            # 2. Backing out of the current word returns to the previous word.
             if self.cur_word_index == 0:
                 self.controller.storage.discard_pending_mnemonic()
             return Destination(BackStackView)

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -504,32 +504,20 @@ class TestSeedEntryBackFlows(FlowTest):
     returns to the correct parent view AND that no flow state leaks.
     """
 
-    def test_back_from_seed_entry_12_word(self):
+    def test_back_from_seed_entry_first_word(self):
         """
-        Seeds Menu → Load a Seed → Enter 12-word → BACK on first word →
+        Seeds Menu → Load a Seed → Enter 12/24-word → BACK on first word →
         should return to LoadSeedView, NOT MainMenuView.
         """
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-            FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # No seeds loaded; auto-redirects to LoadSeedView
-            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
-            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
-            FlowStep(seed_views.LoadSeedView),  # Should land here, NOT MainMenuView
-        ])
-
-
-    def test_back_from_seed_entry_24_word(self):
-        """
-        Seeds Menu → Load a Seed → Enter 24-word → BACK on first word →
-        should return to LoadSeedView, NOT MainMenuView.
-        """
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-            FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # No seeds loaded; auto-redirects to LoadSeedView
-            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_24WORD),
-            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
-            FlowStep(seed_views.LoadSeedView),  # Should land here, NOT MainMenuView
-        ])
+        for seed_type in [seed_views.LoadSeedView.TYPE_12WORD, seed_views.LoadSeedView.TYPE_24WORD]:
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # No seeds loaded; auto-redirects to LoadSeedView
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_type),
+                FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
+                FlowStep(seed_views.LoadSeedView),  # Should land here, NOT MainMenuView
+            ])
+            BaseTest.reset_controller()
 
 
     def test_back_from_seed_entry_mid_word(self):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -495,6 +495,110 @@ class TestSeedFlows(FlowTest):
 
 
 
+class TestSeedEntryBackFlows(FlowTest):
+    """
+    Tests for every BACK exit scenario from SeedMnemonicEntryView and related views.
+    
+    A naive BackStackView swap can leave resume_main_flow dangling, causing
+    auto-redirects on stale flow state. These tests verify that BACK navigation
+    returns to the correct parent view AND that no flow state leaks.
+    """
+
+    def test_back_from_seed_entry_12_word(self):
+        """
+        Seeds Menu → Load a Seed → Enter 12-word → BACK on first word →
+        should return to LoadSeedView, NOT MainMenuView.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # No seeds loaded; auto-redirects to LoadSeedView
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.LoadSeedView),  # Should land here, NOT MainMenuView
+        ])
+
+
+    def test_back_from_seed_entry_24_word(self):
+        """
+        Seeds Menu → Load a Seed → Enter 24-word → BACK on first word →
+        should return to LoadSeedView, NOT MainMenuView.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # No seeds loaded; auto-redirects to LoadSeedView
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_24WORD),
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.LoadSeedView),  # Should land here, NOT MainMenuView
+        ])
+
+
+    def test_back_from_seed_entry_mid_word(self):
+        """
+        Pressing BACK from a middle word (eg. word #2) should return to the
+        previous SeedMnemonicEntryView (eg. word #1) via the back stack.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value="abandon"),  # word #1
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),  # BACK from word #2
+            FlowStep(seed_views.SeedMnemonicEntryView),  # Returns to word #1
+        ])
+
+
+    def test_back_from_seed_entry_via_seed_select(self):
+        """
+        When entering a seed via SeedSelectSeedView (e.g. during sign message flow),
+        pressing BACK on the first word should return to SeedSelectSeedView, NOT
+        MainMenuView. Crucially, resume_main_flow must remain valid since the user
+        is still within that flow.
+        """
+        from seedsigner.controller import Controller
+        from seedsigner.models.settings import SettingsConstants
+
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        def load_signmessage_into_decoder(view):
+            view.decoder.add_data("signmessage m/84h/0h/0h/0/0 ascii:test message")
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_signmessage_into_decoder),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.TYPE_12WORD),
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),  # BACK on first word
+            FlowStep(seed_views.SeedSelectSeedView),  # Should return here, in the sign message flow
+        ])
+
+        # Verify resume_main_flow is still set — user is still in the sign message flow
+        assert self.controller.resume_main_flow == Controller.FLOW__SIGN_MESSAGE
+
+
+    def test_back_from_seed_finalize(self):
+        """
+        Pressing BACK from SeedFinalizeView should return to the last word
+        entry view via the back stack.
+        """
+        mnemonic = "tone flat shed cool census soul paddle boy flight fantasy stem social".split()
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+        ]
+
+        for word in mnemonic:
+            sequence.append(FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=word))
+
+        sequence += [
+            FlowStep(seed_views.SeedFinalizeView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.SeedMnemonicEntryView),  # Returns to last word entry
+        ]
+
+        self.run_sequence(sequence)
+
+
+
 class TestMessageSigningFlows(FlowTest):
     MAINNET_DERIVATION_PATH = "m/84h/0h/0h/0/0"
     TESTNET_DERIVATION_PATH = "m/84h/1h/0h/0/0"

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -506,8 +506,8 @@ class TestSeedEntryBackFlows(FlowTest):
 
     def test_back_from_seed_entry_first_word(self):
         """
-        Seeds Menu → Load a Seed → Enter 12/24-word → BACK on first word →
-        should return to LoadSeedView, NOT MainMenuView.
+        Pressing BACK on the first word of mnemonic entry should return to
+        the View that initiated the mnemonic entry process.
         """
         for seed_type in [seed_views.LoadSeedView.TYPE_12WORD, seed_views.LoadSeedView.TYPE_24WORD]:
             self.run_sequence([
@@ -534,13 +534,16 @@ class TestSeedEntryBackFlows(FlowTest):
             FlowStep(seed_views.SeedMnemonicEntryView),  # Returns to word #1
         ])
 
+        # Verify we're back on word #1: word at index 0 should still be set
+        # from the previous entry, while word at index 1 should be unset.
+        assert self.controller.storage.get_pending_mnemonic_word(0) == "abandon"
+        assert self.controller.storage.get_pending_mnemonic_word(1) is None
+
 
     def test_back_from_seed_entry_via_seed_select(self):
         """
-        When entering a seed via SeedSelectSeedView (e.g. during sign message flow),
-        pressing BACK on the first word should return to SeedSelectSeedView, NOT
-        MainMenuView. Crucially, resume_main_flow must remain valid since the user
-        is still within that flow.
+        Backing out of mnemonic entry during an active flow must preserve
+        `resume_main_flow` so the user remains within that flow.
         """
         from seedsigner.controller import Controller
         from seedsigner.models.settings import SettingsConstants

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -575,28 +575,6 @@ class TestSeedEntryBackFlows(FlowTest):
         assert self.controller.resume_main_flow == Controller.FLOW__SIGN_MESSAGE
 
 
-    def test_back_from_seed_finalize(self):
-        """
-        Pressing BACK from SeedFinalizeView should return to the last word
-        entry view via the back stack.
-        """
-        mnemonic = "tone flat shed cool census soul paddle boy flight fantasy stem social".split()
-        sequence = [
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
-            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
-            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
-        ]
-
-        for word in mnemonic:
-            sequence.append(FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=word))
-
-        sequence += [
-            FlowStep(seed_views.SeedFinalizeView, screen_return_value=RET_CODE__BACK_BUTTON),
-            FlowStep(seed_views.SeedMnemonicEntryView),  # Returns to last word entry
-        ]
-
-        self.run_sequence(sequence)
-
 
 
 class TestMessageSigningFlows(FlowTest):


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

<!--
Describe the problem this PR solves.
Include background context, links to relevant issues, BIPs, discussions, etc.
-->


Pressing BACK on the first word of seed entry takes you straight to the Main Menu instead of going back to the Seeds Menu where you came from.

Current behavior:
Seeds Menu → Enter 12-word seed → Back → Main Menu 
Seeds Menu → Enter 24-word seed → Back → Main Menu 


Expected behavior:
Seeds Menu → Enter 12-word seed → Back → Seeds Menu
Seeds Menu → Enter 24-word seed → Back → Seeds Menu 

### Solution

<!--
Describe your approach and key technical implementation details.
Explain why this approach was chosen.
-->

`SeedMnemonicEntryView`: When pressing BACK on the first word, the old code hard-coded a jump to `MainMenuView`. Changed it to use `BackStackView` instead, so it naturally returns to wherever the user came from, either `LoadSeedView` (the normal "enter a seed" path) or `SeedSelectSeedView` (when entering a seed mid-flow, like during sign message). 
The pending mnemonic is still properly discarded.

### Additional Information

<!--
Tradeoffs, follow-ups, limitations, or anything reviewers should be aware of.
-->

### Screenshots

<!--
Include screenshots for any new or modified screens.
If omitted, explain why.
-->

No UI changes, only navigation logic.
---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.