### PR TITLE
feat: Enhance l10n error handling by introducing seedsigner_gettext

### DIFF
--- a/l10n/README.md
+++ b/l10n/README.md
@@ -101,7 +101,7 @@ In general we try to avoid using `_mft` at all, but some class-level attributes 
 This is the way you'll see text wrapping handled in the vast majority of tutorials.
 
 ```python
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 my_text = _("Hello!")
 
@@ -121,7 +121,7 @@ This approach marks string literals for translation AND retrieves the translated
 We do the same in SeedSigner code, but only when the string literal is in a part of the code that is dynamically evaluated:
 
 ```python
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 class SomeView(View):
     def __init__(self):

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -7,7 +7,7 @@ import time
 
 from dataclasses import dataclass
 from decimal import Decimal
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
 from typing import Any, List, Tuple
 

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from PIL import Image, ImageDraw, ImageFont
 from typing import Tuple
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from seedsigner.gui.components import Fonts, GUIConstants, SeedSignerIconConstants
 from seedsigner.hardware.buttons import HardwareButtonsConstants

--- a/src/seedsigner/gui/screens/psbt_screens.py
+++ b/src/seedsigner/gui/screens/psbt_screens.py
@@ -2,7 +2,7 @@ import math
 import time
 
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from gettext import ngettext
 from PIL import Image, ImageDraw, ImageFilter
 

--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -1,7 +1,7 @@
 import time
 
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from PIL import Image, ImageDraw
 
 from seedsigner.gui import renderer

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from dataclasses import dataclass, field
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from PIL import Image, ImageDraw, ImageColor
 from typing import Any, List, Tuple
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -464,7 +464,7 @@ class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
 
     def __post_init__(self):
         # TRANSLATOR_NOTE: Displays the page number and total: (e.g. page 1 of 6)
-        self.title = _("Seed Words: {}/{}").format(self.page_index + 1, self.num_pages)
+        self.title = _("Seed Words: {}/{}", self.page_index + 1, self.num_pages)
         super().__post_init__()
 
         words_per_page = len(self.words)

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -3,7 +3,7 @@ import math
 import time
 
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from PIL import Image, ImageDraw, ImageFilter
 from typing import List
 

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -1,7 +1,7 @@
 import time
 
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from PIL.ImageOps import autocontrast
 from typing import List
 

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -1,7 +1,7 @@
 import time
 
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from typing import Any
 from PIL.Image import Image
 from seedsigner.gui.renderer import Renderer

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from seedsigner.gui.components import BaseComponent, GUIConstants, Icon, SeedSignerIconConstants, TextArea
 from seedsigner.models.threads import BaseThread

--- a/src/seedsigner/helpers/l10n.py
+++ b/src/seedsigner/helpers/l10n.py
@@ -24,17 +24,18 @@ class TranslationVariableMissingError(Exception):
             return f"Translation error in locale '{self.locale}': Translation missing variables {expected_vars_str}.\nOriginal: '{self.message}'\nTranslation: '{self.translated}'"
         return f"Translation error in locale '{self.locale}'"
 
-def seedsigner_gettext(message: str, **kwargs):
+def seedsigner_gettext(message: str, *args, **kwargs):
     """
     Enhanced gettext with built-in variable formatting and better error messages.
+    Supports both positional args (for {} placeholders) and keyword args (for {name} placeholders).
     """
     translated = gettext.gettext(message)
     
-    if not kwargs:
+    if not args and not kwargs:
         return translated
     
     try:
-        return translated.format(**kwargs)
+        return translated.format(*args, **kwargs)
     except (KeyError, IndexError, ValueError) as e:
         from seedsigner.models.settings import Settings
         from seedsigner.models.settings_definition import SettingsConstants
@@ -54,20 +55,21 @@ def seedsigner_gettext(message: str, **kwargs):
             locale=locale,
             message=message,
             translated=translated,
-            expected_vars=list(kwargs.keys())
+            expected_vars=list(kwargs.keys()) if kwargs else [f'arg{i}' for i in range(len(args))]
         ) from e
 
-def seedsigner_ngettext(singular: str, plural: str, n: int, **kwargs):
+def seedsigner_ngettext(singular: str, plural: str, n: int, *args, **kwargs):
     """
     Enhanced ngettext with built-in variable formatting and better error messages.
+    Supports both positional args (for {} placeholders) and keyword args (for {name} placeholders).
     """
     translated = gettext.ngettext(singular, plural, n)
     
