### PR TITLE
[Bugfix] Fix back button trap in seed backup verification review

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1360,7 +1360,7 @@ class SeedWordsBackupTestMistakeView(View):
 
         if button_data[selected_menu_num] == self.REVIEW:
             return Destination(
-                SeedWordsView,
+                SeedWordsWarningView,
                 view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
                 skip_current_view=True,
             )

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1040,7 +1040,7 @@ class SeedWordsView(View):
     NEXT = ButtonOption("Next")
     DONE = ButtonOption("Done")
 
-    def __init__(self, seed_num: int, bip85_data: dict = None, page_index: int = 0):
+    def __init__(self, seed_num: int, bip85_data: dict = None, page_index: int = 0, review_mode: bool = False):
         super().__init__()
         self.seed_num = seed_num
         if self.seed_num is None:
@@ -1049,6 +1049,7 @@ class SeedWordsView(View):
             self.seed = self.controller.get_seed(self.seed_num)
         self.bip85_data = bip85_data
         self.page_index = page_index
+        self.review_mode = review_mode
 
 
     def run(self):
@@ -1081,6 +1082,11 @@ class SeedWordsView(View):
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
+            if self.page_index == 0 and self.review_mode:
+                return Destination(
+                    SeedWordsBackupTestPromptView,
+                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                )
             return Destination(BackStackView)
 
         if button_data[selected_menu_num] == self.NEXT:
@@ -1360,8 +1366,8 @@ class SeedWordsBackupTestMistakeView(View):
 
         if button_data[selected_menu_num] == self.REVIEW:
             return Destination(
-                SeedWordsWarningView,
-                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                SeedWordsView,
+                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, review_mode=True),
                 skip_current_view=True,
             )
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1362,6 +1362,7 @@ class SeedWordsBackupTestMistakeView(View):
             return Destination(
                 SeedWordsView,
                 view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                skip_current_view=True,
             )
 
         elif button_data[selected_menu_num] == self.RETRY:

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -495,6 +495,51 @@ class TestSeedFlows(FlowTest):
 
 
 
+class TestBackupVerificationFlows(FlowTest):
+
+    def test_review_words_after_wrong_answer_no_back_trap(self):
+        """
+        Picking the wrong word during backup verification and then selecting
+        "Review seed words" should NOT create a back-button loop. Pressing
+        BACK from the word review must return to a fresh verification attempt,
+        not to the "Wrong Word!" screen.
+
+        Regression test for issue #854.
+        """
+        def force_wrong_word(view):
+            # rand_seed=3, cur_index=2 -> after shuffle, real word lands at index 3
+            # so screen_return_value=0 picks a fake word
+            view.rand_seed = 3
+            view.cur_index = 2
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BACKUP),
+            FlowStep(seed_views.SeedBackupView, button_data_selection=seed_views.SeedBackupView.VIEW_WORDS),
+            FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
+            FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY),
+
+            # rand_seed=3 + cur_index=2: real word lands at index 3 after shuffle;
+            # screen_return_value=0 picks a fake word -> triggers MistakeView
+            FlowStep(seed_views.SeedWordsBackupTestView, before_run=force_wrong_word, screen_return_value=0),
+
+            # We're on the "Wrong Word!" screen — select "Review seed words"
+            FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.REVIEW),
+
+            # Now viewing seed words; press BACK
+            FlowStep(seed_views.SeedWordsView, screen_return_value=RET_CODE__BACK_BUTTON),
+
+            # Must land on a fresh verification attempt, NOT the mistake screen
+            FlowStep(seed_views.SeedWordsBackupTestView),
+        ])
+
+
+
 class TestMessageSigningFlows(FlowTest):
     MAINNET_DERIVATION_PATH = "m/84h/0h/0h/0/0"
     TESTNET_DERIVATION_PATH = "m/84h/1h/0h/0/0"

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -497,21 +497,21 @@ class TestSeedFlows(FlowTest):
 
 class TestBackupVerificationFlows(FlowTest):
 
+    @staticmethod
+    def force_wrong_word(view):
+        """Force deterministic random so screen_return_value=0 picks a fake word."""
+        view.rand_seed = 3
+        view.cur_index = 2
+
     def test_review_words_after_wrong_answer_no_back_trap(self):
         """
         Picking the wrong word during backup verification and then selecting
-        "Review seed words" should NOT create a back-button loop. Pressing
-        BACK from the word review must return to a fresh verification attempt,
-        not to the "Wrong Word!" screen.
+        "Review seed words" should NOT create a back-button loop. The review
+        path must go through the words and return to a fresh verification
+        prompt with no stale confirmed_list.
 
         Regression test for issue #854.
         """
-        def force_wrong_word(view):
-            # rand_seed=3, cur_index=2 -> after shuffle, real word lands at index 3
-            # so screen_return_value=0 picks a fake word
-            view.rand_seed = 3
-            view.cur_index = 2
-
         self.run_sequence([
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
             FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
@@ -524,18 +524,56 @@ class TestBackupVerificationFlows(FlowTest):
             FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
             FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY),
 
-            # rand_seed=3 + cur_index=2: real word lands at index 3 after shuffle;
-            # screen_return_value=0 picks a fake word -> triggers MistakeView
-            FlowStep(seed_views.SeedWordsBackupTestView, before_run=force_wrong_word, screen_return_value=0),
+            # Force a wrong word selection
+            FlowStep(seed_views.SeedWordsBackupTestView, before_run=self.force_wrong_word, screen_return_value=0),
 
-            # We're on the "Wrong Word!" screen — select "Review seed words"
+            # Select "Review seed words" from the mistake screen
             FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.REVIEW),
 
