### PR TITLE
Add taproot multisig address verification support

### DIFF
--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -50,7 +50,7 @@ def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, walle
         elif script_type == SettingsConstants.NATIVE_SEGWIT:
             return f"m/48'/{network_path}/0'/2'"
         elif script_type == SettingsConstants.TAPROOT:
-            raise Exception("Taproot multisig not yet supported")
+            return f"m/48'/{network_path}/0'/3'"
         else:
             raise Exception("Unexpected script type")
     else:
@@ -92,23 +92,33 @@ def get_multisig_address(descriptor: Descriptor, index: int = 0, is_change: bool
     else:
         branch_index = 0
 
-    # Can derive p2wsh, p2sh-p2wsh, and legacy (non-segwit) p2sh
-    if descriptor.is_segwit or (descriptor.is_legacy and descriptor.is_basic_multisig):
+    # Can derive p2wsh, p2sh-p2wsh, legacy p2sh, and taproot descriptors.
+    if descriptor.is_taproot or descriptor.is_segwit or (descriptor.is_legacy and descriptor.is_basic_multisig):
         return descriptor.derive(index, branch_index=branch_index).script_pubkey().address(network=NETWORKS[embit_network])
-
-    elif descriptor.is_taproot:
-        # TODO: Not yet implemented!
-        raise Exception("Taproot verification not yet implemented!")
 
     raise Exception(f"{descriptor.script_pubkey().script_type()} address verification not yet implemented!")
 
 
 
 def get_multisig_policy(descriptor: Descriptor) -> tuple:
-    """Extract (threshold, n) from a basic multisig descriptor."""
-    if not descriptor.is_basic_multisig:
-        raise ValueError(f"Expected a basic multisig descriptor, got: {descriptor.brief_policy}")
-    return (str(descriptor.miniscript.args[0]), str(len(descriptor.keys)))
+    """Extract (threshold, n) from multisig descriptors supported by SeedSigner."""
+    if descriptor.is_basic_multisig:
+        return (str(descriptor.miniscript.args[0]), str(len(descriptor.keys)))
+
+    if descriptor.is_taproot and descriptor.taptree:
+        tap_tree = getattr(descriptor.taptree, "tree", descriptor.taptree)
+        miniscript = getattr(tap_tree, "miniscript", None)
+        miniscript_name = miniscript.__class__.__name__.lower() if miniscript else ""
+
+        # Taproot multisig script-path policies are represented as *_a miniscript nodes.
+        if miniscript_name in ["multia", "sortedmultia"]:
+            threshold = getattr(miniscript, "k", None)
+            if threshold is None and miniscript.args:
+                threshold = int(str(miniscript.args[0]))
+            n = len(miniscript.args) - 1
+            return (str(threshold), str(n))
+
+    raise ValueError(f"Expected a supported multisig descriptor, got: {descriptor.brief_policy}")
 
 
 

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -122,9 +122,18 @@ class ScanView(View):
 
                 descriptor = Descriptor.from_string(descriptor_str)
 
-                if not descriptor.is_basic_multisig:
-                    # TODO: Handle single-sig descriptors?
-                    logger.info(f"Received single sig descriptor: {descriptor}")
+                is_supported_multisig_descriptor = descriptor.is_basic_multisig
+                if descriptor.is_taproot:
+                    # Taproot multisig support requires a miniscript policy we can parse.
+                    from seedsigner.helpers.embit_utils import get_multisig_policy
+                    try:
+                        get_multisig_policy(descriptor)
+                        is_supported_multisig_descriptor = True
+                    except ValueError:
+                        pass
+
+                if not is_supported_multisig_descriptor:
+                    logger.info(f"Received unsupported descriptor: {descriptor}")
                     return Destination(NotYetImplementedView)
 
                 self.controller.multisig_wallet_descriptor = descriptor

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1763,8 +1763,8 @@ class AddressVerificationStartView(View):
                 destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
 
         elif self.controller.unverified_address["script_type"] == SettingsConstants.TAPROOT:
-            sig_type = SettingsConstants.SINGLE_SIG
-            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
+            # No way to differentiate single sig from multisig at scan time.
+            return Destination(AddressVerificationSigTypeView, skip_current_view=True)
 
         derivation_path = embit_utils.get_standard_derivation_path(
             network=self.controller.unverified_address["network"],

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -41,9 +41,9 @@ def test_get_standard_derivation_path():
         (SC.TESTNET, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
         (SC.REGTEST, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
 
-        (SC.MAINNET, SC.MULTISIG, SC.TAPROOT): Exception,
-        (SC.TESTNET, SC.MULTISIG, SC.TAPROOT): Exception,
-        (SC.REGTEST, SC.MULTISIG, SC.TAPROOT): Exception,
+        (SC.MAINNET, SC.MULTISIG, SC.TAPROOT): "m/48'/0'/0'/3'",
+        (SC.TESTNET, SC.MULTISIG, SC.TAPROOT): "m/48'/1'/0'/3'",
+        (SC.REGTEST, SC.MULTISIG, SC.TAPROOT): "m/48'/1'/0'/3'",
 
         (SC.MAINNET, SC.MULTISIG, SC.LEGACY_P2PKH): "m/45'",
 
@@ -288,7 +288,9 @@ def test_get_multisig_address():
     #    keystore2 = 0x11*16 = 0be174ee = 'baby mass dust captain baby mass dust captain baby mass dust casino'
     #    keystore3 = 0x22*16 = 8d55ff0d = 'captain baby mass dust captain baby mass dust captain baby mass dutch'
 
-    vector_args_expected = { 
+    taproot_multisig_descriptor = "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,sortedmulti_a(2,[0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*,[8d55ff0d/86h/1h/0h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*))"
+
+    vector_args_expected = {
         # multisig native segwit on testnet, first payment and change addresses
         ("wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#zw6cnrlk" , 0, False, "test"): "tb1q7tpecll8jhp77yqdeyt2t8q5swxmmqeh2v22cqpms5dxlp6p27dqlftet8",
         ("wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#zw6cnrlk" , 0, True, "test"): "tb1q7h94ywhfjrpxdfzwl4dcawrg80r4rywswjrh447x4n3e5t3m0jms9jh7pm",
@@ -301,8 +303,9 @@ def test_get_multisig_address():
         ("sh(sortedmulti(2,[8d55ff0d/45h]tpubDANogJ2yfnizHwX7fSi5kUVzybyuPXDhgHB2TR9TUvkSLZFW73cRq4STKFDpx7qjJJiisyq82tbu4CeiYtmKEmT1xoCq9P8BPvXV31HUh6d/{0,1}/*,[0be174ee/45h]tpubDBkeVF2tDNT1Pz7L47iJeBB6RokU12LX6x4E6Ph8T89hmjQfB77q1AMyGwL8qpREVGq9sCJEbWwmnemwNTxnpxGn1di7BGy8jx9wEi5Vahu/{0,1}/*,[73c5da0a/45h]tpubDBKsGC1UqBDNvx9aivFmxZNgeZTUnmsCFGhWrqkLzucUCDePvbWWm3n8tAaAwMmxBG2ihdKCG9fzBdUnMxKx5PrkiqSZFi6Vkv6msUs9ddN/{0,1}/*))#p5t8sa8c", 0, False, "test"): "2NBXci43Y2fagvrFYTg3QmXj2LCPU2oaRFH",
         ("sh(sortedmulti(2,[8d55ff0d/45h]tpubDANogJ2yfnizHwX7fSi5kUVzybyuPXDhgHB2TR9TUvkSLZFW73cRq4STKFDpx7qjJJiisyq82tbu4CeiYtmKEmT1xoCq9P8BPvXV31HUh6d/{0,1}/*,[0be174ee/45h]tpubDBkeVF2tDNT1Pz7L47iJeBB6RokU12LX6x4E6Ph8T89hmjQfB77q1AMyGwL8qpREVGq9sCJEbWwmnemwNTxnpxGn1di7BGy8jx9wEi5Vahu/{0,1}/*,[73c5da0a/45h]tpubDBKsGC1UqBDNvx9aivFmxZNgeZTUnmsCFGhWrqkLzucUCDePvbWWm3n8tAaAwMmxBG2ihdKCG9fzBdUnMxKx5PrkiqSZFi6Vkv6msUs9ddN/{0,1}/*))#p5t8sa8c", 0, True, "test"): "2MuWQTq7hUGiX1HpXuPRnf7YTM42H5zoEwj",
 
-        # multisig taproot on testnet, not supported
-        # TODO: find what a multisig-taproot descriptor would look like and add a test so we can fall into the last condition exception.
+        # multisig taproot on regtest, receive and change addresses @ index 5
+        (taproot_multisig_descriptor, 5, False, "regtest"): "bcrt1pfsufc0ppyw2l4635zeqqzhrtvr59d0pgxxlh30fpqhu2vwlztjaqllqh9s",
+        (taproot_multisig_descriptor, 5, True, "regtest"): "bcrt1pm57mks7grthqxqevqrul90pdsh3v076hhrjhdujpc8949zp68xhsyskuz3",
 
         # some policy that is not supported:
         # TODO: find anything non supported so we can drop off the function: Would it be preferred to "else: raise ValueError()"?
@@ -359,6 +362,8 @@ def test_get_multisig_policy():
         "sh(wsh(sortedmulti(2,[73c5da0a/48h/1h/1h/0h/1h]tpubDFH9dgzveyD8yHQb8VrpG8FYAuwcLMHMje2CCcbBo1FpaGzYVtJeYYxcYgRqSTta5utUFts8nPPHs9C2bqoxrey5jia6Dwf9mpwrPq7YvcJ/{0,1}/*,[0be174ee/48h/1h/0h/1h]tpubDEsePyLPkbxbnj6XuKvWwdERHaKkikZxaGJ9sJqmM7okbZXgkNSFiGU6GX6qEes6kD8f9Z9FosYB9UEnBSgBEyEwwJhj4uUcFE1WE8VtKoh/{0,1}/*,[8d55ff0d/48h/1h/0h/1h]tpubDDxNVWk924RTT3vyGLHdSDoZ2JUVX7jUsPcwCQ9MrKHAtJrW5zECTF9rFHCvqu526E4PjHp61hBknts2c5aGexvX7hvCZ8TGPvQFdzxxy59/{0,1}/*)))#2ujlfp73": ("2", "3"),
         # legacy p2sh 2-of-3
         "sh(sortedmulti(2,[8d55ff0d/45h]tpubDANogJ2yfnizHwX7fSi5kUVzybyuPXDhgHB2TR9TUvkSLZFW73cRq4STKFDpx7qjJJiisyq82tbu4CeiYtmKEmT1xoCq9P8BPvXV31HUh6d/{0,1}/*,[0be174ee/45h]tpubDBkeVF2tDNT1Pz7L47iJeBB6RokU12LX6x4E6Ph8T89hmjQfB77q1AMyGwL8qpREVGq9sCJEbWwmnemwNTxnpxGn1di7BGy8jx9wEi5Vahu/{0,1}/*,[73c5da0a/45h]tpubDBKsGC1UqBDNvx9aivFmxZNgeZTUnmsCFGhWrqkLzucUCDePvbWWm3n8tAaAwMmxBG2ihdKCG9fzBdUnMxKx5PrkiqSZFi6Vkv6msUs9ddN/{0,1}/*))#p5t8sa8c": ("2", "3"),
+        # taproot 2-of-2 script-path multisig (plus internal key)
+        "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,sortedmulti_a(2,[0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*,[8d55ff0d/86h/1h/0h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*))": ("2", "2"),
     }
 
     for desc_str, (expected_threshold, expected_n) in vectors_descriptor_expected.items():

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -246,6 +246,36 @@ class TestToolsFlows(FlowTest):
         ])
 
 
+    def test__verify_address__taproot_multisig__flow(self):
+        """
+            Address Explorer should be able to scan a taproot multisig address and
+            verify it against its descriptor.
+        """
+        def load_address_into_decoder(view: scan_views.ScanView):
+            # Receive addr @ index 5 from descriptor below
+            view.decoder.add_data("bcrt1pfsufc0ppyw2l4635zeqqzhrtvr59d0pgxxlh30fpqhu2vwlztjaqllqh9s")
+
+        def load_descriptor_into_decoder(view: scan_views.ScanView):
+            taproot_descriptor = "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,sortedmulti_a(2,[0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*,[8d55ff0d/86h/1h/0h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*))"
+            view.decoder.add_data(taproot_descriptor)
+
+        settings = Controller.get_instance().settings
+        settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate read address QR
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.AddressVerificationSigTypeView, button_data_selection=seed_views.AddressVerificationSigTypeView.MULTISIG),
+            FlowStep(seed_views.LoadMultisigWalletDescriptorView, button_data_selection=seed_views.LoadMultisigWalletDescriptorView.SCAN),
+            FlowStep(scan_views.ScanWalletDescriptorView, before_run=load_descriptor_into_decoder),  # simulate read descriptor QR
+            FlowStep(seed_views.MultisigWalletDescriptorView, screen_return_value=0),
+            FlowStep(seed_views.SeedAddressVerificationView),
+            FlowStep(seed_views.SeedAddressVerificationSuccessView),
+        ])
+
+
     def test__verify_address__singlesig__flow(self):
         """
             Address Explorer should be able to scan a singlesig address and
@@ -270,12 +300,20 @@ class TestToolsFlows(FlowTest):
                 # Native segwit regtest receive addr @ index 6
                 view.decoder.add_data(test_addr)
 
-            self.run_sequence([
+            flow_steps = [
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
                 FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
                 FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate read address QR
                 FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            ]
+
+            if test_addr.startswith("bcrt1p"):
+                flow_steps.append(FlowStep(seed_views.AddressVerificationSigTypeView, button_data_selection=seed_views.AddressVerificationSigTypeView.SINGLE_SIG))
+
+            flow_steps.extend([
                 FlowStep(seed_views.SeedSelectSeedView, screen_return_value=0),
                 FlowStep(seed_views.SeedAddressVerificationView),
                 FlowStep(seed_views.SeedAddressVerificationSuccessView),
             ])
+
+            self.run_sequence(flow_steps)


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

SeedSigner can verify single-sig Taproot addresses, but Taproot multisig address verification is still missing in the Verify Address workflow. This blocks air-gapped verification for multisig wallets that use Taproot descriptors.
fixes #924 
### Solution

Added taproot multisig address verification support

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.