### PR TITLE
[l10n/automation] Post-merge messages.pot sync and rolling PR

### DIFF
--- a/.github/workflows/l10n-pot-sync.yml
+++ b/.github/workflows/l10n-pot-sync.yml
@@ -1,0 +1,205 @@
+# Keeps messages.pot in sync after a merge to the default branch.
+#
+# When source strings actually change, it opens or updates a single rolling PR
+# from the bot fork into this repo, and mirrors the canonical messages.pot into
+# the translations bot fork so Transifex picks up the new source.
+#
+# Branch writes happen only inside bot forks, using short-lived GitHub App
+# tokens; this repo's own GITHUB_TOKEN stays read-only. The job no-ops while
+# vars.L10N_BOT_FORK is unset, so it is safe to merge before a bot fork exists.
+name: l10n source-string sync
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "src/**"
+      - "setup.cfg"
+      - "l10n/messages.pot"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: l10n-pot-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # Activates only once a bot fork is configured. Until then this is a no-op.
+    if: ${{ vars.L10N_BOT_FORK != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve bot topology
+        id: prep
+        env:
+          BOT_FORK: ${{ vars.L10N_BOT_FORK }}
+          TR_FORK: ${{ vars.L10N_TRANSLATIONS_BOT_FORK }}
+        run: |
+          set -euo pipefail
+          bot_owner="${BOT_FORK%%/*}"
+          repos="${BOT_FORK##*/}"
+          if [ -n "${TR_FORK:-}" ]; then
+            repos="$repos,${TR_FORK##*/}"
+          fi
+          echo "bot_owner=$bot_owner" >> "$GITHUB_OUTPUT"
+          echo "bot_repos=$repos" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: python -m pip install --quiet -r l10n/requirements-l10n.txt
+
+      - name: Regenerate and detect source-string change
+        id: detect
+        run: |
+          set -euo pipefail
+          python setup.py extract_messages -o regen.pot
+          changed="$(python l10n/automation/pot_sync_helper.py \
+            --committed l10n/messages.pot --regenerated regen.pot)"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      # Privileged tokens are minted only when there is an actual source-string
+      # change to publish, so no-op merges never create write-capable tokens.
+      # The PR-side token is scoped to pull-requests:write on this repo and is
+      # never granted contents:write, so the main repo cannot mutate branches.
+      - name: Mint app token (main repo, pull-requests write)
+        id: app_main
+        if: steps.detect.outputs.changed == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.L10N_PR_CLIENT_ID }}
+          private-key: ${{ secrets.L10N_PR_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      # Token for the bot account, scoped to contents:write on the bot forks only.
+      - name: Mint app token (bot forks, contents write)
+        id: app_bot
+        if: steps.detect.outputs.changed == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.L10N_FORK_CLIENT_ID }}
+          private-key: ${{ secrets.L10N_FORK_PRIVATE_KEY }}
+          owner: ${{ steps.prep.outputs.bot_owner }}
+          repositories: ${{ steps.prep.outputs.bot_repos }}
+          permission-contents: write
+
+      - name: Push rolling branch to bot fork
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GIT_TOKEN: ${{ steps.app_bot.outputs.token }}
+          BOT_FORK: ${{ vars.L10N_BOT_FORK }}
+          APP_SLUG: ${{ steps.app_bot.outputs.app-slug }}
+          BRANCH: automation/messages-pot
+        run: |
+          set -euo pipefail
+          cp regen.pot l10n/messages.pot
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add l10n/messages.pot
+          git commit -m "l10n: sync messages.pot (source strings)"
+          # Force-push keeps the rolling branch rebased on the latest default branch.
+          git push --force \
+            "https://x-access-token:${GIT_TOKEN}@github.com/${BOT_FORK}.git" \
+            "HEAD:refs/heads/${BRANCH}"
+
+      - name: Open or update rolling PR
+        if: steps.detect.outputs.changed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BOT_OWNER: ${{ steps.prep.outputs.bot_owner }}
+          BOT_FORK: ${{ vars.L10N_BOT_FORK }}
+          BRANCH: automation/messages-pot
+        with:
+          github-token: ${{ steps.app_main.outputs.token }}
+          script: |
+            const head = `${process.env.BOT_OWNER}:${process.env.BRANCH}`;
+            const headRepo = process.env.BOT_FORK.split('/')[1];
+            const base = context.ref.replace('refs/heads/', '');
+            const title = 'l10n: sync messages.pot (source strings)';
+            const body = [
+              'Automated regeneration of `l10n/messages.pot` from the source on ' +
+                '`' + base + '`. This rolling PR updates in place as new source ' +
+                'strings land.',
+              '',
+              'Merging keeps the canonical translation source in step with the code.',
+            ].join('\n');
+
+            const { data: open } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head,
+              base,
+            });
+
+            if (open.length > 0) {
+              core.info(`Rolling PR already open: #${open[0].number} (branch updated).`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head,
+              head_repo: headRepo,
+              base,
+              title,
+              body,
+              // This token has pull-requests:write on this repo only; it has no
+              // write access to the bot fork that owns the head branch. Requesting
+              // maintainer edit rights (the API default) would make a cross-fork
+              // create fail with 403, so opt out of it explicitly.
+              maintainer_can_modify: false,
+            });
+            core.info(`Opened rolling PR #${pr.number}.`);
+
+      - name: Mirror canonical messages.pot to translations bot fork
+        if: steps.detect.outputs.changed == 'true' && vars.L10N_TRANSLATIONS_BOT_FORK != ''
+        env:
+          GIT_TOKEN: ${{ steps.app_bot.outputs.token }}
+          TR_FORK: ${{ vars.L10N_TRANSLATIONS_BOT_FORK }}
+          TR_BRANCH: ${{ vars.L10N_TRANSLATIONS_BRANCH || 'dev' }}
+          TR_POT_PATH: ${{ vars.L10N_TRANSLATIONS_POT_PATH || 'l10n/messages.pot' }}
+          APP_SLUG: ${{ steps.app_bot.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          git clone --quiet --depth 1 --branch "$TR_BRANCH" \
+            "https://x-access-token:${GIT_TOKEN}@github.com/${TR_FORK}.git" "$tmp"
+          mkdir -p "$(dirname "$tmp/$TR_POT_PATH")"
+          cp regen.pot "$tmp/$TR_POT_PATH"
+          cd "$tmp"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git add "$TR_POT_PATH"
+          if git diff --cached --quiet; then
+            echo "Translations source already up to date; nothing to mirror."
+          else
+            git commit -m "l10n: sync messages.pot source from main repo"
+            git push origin "HEAD:refs/heads/${TR_BRANCH}"
+          fi
+
+      - name: Summary
+        if: always()
+        env:
+          CHANGED: ${{ steps.detect.outputs.changed }}
+        run: |
+          if [ "${CHANGED:-}" = "true" ]; then
+            echo "Source strings changed; rolling PR and translations mirror updated." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No source-string change detected; nothing to sync." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/l10n/automation/SETUP.md
+++ b/l10n/automation/SETUP.md
@@ -1,0 +1,59 @@
+# l10n automation: operator setup
+
+The advisory-comment workflows need no setup (they use the repository's own
+`GITHUB_TOKEN`). The post-merge sync (`l10n-pot-sync.yml`) needs a bot account
+and GitHub App credentials, configured through repository variables and secrets.
+
+The sync job no-ops until `L10N_BOT_FORK` is set, so the workflow is safe to
+merge before any of this exists.
+
+## Topology
+
+The sync never writes to an upstream repo. It pushes the rolling `messages.pot`
+branch to a bot-owned fork and opens a PR from there:
+
+- `<bot>/seedsigner`: fork of the main repo; source of the rolling messages.pot PR.
+- `<bot>/seedsigner-translations`: fork of the translations repo; the Transifex
+  source-mirror target.
+
+The bot forks must be real GitHub forks (same fork network) so the cross-fork PR
+is allowed, and their default branches should track upstream (otherwise the
+rolling-branch push re-introduces `.github/workflows/` files and the Fork App
+then also needs `workflows: write`).
+
+## Credentials: GitHub App(s)
+
+The bot authenticates as a GitHub App (no long-lived PATs); the workflow mints
+short-lived, least-privilege installation tokens at runtime. Two logical roles:
+
+- PR role: `pull-requests: write` on the main repo; opens the rolling PR.
+- Fork role: `contents: write` on the bot forks; pushes the rolling branch and
+  mirrors the `.pot`.
+
+Because no upstream repo may ever be granted `contents: write`, production uses
+**two** separate Apps (the main-repo App carries `pull-requests: write` only).
+For a single-maintainer test you may use one App with both permissions installed
+on both accounts. Each role is configured by its App's **Client ID** (the legacy
+numeric App ID is deprecated) and private key.
+
+## Repository variables
+
+Settings -> Secrets and variables -> Actions -> Variables:
+
+| Variable | Example | Notes |
+| --- | --- | --- |
+| `L10N_BOT_FORK` | `<bot>/seedsigner` | Enables the sync job. Empty means no-op. |
+| `L10N_TRANSLATIONS_BOT_FORK` | `<bot>/seedsigner-translations` | Empty means the mirror step is skipped. |
+| `L10N_TRANSLATIONS_BRANCH` | `dev` | Branch Transifex reads source from. |
+| `L10N_TRANSLATIONS_POT_PATH` | `l10n/messages.pot` | Source `.pot` path in the translations repo. |
+
+## Repository secrets
+
+| Secret | Value |
+| --- | --- |
+| `L10N_PR_CLIENT_ID` | PR App's Client ID |
+| `L10N_PR_PRIVATE_KEY` | PR App's private key (`.pem` contents) |
+| `L10N_FORK_CLIENT_ID` | Fork App's Client ID |
+| `L10N_FORK_PRIVATE_KEY` | Fork App's private key (`.pem` contents) |
+
+For a single-App test setup, put that App's Client ID and key in both pairs.

--- a/l10n/automation/pot_sync_helper.py
+++ b/l10n/automation/pot_sync_helper.py
@@ -1,0 +1,43 @@
+"""Decide whether a freshly regenerated messages.pot is a meaningful change.
+
+Used by the post-merge sync workflow to stay idempotent: the rolling PR and the
+translations mirror are only touched when source strings actually changed.
+Header churn (e.g. POT-Creation-Date) and source-location moves are ignored,
+because they carry no translator-facing meaning.
+
+Prints ``true``/``false`` to stdout and a human summary to stderr.
+"""
+
+import argparse
+import sys
+
+import pot_diff
+
+
+def has_meaningful_change(committed_path: str, regenerated_path: str) -> tuple[bool, dict]:
+    committed = pot_diff.load_catalog(committed_path)
+    regenerated = pot_diff.load_catalog(regenerated_path)
+    diff = pot_diff.diff_catalogs(committed, regenerated)
+    c = diff["counts"]
+    changed = bool(c["added"] or c["removed"] or c["changed"])
+    return changed, c
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--committed", required=True)
+    p.add_argument("--regenerated", required=True)
+    args = p.parse_args(argv)
+
+    changed, c = has_meaningful_change(args.committed, args.regenerated)
+    print("true" if changed else "false")
+    print(
+        f"source strings: +{c['added']} -{c['removed']} ~{c['changed']} "
+        f"(committed={c['total_base']}, regenerated={c['total_head']})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/tests/test_sync_helper.py
+++ b/l10n/automation/tests/test_sync_helper.py
@@ -1,0 +1,33 @@
+"""Tests for the post-merge change-detection helper."""
+
+import pytest
+
+pytest.importorskip("babel")
+
+import pot_sync_helper  # noqa: E402
+from conftest import write_pot  # noqa: E402
+
+
+def test_no_change_when_strings_match(tmp_path):
+    committed = write_pot(tmp_path / "c.pot", [{"id": "Hello"}, {"id": "Bye"}])
+    regen = write_pot(tmp_path / "r.pot", [{"id": "Hello"}, {"id": "Bye"}])
+    changed, counts = pot_sync_helper.has_meaningful_change(committed, regen)
+    assert changed is False
+    assert counts["added"] == counts["removed"] == counts["changed"] == 0
+
+
+def test_change_when_string_added(tmp_path):
+    committed = write_pot(tmp_path / "c.pot", [{"id": "Hello"}])
+    regen = write_pot(tmp_path / "r.pot", [{"id": "Hello"}, {"id": "New"}])
+    changed, counts = pot_sync_helper.has_meaningful_change(committed, regen)
+    assert changed is True
+    assert counts["added"] == 1
+
+
+def test_cli_outputs_bool(tmp_path, capsys):
+    committed = write_pot(tmp_path / "c.pot", [{"id": "Hello"}])
+    regen = write_pot(tmp_path / "r.pot", [{"id": "Hello"}, {"id": "New"}])
+    rc = pot_sync_helper.main(["--committed", committed, "--regenerated", regen])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.out.strip() == "true"


### PR DESCRIPTION
> [!NOTE]
> One of the l10n source-string automation PRs (#940, #941, #942, #943, #944). It uses the diff engine from #940.
> Operated through a bot fork a maintainer sets up (a bot account that forks this repo, a GitHub App, and repository variables and secrets; see SETUP.md, added here). Gated on the `L10N_BOT_FORK` variable, it no-ops, minting no tokens and opening no PRs, until that is configured. Unlike the fork-only translation-side bridge, once configured this one does run in this repo on pushes to `dev`.

## Description

### Problem or Issue being addressed

`l10n/messages.pot` goes stale unless a developer remembers to run `extract_messages` after every source-string change and commit the result. This is easy to skip, especially on small changes, and there is no mechanism that keeps the translation source in sync with the code automatically.

### Solution

Adds the post-merge sync pipeline:

- `l10n-pot-sync.yml` -- triggers on push to `dev` when `src/**`, `setup.cfg`, or `l10n/messages.pot` changes. It regenerates the catalog, checks whether the result is meaningfully different (via `pot_sync_helper.py`), and if so force-pushes a rolling branch to the configured bot fork and opens or updates a single rolling PR into the main repo. A second step mirrors the canonical `.pot` to a translations bot fork for Transifex. The job is gated on `vars.L10N_BOT_FORK != ''`, so it no-ops until a bot fork is configured -- safe to merge before the bot exists. Write-capable GitHub App tokens are minted only when an actual change is detected, so no-op merges never produce privileged credentials.
- `pot_sync_helper.py` -- prints `true` or `false` for the meaningful-change decision. The definition of "meaningful" is any added, removed, or changed entry ignoring header and source-location lines, which is the same comparison `pot_diff.py` uses.
- `SETUP.md` -- operator guide covering the required GitHub Apps, secrets, and repository variables needed to activate the sync.

---

This pull request is categorized as a:
- [x] Other (l10n automation)

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

(`python -m pytest l10n/automation/tests` -- these tests live outside the project's default `testpaths` and are run explicitly.)

---

#### I included screenshots of any new or modified screens
- [x] N/A

---

#### I added or updated tests
- [x] Yes

---

#### I tested this PR hands-on on the following platform(s):
- [x] Github Actions

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