-            # Now viewing seed words; press BACK
-            FlowStep(seed_views.SeedWordsView, screen_return_value=RET_CODE__BACK_BUTTON),
+            # Review goes through the warning -> word pages -> done -> fresh prompt
+            FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
 
-            # Must land on a fresh verification attempt, NOT the mistake screen
-            FlowStep(seed_views.SeedWordsBackupTestView),
+            # Lands at a fresh verification prompt — no stale confirmed_list
+            FlowStep(seed_views.SeedWordsBackupTestPromptView),
+        ])
+
+
+    def test_review_words_after_wrong_answer_bip85(self):
+        """
+        Same back-button trap test but for BIP-85 child seed verification.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS, SettingsConstants.OPTION__ENABLED)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BIP85_CHILD_SEED),
+            FlowStep(seed_views.SeedBIP85SelectNumWordsView, button_data_selection=seed_views.SeedBIP85SelectNumWordsView.WORDS_12),
+            FlowStep(seed_views.SeedBIP85SelectChildIndexView, screen_return_value=0),
+            FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
+            FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY),
+
+            # Force wrong word
+            FlowStep(seed_views.SeedWordsBackupTestView, before_run=self.force_wrong_word, screen_return_value=0),
+
+            # Review words from mistake screen
+            FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.REVIEW),
+
+            # Goes through warning -> words -> done -> fresh prompt
+            FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
+            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
+
+            # Fresh verification prompt
+            FlowStep(seed_views.SeedWordsBackupTestPromptView),
         ])
 
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -506,9 +506,9 @@ class TestBackupVerificationFlows(FlowTest):
     def test_review_words_after_wrong_answer_no_back_trap(self):
         """
         Picking the wrong word during backup verification and then selecting
-        "Review seed words" should NOT create a back-button loop. The review
-        path must go through the words and return to a fresh verification
-        prompt with no stale confirmed_list.
+        "Review seed words" should NOT create a back-button loop. Pressing
+        BACK from page 1 of the review must go to a fresh verification
+        prompt, not to the "Wrong Word!" screen or stale verification state.
 
         Regression test for issue #854.
         """
@@ -527,23 +527,20 @@ class TestBackupVerificationFlows(FlowTest):
             # Force a wrong word selection
             FlowStep(seed_views.SeedWordsBackupTestView, before_run=self.force_wrong_word, screen_return_value=0),
 
-            # Select "Review seed words" from the mistake screen
+            # Select "Review seed words" — enters word review in review_mode
             FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.REVIEW),
 
-            # Review goes through the warning -> word pages -> done -> fresh prompt
-            FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
-            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
-            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
-            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
+            # BACK from page 1 in review_mode goes directly to fresh prompt
+            FlowStep(seed_views.SeedWordsView, screen_return_value=RET_CODE__BACK_BUTTON),
 
-            # Lands at a fresh verification prompt — no stale confirmed_list
+            # Fresh verification prompt — no stale confirmed_list
             FlowStep(seed_views.SeedWordsBackupTestPromptView),
         ])
 
 
     def test_review_words_after_wrong_answer_bip85(self):
         """
-        Same back-button trap test but for BIP-85 child seed verification.
+        Same review-back test for BIP-85 child seed verification.
         """
         self.settings.set_value(SettingsConstants.SETTING__BIP85_CHILD_SEEDS, SettingsConstants.OPTION__ENABLED)
 
@@ -566,11 +563,8 @@ class TestBackupVerificationFlows(FlowTest):
             # Review words from mistake screen
             FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.REVIEW),
 
-            # Goes through warning -> words -> done -> fresh prompt
-            FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
-            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
-            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT),
-            FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE),
+            # BACK from page 1 in review_mode -> fresh prompt
+            FlowStep(seed_views.SeedWordsView, screen_return_value=RET_CODE__BACK_BUTTON),
 
             # Fresh verification prompt
             FlowStep(seed_views.SeedWordsBackupTestPromptView),


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Fixes #854.

During seed backup verification, if you pick the wrong word you get a "Wrong Word!" screen with two options: "Review seed words" and "Try again." If you choose "Review seed words," it shows the seed words with a back button. Pressing back returns you to the "Wrong Word!" screen, creating an infinite loop:

Wrong Word → Review seed words → Seed words display → Back → Wrong Word → (repeat)

The only escape is remembering the correct word and using "Try again."

### Solution

Added `skip_current_view=True` to the `Destination` returned when the user selects "Review seed words" in `SeedWordsBackupTestMistakeView`. This prevents the mistake view from being pushed onto the back stack, so pressing BACK from the word review returns to a fresh verification attempt instead of looping back to the error screen.

One-line fix in `seed_views.py`. Same pattern used by `SeedWordsWarningView` (line 1019) to prevent going BACK to warning screens.

### Additional Information

Includes a FlowTest (`test_review_words_after_wrong_answer_no_back_trap`) that:
- Walks the full backup verification flow
- Forces a wrong word selection using deterministic random seeding (`rand_seed=3, cur_index=2`)
- Selects "Review seed words" from the mistake screen
- Presses BACK from the word review
- Asserts we land on `SeedWordsBackupTestView` (fresh verification), NOT `SeedWordsBackupTestMistakeView` (the loop)

Verified the test fails without the fix (lands on MistakeView) and passes with it.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.