### PR TITLE
[Feature] allow message signing for any derivation path

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1666,9 +1666,10 @@ class SeedSignMessageConfirmAddressScreen(ButtonListScreen):
         )
         self.components.append(derivation_path_display)
 
-        address_display = FormattedAddress(
-            address=self.address,
-            max_lines=3,
-            screen_y=derivation_path_display.screen_y + derivation_path_display.height + 2*GUIConstants.COMPONENT_PADDING,
-        )
-        self.components.append(address_display)
+        if self.address is not None:
+            address_display = FormattedAddress(
+                address=self.address,
+                max_lines=3,
+                screen_y=derivation_path_display.screen_y + derivation_path_display.height + 2*GUIConstants.COMPONENT_PADDING,
+            )
+            self.components.append(address_display)

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -153,7 +153,26 @@ def parse_derivation_path(derivation_path: str) -> dict:
         }
     }
 
+    # Electrum single-sig segwit: m/0h/change/index (no purpose or coin-type level)
+    is_electrum_path = (
+        len(sections) == 4
+        and sections[1] == "0h"
+        and sections[2] in ["0", "1"]
+        and sections[3].isdigit()
+    )
+
     details = dict()
+    if is_electrum_path:
+        details["script_type"] = SettingsConstants.NATIVE_SEGWIT
+        details["network"] = SettingsConstants.MAINNET
+        details["is_change"] = sections[2] == "1"
+        details["index"] = int(sections[3])
+        details["wallet_derivation_path"] = "m/0h"
+        details["is_electrum_path"] = True
+        details["clean_match"] = True
+        return details
+
+    details["is_electrum_path"] = False
     details["script_type"] = lookups["script_types"].get(sections[1])
     if not details["script_type"]:
         details["script_type"] = SettingsConstants.CUSTOM_DERIVATION

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2133,22 +2133,20 @@ class SeedSignMessageStartView(View):
             self.set_redirect(Destination(OptionDisabledView, view_args=dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)))
             return
 
-        # calculate the actual receive address
         addr_format = embit_utils.parse_derivation_path(derivation_path)
-        if not addr_format["clean_match"]:
-            self.set_redirect(Destination(NotYetImplementedView, view_args=dict(text=f"Signing messages for custom derivation paths not supported")))
-            self.controller.resume_main_flow = None
-            return
 
-        # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
-        if self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:
-            from seedsigner.views.view import NetworkMismatchErrorView
-            self.set_redirect(Destination(NetworkMismatchErrorView, view_args=dict(derivation_path=self.derivation_path)))
+        # Note: addr_format["network"] can be MAINNET, [TESTNET, REGTEST], or None
+        # for custom derivation paths where the network can't be determined.
+        # Only enforce a network check when the path encodes a network.
+        if addr_format["network"] is not None:
+            if self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:
+                from seedsigner.views.view import NetworkMismatchErrorView
+                self.set_redirect(Destination(NetworkMismatchErrorView, view_args=dict(derivation_path=self.derivation_path)))
 
-            # cleanup. Note: We could leave this in place so the user can resume the
-            # flow, but for now we avoid complications and keep things simple.
-            self.controller.resume_main_flow = None
-            return
+                # cleanup. Note: We could leave this in place so the user can resume the
+                # flow, but for now we avoid complications and keep things simple.
+                self.controller.resume_main_flow = None
+                return
 
         data = self.controller.sign_message_data
         if not data:
@@ -2212,15 +2210,10 @@ class SeedSignMessageConfirmAddressView(View):
             raise Exception("Routing error: sign_message_data hasn't been set")
 
         seed = self.controller.storage.seeds[seed_num]
-        addr_format = data.get("addr_format")
-
-        # calculate the actual receive address
-        seed = self.controller.storage.seeds[seed_num]
         addr_format = embit_utils.parse_derivation_path(self.derivation_path)
-        if not addr_format["clean_match"] or addr_format["script_type"] == SettingsConstants.CUSTOM_DERIVATION:
-            raise Exception(_("Signing messages for custom derivation paths not supported"))
 