-    if not kwargs:
+    if not args and not kwargs:
         return translated
     
     try:
-        return translated.format(**kwargs)
+        return translated.format(*args, **kwargs)
     except (KeyError, IndexError, ValueError) as e:
         from seedsigner.models.settings import Settings
         from seedsigner.models.settings_definition import SettingsConstants
@@ -81,5 +83,5 @@ def seedsigner_ngettext(singular: str, plural: str, n: int, **kwargs):
             locale=locale,
             message=singular if n == 1 else plural,
             translated=translated,
-            expected_vars=list(kwargs.keys())
+            expected_vars=list(kwargs.keys()) if kwargs else [f'arg{i}' for i in range(len(args))]
         ) from e

--- a/src/seedsigner/helpers/l10n.py
+++ b/src/seedsigner/helpers/l10n.py
@@ -1,3 +1,85 @@
+import gettext
+import re
+import logging
+
 def mark_for_translation(message: str) -> str:
-    # Wraps the target string literal for translation but does NOT return the translated string.
+    """
+    Wraps the target string literal for translation but does NOT return the translated string.
+    """
     return message
+
+class TranslationVariableMissingError(Exception):
+    """
+    Raised when a translation does not include the expected named variable(s).
+    """
+    def __init__(self, locale=None, message=None, translated=None, expected_vars=None):
+        self.locale = locale
+        self.message = message
+        self.translated = translated
+        self.expected_vars = expected_vars
+
+    def __str__(self):
+        if self.expected_vars:
+            expected_vars_str = ', '.join([f'{{{var}}}' for var in self.expected_vars])
+            return f"Translation error in locale '{self.locale}': Translation missing variables {expected_vars_str}.\nOriginal: '{self.message}'\nTranslation: '{self.translated}'"
+        return f"Translation error in locale '{self.locale}'"
+
+def seedsigner_gettext(message: str, **kwargs):
+    """
+    Enhanced gettext with built-in variable formatting and better error messages.
+    """
+    translated = gettext.gettext(message)
+    
+    if not kwargs:
+        return translated
+    
+    try:
+        return translated.format(**kwargs)
+    except (KeyError, IndexError, ValueError) as e:
+        from seedsigner.models.settings import Settings
+        from seedsigner.models.settings_definition import SettingsConstants
+        
+        locale = Settings.get_instance().get_value(SettingsConstants.SETTING__LOCALE)
+        
+        # More detailed error logging based on exception type
+        if isinstance(e, IndexError) and re.search(r'{}', translated):
+            logging.error(f"Translation contains empty brackets {{}} instead of named variables in locale '{locale}'")
+        elif isinstance(e, KeyError):
+            missing_var = str(e).strip("'")
+            logging.error(f"Translation missing named variable {{{missing_var}}} in locale '{locale}'")
+        else:
+            logging.error(f"Translation formatting error in locale '{locale}': {str(e)}")
+        
+        raise TranslationVariableMissingError(
+            locale=locale,
+            message=message,
+            translated=translated,
+            expected_vars=list(kwargs.keys())
+        ) from e
+
+def seedsigner_ngettext(singular: str, plural: str, n: int, **kwargs):
+    """
+    Enhanced ngettext with built-in variable formatting and better error messages.
+    """
+    translated = gettext.ngettext(singular, plural, n)
+    
+    if not kwargs:
+        return translated
+    
+    try:
+        return translated.format(**kwargs)
+    except (KeyError, IndexError, ValueError) as e:
+        from seedsigner.models.settings import Settings
+        from seedsigner.models.settings_definition import SettingsConstants
+        
+        locale = Settings.get_instance().get_value(SettingsConstants.SETTING__LOCALE)
+        
+        # Log the error
+        logging.error(f"Translation formatting error in locale '{locale}': {str(e)}")
+        
+        raise TranslationVariableMissingError(
+            locale=locale,
+            message=singular if n == 1 else plural,
+            translated=translated,
+            expected_vars=list(kwargs.keys())
+        ) from e

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -1,4 +1,4 @@
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination

--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -4,7 +4,7 @@ import random
 import time
 
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from seedsigner.gui.components import Fonts, GUIConstants, load_image
 from seedsigner.gui.screens.screen import BaseScreen

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3,7 +3,7 @@ import random
 import time
 
 from binascii import hexlify
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from embit.descriptor import Descriptor
 

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -1,5 +1,5 @@
 import logging
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from seedsigner.gui.components import GUIConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen, settings_screens)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants, resize_image_to_fill
 from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 from typing import Type
 
 from seedsigner.helpers.l10n import mark_for_translation as _mft

