### PR TITLE
Fix/ur2 cbor tests

### DIFF
--- a/src/seedsigner/helpers/ur2/cbor_lite.py
+++ b/src/seedsigner/helpers/ur2/cbor_lite.py
@@ -150,10 +150,11 @@ class CBOREncoder:
         return length + self.encodeBytes(value)
 
     def encodeText(self, value):
-        str_len = len(value)
-        length = self.encodeTagAndValue(Tag_Major_textString, str_len)
-        self.buf.extend(bytes(value, 'utf8'))  # fix: extend() not append() for bytes
-        return length + str_len
+        utf8_bytes = value.encode('utf-8')
+        byte_len = len(utf8_bytes)
+        length = self.encodeTagAndValue(Tag_Major_textString, byte_len)
+        self.buf.extend(utf8_bytes)
+        return length + byte_len
 
     def encodeArraySize(self, value):
         return self.encodeTagAndValue(Tag_Major_array, value)

--- a/src/seedsigner/helpers/ur2/cbor_lite.py
+++ b/src/seedsigner/helpers/ur2/cbor_lite.py
@@ -152,7 +152,7 @@ class CBOREncoder:
     def encodeText(self, value):
         str_len = len(value)
         length = self.encodeTagAndValue(Tag_Major_textString, str_len)
-        self.buf.append(bytes(value, 'utf8'))
+        self.buf.extend(bytes(value, 'utf8'))  # fix: extend() not append() for bytes
         return length + str_len
 
     def encodeArraySize(self, value):
@@ -311,6 +311,6 @@ class CBORDecoder:
 
     def decodeMapSize(self, flags=Flag_None):
         (tag, value, length) = self.decodeTagAndValue(flags)
-        if tag != Tag_Major_mask:
+        if tag != Tag_Major_map:  # fix: was Tag_Major_mask (0xe0), should be Tag_Major_map (0xa0)
             raise Exception("Expected Tag_Major_map, but found {}".format(tag))
         return (value, length)

