### PR TITLE
fix: add graceful error logging for BaseThread crashes

### DIFF
--- a/src/seedsigner/models/threads.py
+++ b/src/seedsigner/models/threads.py
@@ -7,6 +7,16 @@ logger = logging.getLogger(__name__)
 class BaseThread(Thread):
     def __init__(self):
         super().__init__(daemon=True)
+        
+        # Intercept the subclass's run() method to catch silent thread crashes
+        orig_run = self.run
+        def wrapped_run():
+            try:
+                orig_run()
+            except Exception as e:
+                logger.exception(f"Thread {self.__class__.__name__} crashed: {e}")
+                self.keep_running = False
+        self.run = wrapped_run
     
     def start(self):
         logger.debug(f"{self.__class__.__name__} STARTING")

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,21 @@
+import time
+import logging
+from seedsigner.models.threads import BaseThread
+
+def test_basethread_crash_handling(caplog):
+    
+    # This simulates a background process (like hardware listener or scroll ui)
+    # breaking unexpectedly.
+    class ExplodingThread(BaseThread):
+        def run(self):
+            raise ValueError("Intentional Crash!")
+
+    with caplog.at_level(logging.ERROR):
+        t = ExplodingThread()
+        t.start()
+        
+        time.sleep(0.1)
+
+        assert getattr(t, 'keep_running', True) is False
+        
+        assert "Thread ExplodingThread crashed: Intentional Crash!" in caplog.text


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Currently, any class that inherits from BaseThread (which handles nearly all hardware listeners, camera loops, and scrolling UI text) can silently crash without yielding any errors or stack traces to the output, refer to issue #907.

Because the underlying loop encapsulates its execution in an isolated boundary, if a developer writes buggy code or an edge-case logic error occurs inside `def run(self):`, the thread terminates abruptly. It never halts the main UI/application event loop, but the targeted feature has zero trace output, which might make debugging harder.

### Solution

By wrapping the subclass's inherited `.run()` method in a protective global `try/except Exception:` block at the instance level:
1. Crashing threads now securely log a full stack trace utilizing `logger.exception`.
2. The instance state gracefully exits by securely flagging `self.keep_running = False`.

### Additional Information

**MicroPython Portability**: Since it natively preserves the `threading.Thread` inheritance hierarchy, it stays clean and is cross-compatible if there is MicroPython `_thread` port in the future.

### Screenshots
<img width="471" height="279" alt="image" src="https://github.com/user-attachments/assets/f1d87871-4091-4d67-b309-107e0a33ad42" />
<img width="777" height="60" alt="image" src="https://github.com/user-attachments/assets/ecf4e6d1-b565-4e98-9ad5-fcf763421e72" />

Tried adding an intentional bug in class `HorizontalTextScrollThread`, it logs the exception properly. This will help in future dev workflows, rather than making it go unnoticed.

---

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.

Resolves #907 
Part of Summer of Bitcoin