### PR TITLE
[Feature] Optional battery indicator for Waveshare UPS HAT

### DIFF
--- a/requirements-raspi.txt
+++ b/requirements-raspi.txt
@@ -3,3 +3,4 @@ picamera==1.13
 numpy==1.25.2
 RPi.GPIO==0.7.0
 spidev==3.5
+smbus2

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -184,6 +184,9 @@ class Controller(Singleton):
         controller.microsd = MicroSD.get_instance()
         controller.microsd.start_detection()
 
+        from seedsigner.hardware.ups import UPS
+        UPS.configure_instance()
+
         # Store one working psbt in memory
         controller.psbt = None
         controller.psbt_parser = None

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -1751,6 +1751,18 @@ class TopNav(BaseComponent):
                 # for the life of the Component.
                 self.threads.append(self.title.scroll_thread)
 
+        self._battery_icon = None
+        from seedsigner.hardware.ups import UPS
+        if (UPS.get_instance().is_present()
+                and Settings.get_instance().get_value(SettingsConstants.SETTING__BATTERY_INDICATOR) == SettingsConstants.OPTION__ENABLED):
+            icon_w = 22
+            icon_y = (self.height - 12) // 2
+            if self.show_power_button:
+                icon_x = self.right_button.screen_x - GUIConstants.COMPONENT_PADDING - icon_w
+            else:
+                icon_x = self.width - GUIConstants.EDGE_PADDING - icon_w
+            self._battery_icon = BatteryStatusIcon(screen_x=icon_x, screen_y=icon_y)
+
 
     @property
     def selected_button(self):
@@ -1766,7 +1778,9 @@ class TopNav(BaseComponent):
     def render(self):
         self.title.render()
         self.render_buttons()
-    
+        if self._battery_icon is not None:
+            self._battery_icon.render()
+
 
     def render_buttons(self):
         if self.show_back_button:
@@ -1775,6 +1789,45 @@ class TopNav(BaseComponent):
         if self.show_power_button:
             self.right_button.is_selected = self.is_selected
             self.right_button.render()
+
+
+
+@dataclass
+class BatteryStatusIcon(BaseComponent):
+    """Small battery glyph drawn in the top-right corner of TopNav."""
+    screen_x: int = 0
+    screen_y: int = 0
+    width: int = 22   # 20 px body + 2 px nub
+    height: int = 12
+
+    def render(self):
+        from seedsigner.hardware.ups import UPS
+        pct = UPS.get_instance().read_percent()
+        if pct is None:
+            return
+        # Outer body: 20 px wide, full height
+        body_x2 = self.screen_x + 19
+        body_y2 = self.screen_y + self.height - 1
+        self.image_draw.rectangle(
+            [self.screen_x, self.screen_y, body_x2, body_y2],
+            outline=GUIConstants.BODY_FONT_COLOR,
+            fill=GUIConstants.BACKGROUND_COLOR,
+        )
+        # Nub: 2 px wide, 6 px tall, centered vertically on the right edge
+        nub_x1 = self.screen_x + 20
+        nub_y1 = self.screen_y + (self.height - 6) // 2
+        self.image_draw.rectangle(
+            [nub_x1, nub_y1, nub_x1 + 1, nub_y1 + 5],
+            fill=GUIConstants.BODY_FONT_COLOR,
+        )
+        # Fill area: 16 px usable (20 - 2 border - 2 padding)
+        fill_w = max(0, int(round(16 * pct / 100)))
+        if fill_w > 0:
+            self.image_draw.rectangle(
+                [self.screen_x + 2, self.screen_y + 2,
+                 self.screen_x + 1 + fill_w, self.screen_y + self.height - 3],
+                fill=GUIConstants.BODY_FONT_COLOR,
+            )
 
 
 

