### PR TITLE
[Feature] allow message signing for Electrum Segwit paths (m/0h/change/index)

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -1349,6 +1349,10 @@ msgstr ""
 msgid "Signing messages for custom derivation paths not supported"
 msgstr ""
 
+#: src/seedsigner/views/seed_views.py
+msgid "Electrum derivation path requires an Electrum seed"
+msgstr ""
+
 #: src/seedsigner/views/settings_views.py
 msgid "Advanced"
 msgstr ""

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -153,7 +153,26 @@ def parse_derivation_path(derivation_path: str) -> dict:
         }
     }
 
+    # Electrum single-sig segwit: m/0h/change/index (no purpose or coin-type level)
+    is_electrum_path = (
+        len(sections) == 4
+        and sections[1] == "0h"
+        and sections[2] in ["0", "1"]
+        and sections[3].isdigit()
+    )
+
     details = dict()
+    if is_electrum_path:
+        details["script_type"] = SettingsConstants.NATIVE_SEGWIT
+        details["network"] = SettingsConstants.MAINNET
+        details["is_change"] = sections[2] == "1"
+        details["index"] = int(sections[3])
+        details["wallet_derivation_path"] = "m/0h"
+        details["is_electrum_path"] = True
+        details["clean_match"] = True
+        return details
+
+    details["is_electrum_path"] = False
     details["script_type"] = lookups["script_types"].get(sections[1])
     if not details["script_type"]:
         details["script_type"] = SettingsConstants.CUSTOM_DERIVATION

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2220,6 +2220,11 @@ class SeedSignMessageConfirmAddressView(View):
         if not addr_format["clean_match"] or addr_format["script_type"] == SettingsConstants.CUSTOM_DERIVATION:
             raise Exception(_("Signing messages for custom derivation paths not supported"))
 
+        if addr_format.get("is_electrum_path"):
+            from seedsigner.models.seed import ElectrumSeed
+            if not isinstance(seed, ElectrumSeed):
+                raise Exception(_("Electrum derivation path requires an Electrum seed"))
+
         if addr_format["network"] != SettingsConstants.MAINNET:
             # We're in either Testnet or Regtest or...?
             if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in [SettingsConstants.TESTNET, SettingsConstants.REGTEST]:

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -424,6 +424,11 @@ def test_parse_derivation_path():
         (SC.TESTNET, SC.CUSTOM_DERIVATION, True): "m/45'/1'/0'/1/5",
         (SC.REGTEST, SC.CUSTOM_DERIVATION, True): "m/45'/1'/0'/1/5",
 
+        # Electrum single-sig segwit: m/0h/change/index
+        (SC.MAINNET, SC.NATIVE_SEGWIT, False, 2): "m/0'/0/2",
+        (SC.MAINNET, SC.NATIVE_SEGWIT, True, 0): "m/0'/1/0",
+        (SC.MAINNET, SC.NATIVE_SEGWIT, False, 0): "m/0h/0/0",
+
         # CRAZY custom derivation paths
         (None, SC.CUSTOM_DERIVATION, False, 5): "m/123'/9083270/9083270/9083270/9083270/0/5",
 


### PR DESCRIPTION
Fixes #921

## Summary

- `parse_derivation_path` only recognised BIP-44/49/84/86 six-level paths; Electrum single-sig segwit uses a shorter four-level path (`m/0h/change/index`) with no purpose or coin-type level, which fell back to `CUSTOM_DERIVATION` / null network → `clean_match = False` → immediate rejection with *"Signing messages for custom derivation paths not supported"*.
- Detect the four-section Electrum pattern and return `clean_match = True` with `NATIVE_SEGWIT` / `MAINNET` and a new `is_electrum_path` flag.
- Guard `SeedSignMessageConfirmAddressView` so that when `is_electrum_path` is `True` the loaded seed must be an `ElectrumSeed` — prevents a BIP-39 seed from silently signing at the wrong key.
- Add three test vectors for Electrum receive/change paths (`m/0'/0/2`, `m/0'/1/0`, `m/0h/0/0`).

## Test plan

- [x] Load an Electrum Segwit seed, export xpub to Sparrow (Native Segwit), confirm an address, right-click → Sign/Verify Message → sign — SeedSigner should accept and display a signed-message QR.
- [ ] Same flow with a BIP-39 seed at an Electrum-style path: should show "Electrum derivation path requires an Electrum seed".
- [ ] Existing message-signing flows (BIP-84/44/49/86) are unaffected.
- [ ] `tests/test_embit_utils.py::test_parse_derivation_path` passes.