-        if addr_format["network"] != SettingsConstants.MAINNET:
+        # Resolve the network when the path encodes one.
+        if addr_format["network"] is not None and addr_format["network"] != SettingsConstants.MAINNET:
             # We're in either Testnet or Regtest or...?
             if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in [SettingsConstants.TESTNET, SettingsConstants.REGTEST]:
                 addr_format["network"] = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
@@ -2234,9 +2227,19 @@ class SeedSignMessageConfirmAddressView(View):
                 self.controller.sign_message_data = None
                 return
 
-        xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=addr_format["network"])
-        embit_network = embit_utils.get_embit_network_name(addr_format["network"])
-        self.address = embit_utils.get_single_sig_address(xpub=xpub, script_type=addr_format["script_type"], index=addr_format["index"], is_change=addr_format["is_change"], embit_network=embit_network)
+        # Derive and display the address when we know the script type.
+        # Custom derivation paths don't encode a script type, so we skip it.
+        can_show_address = (
+            addr_format["clean_match"]
+            and addr_format["script_type"] != SettingsConstants.CUSTOM_DERIVATION
+        )
+        if can_show_address:
+            network = addr_format["network"] or self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=network)
+            embit_network = embit_utils.get_embit_network_name(network)
+            self.address = embit_utils.get_single_sig_address(xpub=xpub, script_type=addr_format["script_type"], index=addr_format["index"], is_change=addr_format["is_change"], embit_network=embit_network)
+        else:
+            self.address = None
 
 
     def run(self):

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -424,6 +424,11 @@ def test_parse_derivation_path():
         (SC.TESTNET, SC.CUSTOM_DERIVATION, True): "m/45'/1'/0'/1/5",
         (SC.REGTEST, SC.CUSTOM_DERIVATION, True): "m/45'/1'/0'/1/5",
 
+        # Electrum single-sig segwit: m/0h/change/index (no purpose or coin-type level)
+        (SC.MAINNET, SC.NATIVE_SEGWIT, False, 2): "m/0'/0/2",
+        (SC.MAINNET, SC.NATIVE_SEGWIT, True, 0): "m/0'/1/0",
+        (SC.MAINNET, SC.NATIVE_SEGWIT, False, 0): "m/0h/0/0",
+
         # CRAZY custom derivation paths
         (None, SC.CUSTOM_DERIVATION, False, 5): "m/123'/9083270/9083270/9083270/9083270/0/5",
 


### PR DESCRIPTION
Closes #519. Supersedes #923.

Raised by @kdmukai in https://github.com/SeedSigner/seedsigner/issues/519#issuecomment-4281038800 — rather than bolt on support for individual paths one by one, just allow message signing for any derivation path.

## What changed

### `SeedSignMessageStartView`
- Removed the `clean_match` guard that rejected all non-BIP44/49/84/86 paths with *"Signing messages for custom derivation paths not supported"*.
- Network mismatch check is now skipped for paths that don't encode a network (custom/Electrum), since there is nothing to compare against.

### `SeedSignMessageConfirmAddressView`
- Removed the same blocking check.
- Address is computed and shown **only** when the script type can be determined (known BIP path or Electrum path). For truly custom paths, `address = None` and the screen shows only the derivation path.
- Network resolution is skipped when the path has no network component.

### `SeedSignMessageConfirmAddressScreen`
- `FormattedAddress` component is added only when an address is available.

### `parse_derivation_path` (embit_utils)
- Added recognition of Electrum single-sig segwit paths (`m/0h/change/index` — 4 sections, no BIP purpose or coin-type level). These resolve to `NATIVE_SEGWIT / MAINNET` so the address can still be shown on the confirm screen.

## Test plan

- [ ] BIP-84 wallet → Sign message → address shown, signing works.
- [ ] Electrum Segwit seed → Sign message for `m/0h/0/2` → address shown, signing works (resolves #921 / #923).
- [ ] Unchained-style path `m/45'/0'/0'/0/5` → Sign message → only derivation path shown (no address), signing proceeds.
- [ ] Completely custom path → only derivation path shown, signing proceeds.
- [ ] Network mismatch on a known path still triggers `NetworkMismatchErrorView`.
- [ ] `tests/test_embit_utils.py::test_parse_derivation_path` passes.