--- a/src/seedsigner/hardware/ups.py
+++ b/src/seedsigner/hardware/ups.py
@@ -1,0 +1,113 @@
+import logging
+
+from seedsigner.models.singleton import Singleton
+
+logger = logging.getLogger(__name__)
+
+
+class UPS(Singleton):
+    ACTION__DETECTED = "ups__detected"
+    ACTION__ABSENT   = "ups__absent"
+
+    I2C_BUS     = 1
+    INA219_ADDR = 0x43
+
+    REG_CONFIG      = 0x00
+    REG_SHUNT_VOLT  = 0x01  # signed 16-bit, 10 uV/LSB
+    REG_BUS_VOLTAGE = 0x02  # bits [15:3], LSB = 4 mV
+
+    SHUNT_OHMS = 0.1  # Waveshare UPS HAT (C) shunt resistor
+
+    VMIN = 3.0   # 0 %
+    VMAX = 4.2   # 100 %
+
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            ups = cls.__new__(cls)
+            ups._present = False
+            cls._instance = ups
+        return cls._instance
+
+
+    @classmethod
+    def configure_instance(cls):
+        from seedsigner.models.settings import Settings
+        instance = cls.get_instance()
+        instance._present = instance.probe()
+        action = cls.ACTION__DETECTED if instance._present else cls.ACTION__ABSENT
+        Settings.handle_ups_state_change(action)
+
+
+    def probe(self) -> bool:
+        """Probe for an INA219 at I2C_ADDR. Returns True if the chip responds."""
+        try:
+            from smbus2 import SMBus
+            with SMBus(self.I2C_BUS) as bus:
+                # Write default config: 32 V range, 320 mV shunt, 12-bit, continuous
+                config = 0x399F
+                bus.write_i2c_block_data(
+                    self.INA219_ADDR,
+                    self.REG_CONFIG,
+                    [(config >> 8) & 0xFF, config & 0xFF],
+                )
+                raw = bus.read_i2c_block_data(self.INA219_ADDR, self.REG_BUS_VOLTAGE, 2)
+            return (raw[0] << 8 | raw[1]) != 0
+        except Exception:
+            return False
+
+
+    def is_present(self) -> bool:
+        return self._present
+
+
+    def read_voltage(self) -> float | None:
+        """Return bus voltage in volts, or None on read failure."""
+        if not self._present:
+            return None
+        try:
+            from smbus2 import SMBus
+            with SMBus(self.I2C_BUS) as bus:
+                raw = bus.read_i2c_block_data(self.INA219_ADDR, self.REG_BUS_VOLTAGE, 2)
+            # Bits [15:3] are the bus voltage; LSB = 4 mV
+            return ((raw[0] << 8 | raw[1]) >> 3) * 0.004
+        except Exception:
+            return None
+
+
+    def read_current_ma(self) -> float | None:
+        """Return shunt current in mA (positive = charging), or None on read failure."""
+        if not self._present:
+            return None
+        try:
+            from smbus2 import SMBus
+            with SMBus(self.I2C_BUS) as bus:
+                raw = bus.read_i2c_block_data(self.INA219_ADDR, self.REG_SHUNT_VOLT, 2)
+            shunt_raw = raw[0] << 8 | raw[1]
+            if shunt_raw > 0x7FFF:
+                shunt_raw -= 0x10000
+            shunt_uv = shunt_raw * 10  # 10 uV/LSB
+            return (shunt_uv / 1000.0) / self.SHUNT_OHMS
+        except Exception:
+            return None
+
+
+    def read_percent(self) -> int | None:
+        """Return battery level as 0-100, or None if voltage cannot be read."""
+        v = self.read_voltage()
+        if v is None:
+            return None
+        pct = (v - self.VMIN) / (self.VMAX - self.VMIN) * 100.0
+        return max(0, min(100, int(round(pct))))
+
+
+    def is_charging(self) -> bool | None:
+        """Return True if charging, False if discharging, None on read failure.
+
+        Uses a 5 mA deadband to avoid jitter at rest.
+        """
+        ma = self.read_current_ma()
+        if ma is None:
+            return None
+        return ma > 5

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -276,6 +276,21 @@ class Settings(Singleton):
         return self._data[SettingsConstants.SETTING__DEBUG] == SettingsConstants.OPTION__ENABLED
 
 