--- a/tests/test_flows_l10n.py
+++ b/tests/test_flows_l10n.py
@@ -1,4 +1,4 @@
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 # Must import test base before the Controller
 from base import FlowTest, FlowStep

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -1,4 +1,4 @@
-from gettext import gettext as _
+from seedsigner.helpers.l10n import seedsigner_gettext as _
 
 from base import BaseTest
 from seedsigner.gui.screens.screen import ButtonOption

--- a/tests/test_l10n_gettext.py
+++ b/tests/test_l10n_gettext.py
@@ -111,6 +111,63 @@ class TestSeedSignerGettextSuccess:
         assert seedsigner_gettext("Hello {name}", name="World") == "Hello World"
 
 
+class TestSeedSignerGettextPositionalSuccess:
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_single_positional_arg(self, mock_gt):
+        mock_gt.return_value = "Seed Wort #{}"
+        assert seedsigner_gettext("Seed Word #{}", 5) == "Seed Wort #5"
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_multiple_positional_args(self, mock_gt):
+        mock_gt.return_value = "Seed Wörter: {}/{}"
+        assert seedsigner_gettext("Seed Words: {}/{}", 1, 3) == "Seed Wörter: 1/3"
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_no_args_no_kwargs_returns_translated(self, mock_gt):
+        """No args and no kwargs → translated string returned as-is."""
+        mock_gt.return_value = "Würfelwurf 1/50"
+        assert seedsigner_gettext("Dice Roll 1/50") == "Würfelwurf 1/50"
+
+
+class TestSeedSignerGettextPositionalFailure:
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_fewer_placeholders_does_not_raise(self, mock_gt):
+        """Translation has fewer {} than args — Python ignores extra args, no error."""
+        mock_gt.return_value = "Seite {}"
+        # .format(1, 3) with only one {} silently ignores the extra arg
+        assert seedsigner_gettext("Page {}/{}", 1, 3) == "Seite 1"
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_too_many_placeholders_in_translation(self, mock_gt):
+        """Translation has more {} than args provided → IndexError."""
+        mock_gt.return_value = "Seite {}/{}/{}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Page {}/{}", 1, 3)
+
+        exc = exc_info.value
+        assert exc.locale == "de_DE"
+        assert isinstance(exc.__cause__, IndexError)
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_named_placeholder_in_translation_with_positional_args(self, mock_gt):
+        """Translation uses {name} but caller passes positional args → KeyError."""
+        mock_gt.return_value = "Seite {page}/{total}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Page {}/{}", 1, 3)
+
+        exc = exc_info.value
+        assert isinstance(exc.__cause__, KeyError)
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_expected_vars_for_positional_args(self, mock_gt):
+        """On failure with *args, expected_vars should list arg0, arg1, etc."""
+        mock_gt.return_value = "Seite {}/{}/{}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Page {}/{}", 1, 3)
+
+        assert exc_info.value.expected_vars == ["arg0", "arg1"]
+
+
 
 class TestSeedSignerGettextFailure:
     @patch("seedsigner.helpers.l10n.gettext.gettext")
@@ -241,6 +298,18 @@ class TestSeedSignerNgettextSuccess:
     def test_plural_with_kwargs(self, mock_ng):
         mock_ng.return_value = "{count} Dateien"
         result = seedsigner_ngettext("{count} file", "{count} files", 5, count=5)
+        assert result == "5 Dateien"
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_singular_with_positional_arg(self, mock_ng):
+        mock_ng.return_value = "{} Datei"
+        result = seedsigner_ngettext("{} file", "{} files", 1, 1)
+        assert result == "1 Datei"
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_plural_with_positional_arg(self, mock_ng):
+        mock_ng.return_value = "{} Dateien"
+        result = seedsigner_ngettext("{} file", "{} files", 5, 5)
         assert result == "5 Dateien"
 
 