--- a/tests/test_ur2.py
+++ b/tests/test_ur2.py
@@ -1,0 +1,146 @@
+import pytest
+from seedsigner.helpers.ur2.cbor_lite import (
+    CBOREncoder, CBORDecoder
+)
+from seedsigner.helpers.ur2.bytewords import Bytewords, Bytewords_Style_minimal
+from seedsigner.helpers.ur2.ur import UR
+from seedsigner.helpers.ur2.ur_encoder import UREncoder
+from seedsigner.helpers.ur2.ur_decoder import URDecoder, InvalidScheme, InvalidPathLength
+
+
+class TestCBORRoundTrip:
+    """
+    Round-trip encoding and decoding tests for various CBOR types.
+    """
+    def test_unsigned_roundtrip(self):
+        """
+        Should successfully encode and decode various unsigned integers, 
+        handling boundary values for different CBOR integer sizes.
+        """
+        for n in [0, 23, 24, 255, 256, 65535]:
+            enc = CBOREncoder()
+            enc.encodeUnsigned(n)
+            val, _ = CBORDecoder(enc.get_bytes()).decodeUnsigned()
+            assert val == n
+
+    def test_bytes_roundtrip(self):
+        """
+        Should successfully encode and decode a byte payload.
+        """
+        payload = b'\xde\xad\xbe\xef'
+        enc = CBOREncoder()
+        enc.encodeBytes(payload)
+        val, _ = CBORDecoder(enc.get_bytes()).decodeBytes()
+        assert val == payload
+
+    def test_text_roundtrip(self):
+        """
+        Should successfully encode and decode text using UTF-8.
+        """
+        enc = CBOREncoder()
+        enc.encodeText("bitcoin")
+        val, _ = CBORDecoder(enc.get_bytes()).decodeText()
+        assert bytes(val).decode('utf8') == "bitcoin"
+
+    def test_map_size_roundtrip(self):
+        """
+        Should successfully encode and decode map sizes.
+        """
+        for n in [0, 1, 23, 24]:
+            enc = CBOREncoder()
+            enc.encodeMapSize(n)
+            val, _ = CBORDecoder(enc.get_bytes()).decodeMapSize()
+            assert val == n
+
+    def test_array_size_roundtrip(self):
+        """
+        Should successfully encode and decode array sizes.
+        """
+        enc = CBOREncoder()
+        enc.encodeArraySize(5)
+        val, _ = CBORDecoder(enc.get_bytes()).decodeArraySize()
+        assert val == 5
+
+
+class TestBytewords:
+    """
+    Bytewords encoding and decoding tests.
+    """
+    def test_minimal_roundtrip(self):
+        """
+        Given a byte payload, should yield a valid "minimal" style Bytewords string 
+        that can be decoded back to the original payload.
+        """
+        payload = bytes(range(8))
+        encoded = Bytewords.encode(Bytewords_Style_minimal, payload)
+        decoded = Bytewords.decode(Bytewords_Style_minimal, encoded)
+        assert bytes(decoded) == payload
+
+    def test_invalid_byteword_raises(self):
+        """
+        Should raise a ValueError when attempting to decode invalid Bytewords data.
+        """
+        with pytest.raises(ValueError, match="Invalid Bytewords"):
+            Bytewords.decode(Bytewords_Style_minimal, "zzzz")
+
+
+class TestURRoundTrip:
+    """
+    Tests for UREncoder and URDecoder handling of animated QR UR strings.
+    """
+    UR_TYPE = "bytes"
+
+    def _make_ur(self, payload: bytes) -> UR:
+        """
+        Helper method to wrap a byte payload in a CBOR-encoded UR object.
+        """
+        enc = CBOREncoder()
+        enc.encodeBytes(payload)
+        return UR(self.UR_TYPE, enc.get_bytes())
+
+    def test_single_part_roundtrip(self):
+        """
+        Should successfully encode a small payload as a single-part 'ur:bytes' string 
+        and decode it back to original bytes.
+        """
+        payload = b'\x11\x22\x33\x44'
+        ur = self._make_ur(payload)
+        encoded_str = UREncoder.encode(ur)
+        assert encoded_str.startswith("ur:")
+        decoded_ur = URDecoder.decode(encoded_str)
+        val, _ = CBORDecoder(bytearray(decoded_ur.cbor)).decodeBytes()
+        assert bytes(val) == payload
+
+    def test_multi_part_animated_qr_roundtrip(self):
+        """
+        Given a large payload, should successfully encode it into multiple fountain-coded parts 
+        and decode them back once the decoder has received sufficient parts.
+        """
+        payload = bytes(range(100))
+        ur = self._make_ur(payload)
+        encoder = UREncoder(ur, max_fragment_len=20)
+        decoder = URDecoder()
+
+        for _ in range(500):
+            decoder.receive_part(encoder.next_part())
+            if decoder.is_complete():
+                break
+
+        assert decoder.is_complete()
+        assert decoder.is_success()
+        val, _ = CBORDecoder(bytearray(decoder.result_message().cbor)).decodeBytes()
+        assert bytes(val) == payload
+
+    def test_invalid_scheme_raises(self):
+        """
+        Should raise InvalidScheme when decoding a string that doesn't start with 'ur:'.
+        """
+        with pytest.raises(InvalidScheme):
+            URDecoder.decode("bitcoin:abc123")
+
+    def test_invalid_path_length_raises(self):
+        """
+        Should raise InvalidPathLength when the UR string is missing required components.
+        """
+        with pytest.raises(InvalidPathLength):
+            URDecoder.decode("ur:bytes")

--- a/tests/test_ur2.py
+++ b/tests/test_ur2.py
@@ -42,6 +42,19 @@ class TestCBORRoundTrip:
         val, _ = CBORDecoder(enc.get_bytes()).decodeText()
         assert bytes(val).decode('utf8') == "bitcoin"
 
+    def test_text_non_ascii_roundtrip(self):
+        """
+        Should correctly encode non-ASCII text using UTF-8 byte length
+        (not character count) in the CBOR header.
+        e.g. 'café' is 4 characters but 5 UTF-8 bytes.
+        """
+        enc = CBOREncoder()
+        enc.encodeText("café")
+        raw = enc.get_bytes()
+        assert raw[0] == (3 << 5) | 5
+        val, _ = CBORDecoder(raw).decodeText()
+        assert bytes(val).decode('utf8') == "café"
+
     def test_map_size_roundtrip(self):
         """
         Should successfully encode and decode map sizes.


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

While auditing the `ur2/` module (used for animated QR PSBT transmission), I discovered two runtime bugs in the vendored `cbor_lite.py` implementation (refer to issue #914).

### Solution

*   **Logic Fixes:** Corrected the validation constant in `decodeMapSize` and updated `encodeText` to use `.extend()` for bytes compatibility.
*   **Test Coverage:** Introduced `tests/test_ur2.py`, providing the first comprehensive test suite for this module. The tests cover CBOR primitives, Bytewords encoding, and full animated UR round-trips.


### Additional Information

The `ur2/` module is a core part of the animated QR communication stack. This PR increases the reliability of PSBT and xpub transmissions by ensuring the underlying encoding logic is verified and functionally correct.

### Screenshots

N/A, as this is a backend logic and testing improvement with no UI changes.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.

Resolves #914 
Part of Summer of Bitcoin