### PR TITLE
[l10n/automation] Manifest contract and catalog diff engine

### DIFF
--- a/l10n/automation/pot_diff.py
+++ b/l10n/automation/pot_diff.py
@@ -1,0 +1,226 @@
+"""Structured diff between gettext catalogs (.pot/.po) for the l10n automation.
+
+Produces the review manifest consumed by the trusted follow-up comment job.
+Entries are keyed on (msgctxt, msgid); a change to a string's plural form is
+reported as a change to that entry. Source-location churn and header metadata
+are ignored, so they never show up as noise.
+
+The manifest reports the source strings a PR changes: the catalog is extracted
+from the base branch source and from the PR head source, and the two are
+diffed. The committed messages.pot is never consulted, so the result is correct
+regardless of whether it is up to date (it is maintained automatically by the
+post-merge sync, not by hand).
+
+Run as a script to emit a manifest JSON validated by
+``l10n/automation/schema/review-manifest.schema.json``::
+
+    python l10n/automation/pot_diff.py \
+        --base base.pot --head head.pot \
+        --repository owner/name --pr-number 123 \
+        --head-sha <sha> --base-ref dev --out manifest.json
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+SCHEMA_VERSION = "1.0"
+STREAM = "messages-pot"
+
+# Cap how many individual entries we serialize per bucket. Counts stay exact;
+# only the listed examples are capped (manifest.*.truncated flags this).
+MAX_ENTRIES = 50
+
+# Catalog key: (context, singular msgid). The context disambiguates identical
+# source strings, exactly as gettext does.
+Key = Tuple[Optional[str], str]
+
+
+def write_text(text: str, out: str) -> None:
+    """Write UTF-8 text to ``out``, or to stdout when ``out`` is ``-``.
+
+    Source strings are emitted verbatim (``ensure_ascii=False``), so writing to
+    stdout goes through its binary buffer: a runner whose stdout encoding is
+    ASCII would otherwise raise UnicodeEncodeError on the first non-ASCII
+    string. The buffer is absent when stdout is substituted (captured in
+    tests), in which case the text layer already handles the encoding.
+    """
+    if out != "-":
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return
+
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        sys.stdout.write(text)
+    else:
+        buffer.write(text.encode("utf-8"))
+        buffer.flush()
+
+
+def load_catalog(path: Optional[str]) -> Dict[Key, dict]:
+    """Load a .pot/.po into a dict keyed by (msgctxt, msgid).
+
+    A missing or empty path yields an empty catalog so the very first run (no
+    prior .pot) and deleted files degrade gracefully rather than crashing.
+    """
+    if not path or not os.path.exists(path) or os.path.getsize(path) == 0:
+        return {}
+
+    # Imported lazily so importing this module (e.g. for tests on hosts without
+    # Babel) does not hard-fail; callers that actually parse need Babel present.
+    from babel.messages.pofile import read_po
+
+    with open(path, "rb") as fh:
+        catalog = read_po(fh)
+
+    out: Dict[Key, dict] = {}
+    for message in catalog:
+        # The header message has an empty id; skip it.
+        if not message.id:
+            continue
+        if isinstance(message.id, (list, tuple)):
+            singular = message.id[0]
+            plural_text: Optional[str] = message.id[1] if len(message.id) > 1 else None
+            is_plural = len(message.id) > 1
+        else:
+            singular = message.id
+            plural_text = None
+            is_plural = False
+        key: Key = (message.context, singular)
+        out[key] = {
+            "msgid": singular,
+            "msgctxt": message.context,
+            "plural": is_plural,
+            "_plural_text": plural_text,
+        }
+    return out
+
+
+def _entry(record: dict) -> dict:
+    # The manifest entry shape, kept to just the translator-facing fields.
+    return {"msgid": record["msgid"], "msgctxt": record["msgctxt"], "plural": record["plural"]}
+
+
+def _sorted_keys(keys) -> List[Key]:
+    # Deterministic ordering: by context (None first), then msgid.
+    return sorted(keys, key=lambda k: (k[0] is not None, k[0] or "", k[1]))
+
+
+def diff_catalogs(base: Dict[Key, dict], head: Dict[Key, dict]) -> dict:
+    """Compute added/removed/changed between two catalogs.
+
+    * added   -- keys present in ``head`` but not ``base``
+    * removed -- keys present in ``base`` but not ``head``
+    * changed -- keys in both whose plural form (presence or text) differs,
+                 i.e. what translators must now provide changed
+    """
+    base_keys = set(base)
+    head_keys = set(head)
+
+    added = [_entry(head[k]) for k in _sorted_keys(head_keys - base_keys)]
+    removed = [_entry(base[k]) for k in _sorted_keys(base_keys - head_keys)]
+
+    changed: List[dict] = []
+    for k in _sorted_keys(base_keys & head_keys):
+        b, h = base[k], head[k]
+        if b["plural"] != h["plural"] or b.get("_plural_text") != h.get("_plural_text"):
+            changed.append(_entry(h))
+
+    counts = {
+        "added": len(added),
+        "removed": len(removed),
+        "changed": len(changed),
+        "total_base": len(base),
+        "total_head": len(head),
+    }
+    truncated = any(len(b) > MAX_ENTRIES for b in (added, removed, changed))
+    return {
+        "added": added[:MAX_ENTRIES],
+        "removed": removed[:MAX_ENTRIES],
+        "changed": changed[:MAX_ENTRIES],
+        "counts": counts,
+        "truncated": truncated,
+    }
+
+
+def build_manifest(
+    *,
+    base: Optional[str],
+    head: Optional[str],
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    base_ref: str,
+    base_sha: Optional[str] = None,
+    regen_ok: bool = True,
+    generated_at: Optional[str] = None,
+) -> dict:
+    """Assemble the review manifest from the base and head catalogs.
+
+    ``base`` and ``head`` are catalogs freshly extracted from the base branch
+    source and the PR head source respectively, so ``source_strings`` reflects
+    exactly the source strings this PR changes.
+    """
+    source_strings = diff_catalogs(load_catalog(base), load_catalog(head))
+
+    notes: List[str] = []
+    if not regen_ok:
+        notes.append("messages.pot could not be fully regenerated from source; "
+                     "the impact below may be incomplete.")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "stream": STREAM,
+        "generated_at": generated_at or datetime.now(timezone.utc)
+        .replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "repository": repository,
+        "pr": {
+            "number": int(pr_number),
+            "head_sha": head_sha,
+            "base_sha": base_sha,
+            "base_ref": base_ref,
+        },
+        "regen_ok": bool(regen_ok),
+        "source_strings": source_strings,
+        "notes": notes,
+    }
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build the l10n review manifest.")
+    p.add_argument("--base", help="messages.pot extracted from the base branch source")
+    p.add_argument("--head", help="messages.pot extracted from the PR head source")
+    p.add_argument("--repository", required=True)
+    p.add_argument("--pr-number", type=int, required=True)
+    p.add_argument("--head-sha", required=True)
+    p.add_argument("--base-ref", required=True)
+    p.add_argument("--base-sha", default=None)
+    p.add_argument("--regen-ok", choices=["true", "false"], default="true",
+                   help="whether extraction succeeded for both base and head")
+    p.add_argument("--out", default="-", help="output path, or - for stdout")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    manifest = build_manifest(
+        base=args.base,
+        head=args.head,
+        repository=args.repository,
+        pr_number=args.pr_number,
+        head_sha=args.head_sha,
+        base_ref=args.base_ref,
+        base_sha=args.base_sha,
+        regen_ok=(args.regen_ok == "true"),
+    )
+    payload = json.dumps(manifest, indent=2, ensure_ascii=False)
+    write_text(payload + "\n", args.out)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/schema/review-manifest.schema.json
+++ b/l10n/automation/schema/review-manifest.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/SeedSigner/seedsigner/dev/l10n/automation/schema/review-manifest.schema.json",
+  "title": "SeedSigner l10n review manifest",
+  "description": "Structured, machine-validated summary produced by the read-only PR diff job and consumed by the trusted follow-up comment job. The producing job runs untrusted PR code, so this manifest is treated as untrusted data: the consumer validates it against this schema and re-derives the rendered comment from these fields rather than trusting any pre-rendered text.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "stream",
+    "generated_at",
+    "repository",
+    "pr",
+    "regen_ok",
+    "source_strings"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Manifest format version. Consumers must reject versions they do not understand.",
+      "const": "1.0"
+    },
+    "stream": {
+      "description": "Rolling-stream identifier this manifest belongs to.",
+      "type": "string",
+      "enum": ["messages-pot"]
+    },
+    "generated_at": {
+      "description": "UTC timestamp when the manifest was produced.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "description": "owner/name of the repository the PR targets.",
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "pr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "head_sha", "base_ref"],
+      "properties": {
+        "number": {
+          "description": "Pull request number. The consumer MUST cross-check that this PR's authoritative head SHA equals the triggering workflow_run head SHA before acting on it.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "head_sha": {
+          "description": "Head commit SHA the diff was computed against.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$"
+        },
+        "base_sha": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{7,40}$"
+        },
+        "base_ref": {
+          "description": "Base branch name (e.g. dev).",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "regen_ok": {
+      "description": "True when messages.pot was successfully regenerated from both the base and head source. False means the diff below may be incomplete.",
+      "type": "boolean"
+    },
+    "source_strings": {
+      "description": "Translation impact of this PR: source strings added/removed/changed, computed by extracting the catalog from the base branch source and from the PR head source and diffing the two.",
+      "$ref": "#/$defs/diff"
+    },
+    "notes": {
+      "type": "array",
+      "maxItems": 20,
+      "items": { "type": "string", "maxLength": 2000 }
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["msgid", "msgctxt", "plural"],
+      "properties": {
+        "msgid": { "type": "string", "maxLength": 10000 },
+        "msgctxt": { "type": ["string", "null"], "maxLength": 10000 },
+        "plural": {
+          "description": "True when the message defines a plural form.",
+          "type": "boolean"
+        }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["added", "removed", "changed", "total_base", "total_head"],
+      "properties": {
+        "added": { "type": "integer", "minimum": 0 },
+        "removed": { "type": "integer", "minimum": 0 },
+        "changed": { "type": "integer", "minimum": 0 },
+        "total_base": { "type": "integer", "minimum": 0 },
+        "total_head": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["added", "removed", "changed", "counts", "truncated"],
+      "properties": {
+        "added": { "type": "array", "maxItems": 50, "items": { "$ref": "#/$defs/entry" } },
+        "removed": { "type": "array", "maxItems": 50, "items": { "$ref": "#/$defs/entry" } },
+        "changed": { "type": "array", "maxItems": 50, "items": { "$ref": "#/$defs/entry" } },
+        "counts": { "$ref": "#/$defs/counts" },
+        "truncated": {
+          "description": "True when the added/removed/changed arrays were capped and do not list every entry (counts remain exact).",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/l10n/automation/tests/conftest.py
+++ b/l10n/automation/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Make the l10n automation modules importable when these tests run.
+
+These tests are intentionally outside the project's configured `testpaths`
+(["tests"]), so they are not collected by the main pytest run. Run them with:
+
+    python -m pytest l10n/automation/tests
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_HEADER = 'msgid ""\nmsgstr ""\n"Content-Type: text/plain; charset=UTF-8\\n"\n\n'
+
+
+def write_pot(path, entries):
+    """Write a minimal .pot file to path. entries: list of {id, plural?, ctx?}."""
+    chunks = [_HEADER]
+    for e in entries:
+        block = ""
+        if e.get("ctx"):
+            block += f'msgctxt "{e["ctx"]}"\n'
+        block += f'msgid "{e["id"]}"\n'
+        if e.get("plural"):
+            block += f'msgid_plural "{e["plural"]}"\n'
+            block += 'msgstr[0] ""\nmsgstr[1] ""\n'
+        else:
+            block += 'msgstr ""\n'
+        chunks.append(block + "\n")
+    path.write_text("".join(chunks), encoding="utf-8")
+    return str(path)

--- a/l10n/automation/tests/test_pot_diff.py
+++ b/l10n/automation/tests/test_pot_diff.py
@@ -1,0 +1,136 @@
+"""Tests for the catalog diff and review-manifest builder.
+
+Run standalone (not part of the main suite):
+
+    python -m pytest l10n/automation/tests -q
+"""
+
+import json
+
+import pytest
+
+# Parsing real .pot files needs Babel; skip cleanly where it is absent rather
+# than erroring during collection.
+pytest.importorskip("babel")
+
+import pot_diff  # noqa: E402
+from conftest import write_pot  # noqa: E402
+
+
+def keys_of(entries):
+    return {(e.get("msgctxt"), e["msgid"]) for e in entries}
+
+
+def test_added_and_removed(tmp_path):
+    base = write_pot(tmp_path / "base.pot", [{"id": "Hello"}, {"id": "Bye"}])
+    head = write_pot(tmp_path / "head.pot", [{"id": "Hello"}, {"id": "New"}])
+
+    d = pot_diff.diff_catalogs(pot_diff.load_catalog(base), pot_diff.load_catalog(head))
+
+    assert keys_of(d["added"]) == {(None, "New")}
+    assert keys_of(d["removed"]) == {(None, "Bye")}
+    assert d["counts"] == {"added": 1, "removed": 1, "changed": 0,
+                           "total_base": 2, "total_head": 2}
+    assert d["truncated"] is False
+
+
+def test_context_disambiguates(tmp_path):
+    base = write_pot(tmp_path / "base.pot", [{"id": "File"}])
+    head = write_pot(tmp_path / "head.pot", [{"id": "File"}, {"id": "File", "ctx": "menu"}])
+
+    d = pot_diff.diff_catalogs(pot_diff.load_catalog(base), pot_diff.load_catalog(head))
+
+    assert keys_of(d["added"]) == {("menu", "File")}
+    assert d["counts"]["removed"] == 0
+
+
+def test_plural_toggle_is_a_change(tmp_path):
+    base = write_pot(tmp_path / "base.pot", [{"id": "apple"}])
+    head = write_pot(tmp_path / "head.pot", [{"id": "apple", "plural": "apples"}])
+
+    d = pot_diff.diff_catalogs(pot_diff.load_catalog(base), pot_diff.load_catalog(head))
+
+    assert d["counts"] == {"added": 0, "removed": 0, "changed": 1,
+                           "total_base": 1, "total_head": 1}
+    assert d["changed"][0]["plural"] is True
+
+
+def test_missing_files_are_empty(tmp_path):
+    assert pot_diff.load_catalog(None) == {}
+    assert pot_diff.load_catalog(str(tmp_path / "nope.pot")) == {}
+
+
+def test_truncation_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(pot_diff, "MAX_ENTRIES", 2)
+    base = write_pot(tmp_path / "base.pot", [])
+    head = write_pot(tmp_path / "head.pot", [{"id": f"s{i}"} for i in range(5)])
+
+    d = pot_diff.diff_catalogs(pot_diff.load_catalog(base), pot_diff.load_catalog(head))
+
+    assert d["counts"]["added"] == 5  # exact
+    assert len(d["added"]) == 2       # capped
+    assert d["truncated"] is True
+
+
+def test_manifest_reports_pr_impact(tmp_path):
+    base = write_pot(tmp_path / "base.pot", [{"id": "Hello"}])
+    head = write_pot(tmp_path / "head.pot", [{"id": "Hello"}, {"id": "New"}])
+
+    m = pot_diff.build_manifest(
+        base=base, head=head,
+        repository="owner/repo", pr_number=7, head_sha="abc1234", base_ref="dev",
+    )
+
+    assert m["schema_version"] == "1.0"
+    assert m["regen_ok"] is True
+    assert m["source_strings"]["counts"]["added"] == 1  # "New" vs base
+
+
+def test_manifest_regen_failure_is_noted(tmp_path):
+    base = write_pot(tmp_path / "base.pot", [{"id": "Hello"}])
+    head = write_pot(tmp_path / "head.pot", [{"id": "Hello"}, {"id": "New"}])
+
+    m = pot_diff.build_manifest(
+        base=base, head=head,
+        repository="owner/repo", pr_number=9, head_sha="aaa", base_ref="dev",
+        regen_ok=False,
+    )
+
+    assert m["regen_ok"] is False
+    assert any("could not be fully regenerated" in n for n in m["notes"])
+
+
+def test_cli_writes_manifest(tmp_path):
+    base = write_pot(tmp_path / "base.pot", [{"id": "Hello"}])
+    head = write_pot(tmp_path / "head.pot", [{"id": "Hello"}, {"id": "New"}])
+    out = tmp_path / "manifest.json"
+
+    rc = pot_diff.main([
+        "--base", base, "--head", head,
+        "--repository", "owner/repo", "--pr-number", "11",
+        "--head-sha", "cafe123", "--base-ref", "dev", "--out", str(out),
+    ])
+
+    assert rc == 0
+    manifest = json.loads(out.read_text())
+    assert manifest["pr"]["number"] == 11
+    assert manifest["repository"] == "owner/repo"
+    assert manifest["source_strings"]["counts"]["added"] == 1
+
+
+def test_non_ascii_survives_both_output_paths(tmp_path, capsysbinary):
+    # ensure_ascii=False means the payload carries raw non-ASCII, so neither
+    # output path may depend on the runner's stdout encoding being UTF-8.
+    # Escaped so this file itself stays ASCII.
+    accented = "Phrase de passe incorrecte : r\u00e9essayez"
+    base = write_pot(tmp_path / "base.pot", [])
+    head = write_pot(tmp_path / "head.pot", [{"id": accented}])
+    out = tmp_path / "manifest.json"
+    argv = ["--base", base, "--head", head, "--repository", "owner/repo",
+            "--pr-number", "3", "--head-sha", "abc", "--base-ref", "dev"]
+
+    assert pot_diff.main(argv + ["--out", str(out)]) == 0
+    assert accented in out.read_text(encoding="utf-8")
+
+    assert pot_diff.main(argv + ["--out", "-"]) == 0
+    assert accented in capsysbinary.readouterr().out.decode("utf-8")


### PR DESCRIPTION
> [!NOTE]
> One of the l10n source-string automation PRs (#940, #941, #942, #943, #944). This PR has no dependencies on the others.

## Description

### Problem or Issue being addressed

To tell reviewers and translators what a PR changes, we need
(a) a stable, machine-checkable contract for that data and
(b) a diff between two gettext catalogs that reports only translator-meaningful changes, ignoring source-location moves and header churn.

### Solution

Adds the foundation for the source-string automation:

- `schema/review-manifest.schema.json` -- the "review manifest" contract (JSON Schema draft 2020-12) for the data passed from the untrusted PR diff job to the trusted comment job. It is strict by design: `additionalProperties: false`, a `const` version, bounded array/string lengths, and SHA/`owner/name` patterns on the trust-anchor fields.
- `pot_diff.py` -- keys catalog entries on `(msgctxt, msgid)` and reports added/removed/changed strings, then assembles a manifest conforming to the schema. Counts are always exact; the per-bucket example lists are capped (and flagged `truncated`) so a huge diff cannot produce an unbounded manifest. The committed `messages.pot` is never read -- the catalog is extracted fresh from base and head source -- so the result is correct regardless of whether the committed catalog is current.

---

This pull request is categorized as a:
- [x] Other (l10n automation)

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

(`python -m pytest l10n/automation/tests` -- these tests live outside the project's default `testpaths` and are run explicitly.)

---

#### I included screenshots of any new or modified screens
- [x] N/A

---

#### I added or updated tests
- [x] Yes

---

#### I tested this PR hands-on on the following platform(s):
- [x] Github Actions

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

