### PR TITLE
[l10n/automation] Add comment renderer and manifest validator

### DIFF
--- a/l10n/automation/render_comment.py
+++ b/l10n/automation/render_comment.py
@@ -1,0 +1,153 @@
+"""Render the advisory PR comment markdown from a validated review manifest.
+
+This runs in the trusted follow-up job from default-branch code, but the
+manifest it consumes was produced by untrusted PR code. The source strings are
+shown inside a ``diff`` fenced code block so GitHub colours them red/green, and
+every entry line is prefixed with ``+``/``-`` with newlines flattened, so no
+attacker-controlled text can start a line and break out of the code fence or
+inject markup. (Fenced code is rendered literally, so HTML in a msgid shows as
+text rather than executing.)
+
+The comment is informational: it shows which translatable source strings the PR
+changes. The canonical messages.pot is regenerated automatically after merge, so
+the comment never asks the author to update or commit the catalog.
+"""
+
+import argparse
+import html
+import json
+import sys
+from typing import List
+
+COMMENT_MARKER = "<!-- l10n-automation:comment=messages-pot -->"
+
+# Keep individual rendered strings bounded regardless of source length.
+_MAX_MSGID_CHARS = 200
+
+
+def write_text(text: str, out: str) -> None:
+    """Write UTF-8 text to ``out``, or to stdout when ``out`` is ``-``.
+
+    The body embeds source strings verbatim, so writing to stdout goes through
+    its binary buffer: a runner whose stdout encoding is ASCII would otherwise
+    raise UnicodeEncodeError on the first non-ASCII string. The buffer is
+    absent when stdout is substituted (captured in tests), in which case the
+    text layer already handles the encoding.
+    """
+    if out != "-":
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return
+
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        sys.stdout.write(text)
+    else:
+        buffer.write(text.encode("utf-8"))
+        buffer.flush()
+
+
+def _clean(text: str) -> str:
+    """Flatten to a single line and bound the length for safe fenced display."""
+    flat = (text or "").replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\\n")
+    if len(flat) > _MAX_MSGID_CHARS:
+        flat = flat[:_MAX_MSGID_CHARS] + "..."
+    return flat
+
+
+def _annotations(entry: dict, *, include_plural: bool) -> List[str]:
+    annos: List[str] = []
+    ctx = entry.get("msgctxt")
+    if ctx:
+        annos.append(f"ctx: {_clean(str(ctx))}")
+    if include_plural and entry.get("plural"):
+        annos.append("plural")
+    return annos
+
+
+def _row(prefix: str, msgid: str, annos: List[str]) -> str:
+    tail = f"    [{'; '.join(annos)}]" if annos else ""
+    return f"{prefix} {_clean(msgid)}{tail}"
+
+
+def _diff_block(impact: dict) -> List[str]:
+    ic = impact["counts"]
+    lines: List[str] = ["```diff"]
+
+    for e in impact["added"]:
+        lines.append(_row("+", e.get("msgid", ""), _annotations(e, include_plural=True)))
+    if ic["added"] > len(impact["added"]):
+        lines.append(f"  ...and {ic['added'] - len(impact['added'])} more added (count above)")
+
+    for e in impact["removed"]:
+        lines.append(_row("-", e.get("msgid", ""), _annotations(e, include_plural=True)))
+    if ic["removed"] > len(impact["removed"]):
+        lines.append(f"  ...and {ic['removed'] - len(impact['removed'])} more removed (count above)")
+
+    # An entry is "changed" when its plural form gained, lost or reworded --
+    # the manifest carries only the head state, not which of those it was, so
+    # the annotation stays generic rather than claiming a singular/plural
+    # toggle that may not have happened.
+    for e in impact["changed"]:
+        annos = _annotations(e, include_plural=True) + ["plural form changed"]
+        lines.append(_row("+", e.get("msgid", ""), annos))
+    if ic["changed"] > len(impact["changed"]):
+        lines.append(f"  ...and {ic['changed'] - len(impact['changed'])} more changed (count above)")
+
+    lines.append("```")
+    return lines
+
+
+def render(manifest: dict) -> str:
+    impact = manifest["source_strings"]
+    ic = impact["counts"]
+    base_ref = (manifest["pr"].get("base_ref") or "base").replace("`", "")
+
+    lines: List[str] = [COMMENT_MARKER, "## Localization: source-string impact", ""]
+
+    if not manifest.get("regen_ok", True):
+        lines += ["> **Warning:** Could not fully regenerate `messages.pot` from "
+                  "this PR's source; the impact below may be incomplete.", ""]
+
+    if ic["added"] == ic["removed"] == ic["changed"] == 0:
+        lines += [f"This PR makes no changes to the translatable source strings "
+                  f"(compared with `{base_ref}`)."]
+    else:
+        lines += [
+            f"This PR changes the translatable source strings, compared with "
+            f"`{base_ref}` ({ic['total_head']} strings total):",
+            "",
+            "| Added | Removed | Changed |",
+            "| ----: | ------: | ------: |",
+            f"| {ic['added']} | {ic['removed']} | {ic['changed']} |",
+            "",
+        ]
+        lines += _diff_block(impact)
+
+    for note in manifest.get("notes", []):
+        lines += ["", f"> **Note:** {html.escape(' '.join(note.splitlines()))}"]
+
+    lines += [
+        "",
+        "<sub>Advisory only; this check never blocks the PR. The canonical "
+        "`l10n/messages.pot` is regenerated automatically after merge, so no "
+        "manual update is needed.</sub>",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Render advisory comment from a manifest.")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--out", default="-")
+    args = p.parse_args(argv)
+
+    with open(args.manifest, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+
+    write_text(render(manifest), args.out)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/tests/test_render_comment.py
+++ b/l10n/automation/tests/test_render_comment.py
@@ -1,0 +1,116 @@
+"""Tests for the advisory-comment renderer (red/green diff block + fence safety)."""
+
+import json
+
+import render_comment
+
+
+def base_manifest(**over):
+    m = {
+        "schema_version": "1.0", "stream": "messages-pot",
+        "generated_at": "2026-06-20T00:00:00Z", "repository": "owner/repo",
+        "pr": {"number": 1, "head_sha": "abc", "base_sha": None, "base_ref": "dev"},
+        "regen_ok": True,
+        "source_strings": {"added": [], "removed": [], "changed": [],
+                           "counts": {"added": 0, "removed": 0, "changed": 0,
+                                      "total_base": 0, "total_head": 0},
+                           "truncated": False},
+        "notes": [],
+    }
+    m.update(over)
+    return m
+
+
+def test_render_marker_and_no_changes():
+    body = render_comment.render(base_manifest())
+    assert render_comment.COMMENT_MARKER in body
+    assert "no changes to the translatable source strings" in body
+    # Never nags the author to update or commit the catalog.
+    assert "extract_messages" not in body
+    assert "out of date" not in body
+
+
+def test_render_diff_block_red_green():
+    m = base_manifest(source_strings={
+        "added": [{"msgid": "New label", "msgctxt": "menu", "plural": False},
+                  {"msgid": "New plural", "msgctxt": None, "plural": True}],
+        "removed": [{"msgid": "Old label", "msgctxt": None, "plural": False}],
+        "changed": [{"msgid": "Toggles", "msgctxt": None, "plural": True}],
+        "counts": {"added": 2, "removed": 1, "changed": 1,
+                   "total_base": 10, "total_head": 11},
+        "truncated": False})
+    body = render_comment.render(m)
+    assert "```diff" in body
+    assert "+ New label    [ctx: menu]" in body
+    assert "+ New plural    [plural]" in body
+    assert "- Old label" in body
+    # A changed entry is one line annotated with the head state; the manifest
+    # does not say whether the plural form was gained, lost or reworded, so the
+    # comment must not claim a singular/plural toggle.
+    assert "+ Toggles    [plural; plural form changed]" in body
+    assert "was singular form" not in body
+    assert "now plural form" not in body
+
+
+def test_render_truncation_note():
+    added = [{"msgid": f"s{i}", "msgctxt": None, "plural": False} for i in range(50)]
+    m = base_manifest(source_strings={
+        "added": added, "removed": [], "changed": [],
+        "counts": {"added": 63, "removed": 0, "changed": 0,
+                   "total_base": 0, "total_head": 63},
+        "truncated": True})
+    body = render_comment.render(m)
+    assert "...and 13 more added (count above)" in body
+
+
+def test_render_fences_untrusted_msgid_safely():
+    # Newlines flattened + a +/- prefix mean attacker text cannot start a line
+    # and break out of the diff fence to inject markdown/HTML.
+    nasty = "evil\n```\n## pwned heading\n- nope"
+    m = base_manifest(source_strings={
+        "added": [{"msgid": nasty, "msgctxt": None, "plural": False}],
+        "removed": [], "changed": [],
+        "counts": {"added": 1, "removed": 0, "changed": 0,
+                   "total_base": 0, "total_head": 1},
+        "truncated": False})
+    body = render_comment.render(m)
+    assert "+ evil\\n```\\n## pwned heading\\n- nope" in body
+    assert body.count("```diff") == 1
+    for line in body.splitlines():
+        assert not line.startswith("## pwned")
+
+
+def test_render_flattens_untrusted_notes():
+    # Notes come from the manifest (untrusted producer); newlines are flattened
+    # so a note cannot start a fresh line and break out of the blockquote to
+    # inject markdown.
+    m = base_manifest(notes=["regen failed\n\n## pwned heading\n- nope"])
+    body = render_comment.render(m)
+    assert "> **Note:** regen failed  ## pwned heading - nope" in body
+    for line in body.splitlines():
+        assert not line.startswith("## pwned")
+        assert not line.startswith("- nope")
+
+
+def test_non_ascii_survives_both_output_paths(tmp_path, capsysbinary):
+    # Source strings are embedded verbatim, so neither output path may depend
+    # on the runner's stdout encoding being UTF-8. Escaped so this file itself
+    # stays ASCII.
+    accented = "Phrase de passe : r\u00e9essayez"
+    m = base_manifest(source_strings={
+        "added": [{"msgid": accented, "msgctxt": None, "plural": False}],
+        "removed": [], "changed": [],
+        "counts": {"added": 1, "removed": 0, "changed": 0,
+                   "total_base": 0, "total_head": 1},
+        "truncated": False})
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(m), encoding="utf-8")
+    out = tmp_path / "body.md"
+
+    assert render_comment.main(["--manifest", str(manifest_path),
+                                "--out", str(out)]) == 0
+    assert accented in out.read_text(encoding="utf-8")
+
+    assert render_comment.main(["--manifest", str(manifest_path),
+                                "--out", "-"]) == 0
+    assert accented in capsysbinary.readouterr().out.decode("utf-8")