+    def handle_ups_state_change(action: str):
+        """
+        Enables/Disables the Battery Indicator option based on UPS HAT presence at boot.
+        """
+        from seedsigner.hardware.ups import UPS
+        entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__BATTERY_INDICATOR)
+        if action == UPS.ACTION__DETECTED:
+            entry.selection_options = SettingsConstants.OPTIONS__ENABLED_DISABLED
+            entry.help_text = SettingsConstants.BATTERY_INDICATOR__DETECTED__HELP_TEXT
+        else:
+            Settings.get_instance()._data[SettingsConstants.SETTING__BATTERY_INDICATOR] = SettingsConstants.OPTION__DISABLED
+            entry.selection_options = SettingsConstants.OPTIONS__ONLY_DISABLED
+            entry.help_text = SettingsConstants.BATTERY_INDICATOR__NOT_DETECTED__HELP_TEXT
+
+
     def handle_microsd_state_change(action: str):
         """
         Enables/Disables the Persistent Settings option based on the MicroSD card state.

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -355,6 +355,10 @@ class SettingsConstants:
     SETTING__MICROSD_TOAST_TIMER = "microsd_toast_timer"
 
     SETTING__DEBUG = "debug"
+    SETTING__BATTERY_INDICATOR = "battery_indicator"
+
+    BATTERY_INDICATOR__DETECTED__HELP_TEXT = _mft("Show battery level in top bar")
+    BATTERY_INDICATOR__NOT_DETECTED__HELP_TEXT = _mft("No compatible UPS HAT detected")
 
 
     # Hardware config settings
@@ -735,6 +739,16 @@ class SettingsDefinition:
                       display_name=_mft("Invert colors"),
                       type=SettingsConstants.TYPE__ENABLED_DISABLED,
                       visibility=SettingsConstants.VISIBILITY__HARDWARE,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
+        # TRANSLATOR_NOTE: Settings option to show a small battery icon in the top bar.
+        # Only selectable when a compatible Waveshare UPS HAT is detected at boot.
+        SettingsEntry(category=SettingsConstants.CATEGORY__SYSTEM,
+                      attr_name=SettingsConstants.SETTING__BATTERY_INDICATOR,
+                      abbreviated_name="battery",
+                      display_name=_mft("Battery indicator"),
+                      visibility=SettingsConstants.VISIBILITY__HARDWARE,
+                      help_text=SettingsConstants.BATTERY_INDICATOR__DETECTED__HELP_TEXT,
                       default_value=SettingsConstants.OPTION__DISABLED),
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,12 @@ from typing import Callable
 # Prevent importing modules w/Raspi hardware dependencies.
 # These must precede any SeedSigner imports.
 sys.modules['numpy'] = MagicMock()  # numpy is only in the Raspi requirements; not needed for tests. But is imported in BackgroundImportThread.
+sys.modules['smbus2'] = MagicMock()
+try:
+    import pyzbar  # noqa: F401
+except ImportError:
+    sys.modules['pyzbar'] = MagicMock()
+    sys.modules['pyzbar.pyzbar'] = MagicMock()
 sys.modules['seedsigner.gui.renderer'] = MagicMock()
 sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
 sys.modules['seedsigner.gui.toast'] = MagicMock()
@@ -19,6 +25,7 @@ sys.modules['seedsigner.hardware.ili9341'] = MagicMock()
 from seedsigner.controller import Controller, FlowBasedTestException, StopFlowBasedTest
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__POWER_BUTTON, ButtonOption
 from seedsigner.hardware.microsd import MicroSD
+from seedsigner.hardware.ups import UPS
 from seedsigner.models.settings import Settings
 from seedsigner.views.view import Destination, MainMenuView, View
 
@@ -39,6 +46,20 @@ class BaseTest:
         is_inserted: bool = True
 
 
+    class MockUPS(Mock):
+        """
+        A test suite-friendly replacement for `UPS` that reports no HAT present.
+        """
+        ACTION__DETECTED = "ups__detected"
+        ACTION__ABSENT   = "ups__absent"
+
+        def probe(self): return False
+        def is_present(self): return False
+        def read_voltage(self): return None
+        def read_percent(self): return None
+        def is_charging(self): return None
+
+
     @classmethod
     def setup_class(cls):
         # Ensure there are no on-disk artifacts after running tests.
@@ -53,6 +74,10 @@ class BaseTest:
 
         # And mock it over `MicroSD`'s instance
         MicroSD.get_instance = Mock(return_value=cls.mock_microsd)
+
+        # Instantiate the mocked UPS and install it
+        cls.mock_ups = BaseTest.MockUPS()
+        UPS.get_instance = Mock(return_value=cls.mock_ups)
 
 
     @classmethod

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -10,6 +10,7 @@ from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsDefinition, SettingsConstants
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
 from seedsigner.hardware.microsd import MicroSD
+from seedsigner.hardware.ups import UPS
 from seedsigner.views.view import MainMenuView
 from seedsigner.views import scan_views, settings_views
 
@@ -155,3 +156,24 @@ class TestSettingsFlows(FlowTest):
             load_settingsqr_into_decoder=load_persistent_settingsqr_into_decoder,
             expected_setting_state=SettingsConstants.OPTION__DISABLED
         )
+
+
+    def test_battery_indicator_toggle(self):
+        """Battery indicator setting should be toggleable when UPS HAT is detected."""
+        settings_entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__BATTERY_INDICATOR)
+
+        # Simulate HAT detected: open up the selection options
+        Settings.handle_ups_state_change(UPS.ACTION__DETECTED)
+        assert settings_entry.selection_options == SettingsConstants.OPTIONS__ENABLED_DISABLED
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.ADVANCED),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.HARDWARE),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=ButtonOption(settings_entry.display_name)),
+            FlowStep(settings_views.SettingsEntryUpdateSelectionView, button_data_selection=ButtonOption(settings_entry.get_selection_option_display_name_by_value(SettingsConstants.OPTION__ENABLED))),
+            FlowStep(settings_views.SettingsEntryUpdateSelectionView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(settings_views.SettingsMenuView),
+        ])
+
+        assert self.settings.get_value(SettingsConstants.SETTING__BATTERY_INDICATOR) == SettingsConstants.OPTION__ENABLED

--- a/tests/test_ups.py
+++ b/tests/test_ups.py
@@ -1,0 +1,165 @@
+from unittest.mock import MagicMock, Mock, patch
+
+# Must import test base before the Controller
+from base import BaseTest
+
+from seedsigner.hardware.ups import UPS
+from seedsigner.models.settings import Settings
+from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
+
+
+
+class TestUPS(BaseTest):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+
+    def setup_method(self):
+        super().setup_method()
+        # Reset the UPS singleton so each test gets a fresh instance
+        UPS._instance = None
+
+
+    # -------------------------------------------------------------------------
+    # probe() failure modes
+    # -------------------------------------------------------------------------
+
+    def test_probe_missing_smbus2_returns_false(self):
+        """probe() should return False when smbus2 is not installed."""
+        with patch.dict('sys.modules', {'smbus2': None}):
+            ups = UPS.__new__(UPS)
+            ups._present = False
+            assert ups.probe() is False
+
+    def test_probe_bus_missing_returns_false(self):
+        """probe() should return False when /dev/i2c-1 does not exist."""
+        mock_smbus2 = MagicMock()
+        mock_smbus2.SMBus.return_value.__enter__.side_effect = FileNotFoundError
+        with patch.dict('sys.modules', {'smbus2': mock_smbus2}):
+            ups = UPS.__new__(UPS)
+            ups._present = False
+            assert ups.probe() is False
+
+    def test_probe_oserror_returns_false(self):
+        """probe() should return False on I2C read errors."""
+        mock_smbus2 = MagicMock()
+        mock_smbus2.SMBus.return_value.__enter__.return_value.read_i2c_block_data.side_effect = OSError
+        with patch.dict('sys.modules', {'smbus2': mock_smbus2}):
+            ups = UPS.__new__(UPS)
+            ups._present = False
+            assert ups.probe() is False
+
+    def test_probe_permission_error_returns_false(self):
+        """probe() should return False when I2C access is denied."""
+        mock_smbus2 = MagicMock()
+        mock_smbus2.SMBus.return_value.__enter__.side_effect = PermissionError
+        with patch.dict('sys.modules', {'smbus2': mock_smbus2}):
+            ups = UPS.__new__(UPS)
+            ups._present = False
+            assert ups.probe() is False
+
+    def test_probe_success_sets_present(self):
+        """probe() should return True and configure_instance should notify Settings."""
+        mock_smbus2 = MagicMock()
+        bus_mock = mock_smbus2.SMBus.return_value.__enter__.return_value
+        # Return non-zero bus voltage bytes to indicate chip is present
+        bus_mock.read_i2c_block_data.return_value = [0x1A, 0x40]
+        with patch.dict('sys.modules', {'smbus2': mock_smbus2}):
+            ups = UPS.__new__(UPS)
+            ups._present = False
+            result = ups.probe()
+        assert result is True
+
+
+    # -------------------------------------------------------------------------
+    # Voltage-to-percent math
+    # -------------------------------------------------------------------------
+
+    def test_read_percent_not_present(self):
+        """read_percent() should return None when HAT is not present."""
+        ups = UPS.__new__(UPS)
+        ups._present = False
+        assert ups.read_percent() is None
+
+    def test_read_percent_from_voltage_edges(self):
+        """read_percent() should correctly map voltage to 0-100, clamped."""
+        ups = UPS.__new__(UPS)
+        ups._present = True
+
+        cases = [
+            (3.0, 0),    # VMIN  → 0 %
+            (3.6, 50),   # midpoint
+            (4.2, 100),  # VMAX  → 100 %
+            (2.5, 0),    # below VMIN → clamped to 0
+            (5.0, 100),  # above VMAX → clamped to 100
+        ]
+        for voltage, expected_pct in cases:
+            with patch.object(ups, 'read_voltage', return_value=voltage):
+                assert ups.read_percent() == expected_pct, f"voltage={voltage}"
+
+    def test_read_percent_none_on_read_failure(self):
+        """read_percent() should return None when read_voltage returns None."""
+        ups = UPS.__new__(UPS)
+        ups._present = True
+        with patch.object(ups, 'read_voltage', return_value=None):
+            assert ups.read_percent() is None
+
+
+    # -------------------------------------------------------------------------
+    # is_charging()
+    # -------------------------------------------------------------------------
+
+    def test_is_charging_positive_current(self):
+        """is_charging() should return True when current exceeds the deadband."""
+        ups = UPS.__new__(UPS)
+        ups._present = True
+        with patch.object(ups, 'read_current_ma', return_value=200.0):
+            assert ups.is_charging() is True
+
+    def test_is_charging_negative_current(self):
+        """is_charging() should return False when current is negative (discharging)."""
+        ups = UPS.__new__(UPS)
+        ups._present = True
+        with patch.object(ups, 'read_current_ma', return_value=-100.0):
+            assert ups.is_charging() is False
+
+    def test_is_charging_in_deadband(self):
+        """is_charging() should return False for near-zero current (within 5 mA deadband)."""
+        ups = UPS.__new__(UPS)
+        ups._present = True
+        with patch.object(ups, 'read_current_ma', return_value=3.0):
+            assert ups.is_charging() is False
+
+    def test_is_charging_read_failure(self):
+        """is_charging() should return None when current cannot be read."""
+        ups = UPS.__new__(UPS)
+        ups._present = True
+        with patch.object(ups, 'read_current_ma', return_value=None):
+            assert ups.is_charging() is None
+
+
+    # -------------------------------------------------------------------------
+    # Settings integration
+    # -------------------------------------------------------------------------
+
+    def test_ups_absent_collapses_options(self):
+        """handle_ups_state_change(ABSENT) should restrict the entry to DISABLED only."""
+        Settings.handle_ups_state_change(UPS.ACTION__ABSENT)
+        entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__BATTERY_INDICATOR)
+        assert entry.selection_options == SettingsConstants.OPTIONS__ONLY_DISABLED
+        assert self.settings.get_value(SettingsConstants.SETTING__BATTERY_INDICATOR) == SettingsConstants.OPTION__DISABLED
+        assert entry.help_text == SettingsConstants.BATTERY_INDICATOR__NOT_DETECTED__HELP_TEXT
+
+    def test_ups_detected_restores_options(self):
+        """handle_ups_state_change(DETECTED) should open up ENABLED/DISABLED options."""
+        # Start collapsed
+        Settings.handle_ups_state_change(UPS.ACTION__ABSENT)
+        # Then detect
+        Settings.handle_ups_state_change(UPS.ACTION__DETECTED)
+        entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__BATTERY_INDICATOR)
+        assert entry.selection_options == SettingsConstants.OPTIONS__ENABLED_DISABLED
+        assert entry.help_text == SettingsConstants.BATTERY_INDICATOR__DETECTED__HELP_TEXT
+
+    def test_battery_indicator_default_disabled(self):
+        """Battery indicator should default to DISABLED."""
+        assert self.settings.get_value(SettingsConstants.SETTING__BATTERY_INDICATOR) == SettingsConstants.OPTION__DISABLED


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

SeedSigner has no on-screen indication of power state. Users running on
a Waveshare UPS HAT can't tell when the pack is low and risk losing a
session mid-sign. Fixes #869.

### Solution

At boot, a new `UPS` singleton probes the INA219 on I2C bus 1 at
address 0x43. If the chip responds, a new `Battery indicator` setting
becomes selectable under Settings > Advanced > Hardware; otherwise the
setting's options collapse to Disabled, mirroring the existing MicroSD
state pattern.

When the setting is enabled and the HAT is present, TopNav draws a
small battery glyph in the top bar. Percent is derived from bus
voltage using a linear 3.0V to 4.2V map clamped to 0-100. No percent
text, no charge control, no shutdown behaviour. The glyph is drawn
with Pillow primitives, so no font or asset changes were needed.

smbus2 is added to requirements-raspi.txt and imported lazily inside
the probe. Any ImportError, missing /dev/i2c-1, or I2C read failure
degrades silently to "not present", so desktop builds and non-HAT
hardware are unaffected.

### Additional Information

Only the Waveshare UPS HAT (C) is supported in v1. The probe is
structured so additional INA219-based HATs can be added later without
touching the GUI layer. The indicator is off by default to keep
existing screenshot goldens stable.

Shunt resistor value assumed 0.1 ohm per the Waveshare UPS HAT (C)
schematic - worth confirming before merge if a maintainer has hardware
on hand.

### Screenshots

To be added after testing on hardware.

---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [x] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.