--- a/tests/test_l10n_gettext.py
+++ b/tests/test_l10n_gettext.py
@@ -1,0 +1,359 @@
+import logging
+import re
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import sys
+
+# Prevent importing modules w/Raspi hardware dependencies (same as base.py).
+sys.modules['numpy'] = MagicMock()
+sys.modules['seedsigner.gui.renderer'] = MagicMock()
+sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
+sys.modules['seedsigner.gui.toast'] = MagicMock()
+sys.modules['seedsigner.views.screensaver'] = MagicMock()
+sys.modules['seedsigner.hardware.buttons'] = MagicMock()
+sys.modules['seedsigner.hardware.camera.Camera'] = MagicMock()
+sys.modules['seedsigner.hardware.pivideostream'] = MagicMock()
+sys.modules['seedsigner.hardware.st7789_mpy'] = MagicMock()
+sys.modules['seedsigner.hardware.ili9341'] = MagicMock()
+
+from seedsigner.helpers.l10n import (
+    seedsigner_gettext,
+    seedsigner_ngettext,
+    mark_for_translation,
+    TranslationVariableMissingError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_settings():
+    """Mock Settings.get_instance() so production settings are never touched."""
+    mock_settings = MagicMock()
+    mock_settings.get_value.return_value = "de_DE"
+    with patch("seedsigner.models.settings.Settings") as MockSettings, \
+         patch("seedsigner.models.settings_definition.SettingsConstants") as MockSC:
+        MockSettings.get_instance.return_value = mock_settings
+        MockSC.SETTING__LOCALE = "locale"
+        yield
+
+
+
+class TestMarkForTranslation:
+    def test_returns_original_string(self):
+        assert mark_for_translation("Hello") == "Hello"
+
+    def test_does_not_translate(self):
+        """mark_for_translation must never modify the string."""
+        msg = "Some {variable} string"
+        assert mark_for_translation(msg) is msg
+
+
+
+class TestTranslationVariableMissingError:
+    def test_str_with_all_fields(self):
+        exc = TranslationVariableMissingError(
+            locale="de_DE",
+            message="Hello {name}",
+            translated="Hallo {}",
+            expected_vars=["name"],
+        )
+        s = str(exc)
+        assert "de_DE" in s
+        assert "Hello {name}" in s
+        assert "Hallo {}" in s
+        assert "{name}" in s
+
+    def test_str_without_expected_vars(self):
+        exc = TranslationVariableMissingError(locale="de_DE")
+        assert "de_DE" in str(exc)
+
+    def test_attributes_stored(self):
+        exc = TranslationVariableMissingError(
+            locale="fr_FR",
+            message="original",
+            translated="traduit",
+            expected_vars=["a", "b"],
+        )
+        assert exc.locale == "fr_FR"
+        assert exc.message == "original"
+        assert exc.translated == "traduit"
+        assert exc.expected_vars == ["a", "b"]
+
+
+
+class TestSeedSignerGettextSuccess:
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_no_kwargs_returns_translated(self, mock_gt):
+        mock_gt.return_value = "Hallo"
+        assert seedsigner_gettext("Hello") == "Hallo"
+        mock_gt.assert_called_once_with("Hello")
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_named_variable_substitution(self, mock_gt):
+        mock_gt.return_value = "Hallo {name}"
+        assert seedsigner_gettext("Hello {name}", name="World") == "Hallo World"
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_multiple_named_variables(self, mock_gt):
+        mock_gt.return_value = "Das {n}te Wort wird erstellt aus {bits} Bits"
+        result = seedsigner_gettext(
+            "The {n}th word is built from {bits} bits",
+            n=12,
+            bits=8,
+        )
+        assert result == "Das 12te Wort wird erstellt aus 8 Bits"
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_no_translation_available(self, mock_gt):
+        """When gettext returns the original string unchanged."""
+        mock_gt.return_value = "Hello {name}"
+        assert seedsigner_gettext("Hello {name}", name="World") == "Hello World"
+
+
+
+class TestSeedSignerGettextFailure:
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_missing_variable_in_kwargs_raises(self, mock_gt):
+        """Translation expects {name} but kwargs only has 'greeting' → KeyError."""
+        mock_gt.return_value = "Hallo {name}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Hello {name}", greeting="Hi")
+
+        exc = exc_info.value
+        assert exc.locale == "de_DE"
+        assert exc.message == "Hello {name}"
+        assert exc.translated == "Hallo {name}"
+        assert exc.expected_vars == ["greeting"]
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_positional_placeholder_raises(self, mock_gt, caplog):
+        """Translation uses {} instead of {name} → IndexError."""
+        mock_gt.return_value = "Hallo {}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Hello {name}", name="World")
+
+        exc = exc_info.value
+        assert exc.expected_vars == ["name"]
+        assert "empty brackets" in caplog.text.lower() or "IndexError" in caplog.text or "{}" in caplog.text
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_wrong_variable_name_raises(self, mock_gt, caplog):
+        """Translation uses {username} instead of {name} → KeyError."""
+        mock_gt.return_value = "Hallo {username}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Hello {name}", name="World")
+
+        exc = exc_info.value
+        assert exc.expected_vars == ["name"]
+        assert "username" in caplog.text
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_malformed_format_string_raises(self, mock_gt):
+        """Translation has unclosed brace {name → ValueError."""
+        mock_gt.return_value = "Hallo {name"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Hello {name}", name="World")
+
+        exc = exc_info.value
+        assert exc.locale == "de_DE"
+        assert exc.expected_vars == ["name"]
+
+    @pytest.mark.parametrize(
+        "translated, kwargs, expected_exc_cause",
+        [
+            pytest.param("Hallo {}", dict(name="World"), IndexError, id="positional_placeholder"),
+            pytest.param("Hallo {username}", dict(name="World"), KeyError, id="wrong_variable_name"),
+            pytest.param("Hallo {name", dict(name="World"), ValueError, id="malformed_brace"),
+            pytest.param("{} {} bits", dict(n=12, bits=8), IndexError, id="multiple_positional"),
+        ],
+    )
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_parametrized_failures(self, mock_gt, translated, kwargs, expected_exc_cause):
+        mock_gt.return_value = translated
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("original", **kwargs)
+
+        assert exc_info.value.locale == "de_DE"
+        assert exc_info.value.expected_vars == list(kwargs.keys())
+        assert isinstance(exc_info.value.__cause__, expected_exc_cause)
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_exception_chains_original_cause(self, mock_gt):
+        """The custom exception should chain from the original formatting error."""
+        mock_gt.return_value = "Hallo {}"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_gettext("Hello {name}", name="World")
+
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, IndexError)
+
+
+
+class TestSeedSignerGettextLogging:
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_logs_empty_brackets(self, mock_gt, caplog):
+        mock_gt.return_value = "Hallo {}"
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(TranslationVariableMissingError):
+                seedsigner_gettext("Hello {name}", name="World")
+        assert "empty brackets" in caplog.text.lower() or "{}" in caplog.text
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_logs_missing_named_variable(self, mock_gt, caplog):
+        mock_gt.return_value = "Hallo {username}"
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(TranslationVariableMissingError):
+                seedsigner_gettext("Hello {name}", name="World")
+        assert "username" in caplog.text
+
+    @patch("seedsigner.helpers.l10n.gettext.gettext")
+    def test_logs_malformed_format(self, mock_gt, caplog):
+        mock_gt.return_value = "Hallo {name"
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(TranslationVariableMissingError):
+                seedsigner_gettext("Hello {name}", name="World")
+        assert "de_DE" in caplog.text
+
+
+
+class TestSeedSignerNgettextSuccess:
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_singular_no_kwargs(self, mock_ng):
+        mock_ng.return_value = "1 Datei"
+        result = seedsigner_ngettext("{count} file", "{count} files", 1)
+        assert result == "1 Datei"
+        mock_ng.assert_called_once_with("{count} file", "{count} files", 1)
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_plural_no_kwargs(self, mock_ng):
+        mock_ng.return_value = "5 Dateien"
+        result = seedsigner_ngettext("{count} file", "{count} files", 5)
+        assert result == "5 Dateien"
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_singular_with_kwargs(self, mock_ng):
+        mock_ng.return_value = "{count} Datei"
+        result = seedsigner_ngettext("{count} file", "{count} files", 1, count=1)
+        assert result == "1 Datei"
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_plural_with_kwargs(self, mock_ng):
+        mock_ng.return_value = "{count} Dateien"
+        result = seedsigner_ngettext("{count} file", "{count} files", 5, count=5)
+        assert result == "5 Dateien"
+
+
+
+class TestSeedSignerNgettextFailure:
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_positional_placeholder_raises(self, mock_ng):
+        mock_ng.return_value = "{} Dateien"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_ngettext("{count} file", "{count} files", 5, count=5)
+
+        exc = exc_info.value
+        assert exc.locale == "de_DE"
+        assert exc.expected_vars == ["count"]
+        assert isinstance(exc.__cause__, IndexError)
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_wrong_variable_name_raises(self, mock_ng):
+        mock_ng.return_value = "{anzahl} Dateien"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_ngettext("{count} file", "{count} files", 5, count=5)
+
+        exc = exc_info.value
+        assert exc.expected_vars == ["count"]
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_singular_message_stored_on_error(self, mock_ng):
+        """When n==1, exception.message should be the singular form."""
+        mock_ng.return_value = "{} Datei"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_ngettext("{count} file", "{count} files", 1, count=1)
+
+        assert exc_info.value.message == "{count} file"
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_plural_message_stored_on_error(self, mock_ng):
+        """When n!=1, exception.message should be the plural form."""
+        mock_ng.return_value = "{} Dateien"
+        with pytest.raises(TranslationVariableMissingError) as exc_info:
+            seedsigner_ngettext("{count} file", "{count} files", 5, count=5)
+
+        assert exc_info.value.message == "{count} files"
+
+    @patch("seedsigner.helpers.l10n.gettext.ngettext")
+    def test_ngettext_logs_error(self, mock_ng, caplog):
+        mock_ng.return_value = "{} Dateien"
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(TranslationVariableMissingError):
+                seedsigner_ngettext("{count} file", "{count} files", 5, count=5)
+        assert "de_DE" in caplog.text
+
+
+
+def _extract_named_vars(fmt_string: str) -> set[str]:
+    """Extract named variables from a format string like '{name} is {age}'."""
+    return set(re.findall(r'\{(\w+)\}', fmt_string))
+
+
+def _has_positional_placeholders(fmt_string: str) -> bool:
+    """Detect positional {} placeholders (empty braces)."""
+    return bool(re.search(r'\{\}', fmt_string))
+
+
+class TestVariableConsistencyDetection:
+    """
+    Bonus tests demonstrating how to detect variable mismatches between
+    source and translated strings — useful for a future CI lint step.
+    """
+
+    @pytest.mark.parametrize(
+        "source, translated, expected_match",
+        [
+            pytest.param(
+                "The {n}th word from {bits} bits",
+                "Das {n}te Wort aus {bits} Bits",
+                True,
+                id="matching_vars",
+            ),
+            pytest.param(
+                "The {n}th word from {bits} bits",
+                "Das {number}te Wort aus {bits} Bits",
+                False,
+                id="renamed_var",
+            ),
+            pytest.param(
+                "The {n}th word from {bits} bits",
+                "Das {n}te Wort aus {bits} Bits und {extra}",
+                False,
+                id="extra_var_in_translation",
+            ),
+            pytest.param(
+                "Hello {name}",
+                "Hallo {}",
+                False,
+                id="positional_instead_of_named",
+            ),
+        ],
+    )
+    def test_variable_sets_match(self, source, translated, expected_match):
+        source_vars = _extract_named_vars(source)
+        translated_vars = _extract_named_vars(translated)
+        has_positional = _has_positional_placeholders(translated)
+
+        is_consistent = (source_vars == translated_vars) and not has_positional
+        assert is_consistent == expected_match
+
+    def test_detect_positional_placeholders(self):
+        assert _has_positional_placeholders("Hello {}") is True
+        assert _has_positional_placeholders("Hello {name}") is False
+        assert _has_positional_placeholders("{} and {}") is True
+
+    def test_detect_extra_vars_in_translation(self):
+        source_vars = _extract_named_vars("Hello {name}")
+        trans_vars = _extract_named_vars("Hallo {name} {extra}")
+        extra = trans_vars - source_vars
+        assert extra == {"extra"}


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

_PR #702  (by @AdityaPandeyCN) introduced `seedsigner_gettext` and `seedsigner_ngettext`, enhanced gettext wrappers that catch formatting errors in translations (e.g., `{}` instead of `{variable_name}`) and raise a descriptive `TranslationVariableMissingError`._ 
That PR currently has no test coverage.
### Solution

Added comprehensive `pytest` test coverage for the enhanced gettext functionality in `tests/test_l10n_gettext.py` (36 tests)

### Additional Information

- All tests mock `gettext.gettext` / `gettext.ngettext`, no dependency on real `.po`/`.mo` files
- Tests mock `Settings` to avoid hardware/filesystem dependencies
- Manually verified the error handling in the emulator by corrupting the German `.po` file (replacing `{mnemonic_length}` and `{num_bits}` with positional `{}`), followed by recompiling
- This PR builds on top of #702 
- Addresses issue #693 
- Part of Summer of Bitcoin

### Screenshots

Emulator error screen triggered by intentionally corrupted German translation:

<img width="484" height="293" alt="Screenshot from 2026-04-10 02-55-50" src="https://github.com/user-attachments/assets/5e95d5cd-0066-49fe-b118-d58823a8570c" />

---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.