--- a/l10n/automation/tests/test_validate_manifest.py
+++ b/l10n/automation/tests/test_validate_manifest.py
@@ -1,0 +1,112 @@
+"""Tests for the manifest validator: schema enforcement plus trust anchors.
+
+This is the security boundary between the untrusted diff job and the trusted
+comment job, so each rejection path is checked explicitly.
+"""
+
+import json
+import os
+
+import pytest
+
+pytest.importorskip("jsonschema")
+
+import validate_manifest  # noqa: E402
+
+SCHEMA = os.path.join(os.path.dirname(__file__), "..", "schema",
+                      "review-manifest.schema.json")
+HEAD = "a" * 40
+REPO = "owner/repo"
+
+EMPTY_DIFF = {
+    "added": [], "removed": [], "changed": [],
+    "counts": {"added": 0, "removed": 0, "changed": 0,
+               "total_base": 0, "total_head": 0},
+    "truncated": False,
+}
+
+
+def valid_manifest(**over):
+    m = {
+        "schema_version": "1.0",
+        "stream": "messages-pot",
+        "generated_at": "2026-06-09T00:00:00Z",
+        "repository": REPO,
+        "pr": {"number": 7, "head_sha": HEAD, "base_sha": None, "base_ref": "dev"},
+        "regen_ok": True,
+        "source_strings": dict(EMPTY_DIFF),
+        "notes": [],
+    }
+    m.update(over)
+    return m
+
+
+def run(tmp_path, manifest, *, head=HEAD, repo=REPO):
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps(manifest), encoding="utf-8")
+    return validate_manifest.validate(str(p), SCHEMA, head, repo)
+
+
+def test_valid_manifest_has_no_errors(tmp_path):
+    assert run(tmp_path, valid_manifest()) == []
+
+
+def test_wrong_repository_rejected(tmp_path):
+    errors = run(tmp_path, valid_manifest(), repo="someone/else")
+    assert any("repository" in e for e in errors)
+
+
+def test_wrong_head_sha_rejected(tmp_path):
+    errors = run(tmp_path, valid_manifest(), head="b" * 40)
+    assert any("head" in e for e in errors)
+
+
+def test_schema_version_must_match(tmp_path):
+    # schema_version is a const, so any other value must be rejected.
+    errors = run(tmp_path, valid_manifest(schema_version="2.0"))
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_unknown_top_level_field_rejected(tmp_path):
+    # additionalProperties:false guards against smuggled fields.
+    errors = run(tmp_path, valid_manifest(injected="surprise"))
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_oversized_entry_list_rejected(tmp_path):
+    # The 50-entry cap lives in the untrusted producer; the schema must enforce
+    # it independently so a tampered producer cannot emit an unbounded list.
+    entry = {"msgid": "x", "msgctxt": None, "plural": False}
+    oversized = dict(EMPTY_DIFF, added=[entry] * 51)
+    errors = run(tmp_path, valid_manifest(source_strings=oversized))
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_missing_manifest_is_a_clean_error(tmp_path):
+    errors = validate_manifest.validate(
+        str(tmp_path / "nope.json"), SCHEMA, HEAD, REPO)
+    assert any(e.startswith("manifest: cannot read") for e in errors)
+
+
+def test_malformed_manifest_is_a_clean_error(tmp_path):
+    p = tmp_path / "manifest.json"
+    p.write_text("{ this is not json", encoding="utf-8")
+    errors = validate_manifest.validate(str(p), SCHEMA, HEAD, REPO)
+    assert any("is not valid JSON" in e for e in errors)
+
+
+def test_empty_manifest_is_a_clean_error(tmp_path):
+    p = tmp_path / "manifest.json"
+    p.write_text("", encoding="utf-8")
+    errors = validate_manifest.validate(str(p), SCHEMA, HEAD, REPO)
+    assert any("is not valid JSON" in e for e in errors)
+
+
+def test_non_object_manifest_is_rejected(tmp_path):
+    # Valid JSON, but not an object: must never validate clean, and must not
+    # reach the .get() calls that assume a mapping.
+    for payload in ("null", "[]", '"nope"'):
+        p = tmp_path / "manifest.json"
+        p.write_text(payload, encoding="utf-8")
+        errors = validate_manifest.validate(str(p), SCHEMA, HEAD, REPO)
+        assert f"manifest: {str(p)!r} is not a JSON object" in errors

--- a/l10n/automation/validate_manifest.py
+++ b/l10n/automation/validate_manifest.py
@@ -1,0 +1,91 @@
+"""Validate a review manifest before the trusted job acts on it.
+
+The manifest was produced by untrusted PR code, so the trusted follow-up job
+validates it against the JSON Schema and checks two trust anchors that GitHub
+sets authoritatively:
+
+* ``--expect-repository`` must equal ``manifest.repository``
+* ``--expect-head-sha`` (the triggering workflow_run head SHA) must equal
+  ``manifest.pr.head_sha``
+
+The PR-number<->head-SHA binding is completed in the workflow by fetching the
+PR and confirming its head SHA matches too; this script covers the data layer.
+"""
+
+import argparse
+import json
+import sys
+
+
+def _load_json_object(path: str, label: str, errors: list):
+    """Read a JSON object from a file, reporting failures as errors.
+
+    The manifest is attacker-influenced (produced by untrusted PR code) and may
+    be absent, empty or malformed, which must read as a clean rejection in the
+    CI log rather than an unhandled traceback. Returning ``None`` always comes
+    with an appended error, so a bare ``null`` payload cannot pass as valid.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except OSError as exc:
+        errors.append(f"{label}: cannot read {path!r}: {exc}")
+        return None
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label}: {path!r} is not valid JSON: {exc}")
+        return None
+
+    if not isinstance(data, dict):
+        errors.append(f"{label}: {path!r} is not a JSON object")
+        return None
+    return data
+
+
+def validate(manifest_path: str, schema_path: str, expect_head_sha: str,
+             expect_repository: str) -> list:
+    import jsonschema
+
+    errors = []
+    manifest = _load_json_object(manifest_path, "manifest", errors)
+    schema = _load_json_object(schema_path, "schema", errors)
+    if manifest is None or schema is None:
+        return errors
+
+    validator = jsonschema.Draft202012Validator(schema)
+    # Sort on the stringified path: error paths mix str (object keys) and int
+    # (array indices), which are not orderable against each other directly.
+    for err in sorted(validator.iter_errors(manifest), key=lambda e: list(map(str, e.path))):
+        errors.append(f"schema: {'/'.join(map(str, err.path)) or '<root>'}: {err.message}")
+
+    head = manifest.get("pr", {}).get("head_sha")
+    if head != expect_head_sha:
+        errors.append(f"pr.head_sha {head!r} != triggering run head {expect_head_sha!r}")
+
+    repo = manifest.get("repository")
+    if repo != expect_repository:
+        errors.append(f"repository {repo!r} != running repository {expect_repository!r}")
+
+    return errors
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Validate an l10n review manifest.")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--schema", required=True)
+    p.add_argument("--expect-head-sha", required=True)
+    p.add_argument("--expect-repository", required=True)
+    args = p.parse_args(argv)
+
+    errors = validate(args.manifest, args.schema, args.expect_head_sha,
+                       args.expect_repository)
+    if errors:
+        print("Manifest rejected:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print("Manifest OK")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
> [!NOTE]
> One of the l10n source-string automation PRs (#940, #941, #942, #943, #944). The manifest schema this validates against, and the tests' `conftest`, are added in #940.

## Description

### Problem or Issue being addressed

The review manifest is produced by untrusted PR code but rendered into a PR comment by a trusted job. We need to
(a) validate the manifest before trusting it and
(b) render it without letting attacker-controlled source strings break out of the comment.

### Solution

Adds two tools:

- `validate_manifest.py` -- validates a manifest against the schema and checks two trust anchors GitHub sets authoritatively (the repository, and the head SHA the triggering run was built from). This is the security boundary between the untrusted producer and the trusted consumer.
- `render_comment.py` -- renders the advisory comment. Source strings are shown inside a ```` ```diff``` ```` fence with newlines flattened and a `+`/`-` prefix on every line, so no msgid can start a line and break the fence or inject markup. A test feeds a hostile msgid and proves no breakout.

---

This pull request is categorized as a:
- [x] Other (l10n automation)

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

(`python -m pytest l10n/automation/tests` -- these tests live outside the project's default `testpaths` and are run explicitly.)

---

#### I included screenshots of any new or modified screens
- [x] N/A

---

#### I added or updated tests
- [x] Yes

---

#### I tested this PR hands-on on the following platform(s):
- [x] Github Actions

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---
