### PR TITLE
Message signing: confirm a pubkey for any non-standard derivation path

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.7\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-05 22:02+0000\n"
+"POT-Creation-Date: 2026-07-14 21:47-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -425,6 +425,12 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "derivation path"
+msgstr ""
+
+#. "Pubkey" is the public key that will sign the message; shown instead of
+#. an address for derivation paths that have no meaningful single sig address.
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Confirm Pubkey"
 msgstr ""
 
 #: src/seedsigner/gui/screens/settings_screens.py
@@ -1345,10 +1351,6 @@ msgstr ""
 msgid "{threshold} of {n}"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
-msgid "Signing messages for custom derivation paths not supported"
-msgstr ""
-
 #: src/seedsigner/views/settings_views.py
 msgid "Advanced"
 msgstr ""
@@ -1547,6 +1549,16 @@ msgstr ""
 #. "network" will be mainnet/testnet/regtest.
 #: src/seedsigner/views/view.py
 msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr ""
+
+#. A derivation path (e.g. m/84h/0h/0h/0/0) that can't be interpreted
+#: src/seedsigner/views/view.py
+msgid "Invalid Derivation"
+msgstr ""
+
+#. {derivation_path} is the malformed path that was scanned
+#: src/seedsigner/views/view.py
+msgid "{derivation_path} is not a valid derivation path."
 msgstr ""
 
 #: src/seedsigner/views/view.py

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1672,3 +1672,49 @@ class SeedSignMessageConfirmAddressScreen(ButtonListScreen):
             screen_y=derivation_path_display.screen_y + derivation_path_display.height + 2*GUIConstants.COMPONENT_PADDING,
         )
         self.components.append(address_display)
+
+
+
+@dataclass
+class SeedSignMessageConfirmPubkeyScreen(ButtonListScreen):
+    fingerprint: str = None
+    derivation_path: str = None
+    pubkey: str = None
+
+    def __post_init__(self):
+        # TRANSLATOR_NOTE: "Pubkey" is the public key that will sign the message; shown instead of
+        # an address for derivation paths that have no meaningful single sig address.
+        self.title = _("Confirm Pubkey")
+        self.is_bottom_list = True
+        self.is_button_text_centered = True
+        self.button_data = [ButtonOption("Sign message")]
+        super().__post_init__()
+
+        fingerprint_display = IconTextLine(
+            icon_name=SeedSignerIconConstants.FINGERPRINT,
+            icon_color=GUIConstants.INFO_COLOR,
+            label_text=_("fingerprint"),
+            value_text=self.fingerprint,
+            is_text_centered=True,
+            screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
+        )
+        self.components.append(fingerprint_display)
+
+        derivation_path_display = IconTextLine(
+            icon_name=SeedSignerIconConstants.DERIVATION,
+            icon_color=GUIConstants.INFO_COLOR,
+            label_text=_("derivation path"),
+            value_text=self.derivation_path,
+            is_text_centered=True,
+            screen_y=fingerprint_display.screen_y + fingerprint_display.height + GUIConstants.COMPONENT_PADDING,
+        )
+        self.components.append(derivation_path_display)
+
+        # FormattedAddress is a generic fixed-width formatter; it truncates the 66-char pubkey to
+        # its first and last 7 chars across 2 lines.
+        pubkey_display = FormattedAddress(
+            address=self.pubkey,
+            max_lines=2,
+            screen_y=derivation_path_display.screen_y + derivation_path_display.height + GUIConstants.COMPONENT_PADDING,
+        )
+        self.components.append(pubkey_display)

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -66,6 +66,19 @@ def get_xpub(seed_bytes, derivation_path: str, embit_network: str = "main") -> H
 
 
 
+def get_pubkey_hex(seed_bytes, derivation_path: str, embit_network: str = "main") -> str:
+    """
+    The compressed SEC pubkey (33 bytes / 66 hex chars) at the given derivation path.
+
+    Note: the result is the same on all networks. `embit_network` only selects the xprv version
+    bytes, which aren't an input to derivation or to the SEC encoding. Testnet differs only
+    because its coin type makes it a different path (e.g. m/84h/1h/... vs m/84h/0h/...).
+    """
+    root = bip32.HDKey.from_seed(seed_bytes, version=NETWORKS[embit_network]["xprv"])
+    return root.derive(derivation_path).key.get_public_key().sec().hex()
+
+
+
 def get_single_sig_address(xpub: HDKey, script_type: str = SettingsConstants.NATIVE_SEGWIT, index: int = 0, is_change: bool = False, embit_network: str = "main") -> str:
     if is_change:
         pubkey = xpub.derive([1,index]).key
@@ -123,11 +136,29 @@ def get_embit_network_name(settings_name):
 
 
 
+def is_valid_derivation_path(derivation_path: str) -> bool:
+    """
+    Can embit actually derive this path? Guards against malformed input (e.g. a scanned QR
+    with a garbage derivation path).
+
+    Note: embit's `parse_path` accepts out-of-range indexes (negative or >= 2^32) that only
+    blow up later at derivation time, so range-check them here.
+    """
+    try:
+        indexes = bip32.parse_path(derivation_path)
+    except Exception:
+        return False
+
+    return all(0 <= index < 2**32 for index in indexes)
+
+
+
 def parse_derivation_path(derivation_path: str) -> dict:
     """
     Parses a derivation path into its related SettingsConstants equivalents.
 
-    Primarily only supports single sig derivation paths.
+    Only single sig derivation paths resolve to a script type; anything else (e.g. BIP48
+    multisig) is reported as CUSTOM_DERIVATION.
 
     May return None for fields it cannot parse.
     """
@@ -135,10 +166,6 @@ def parse_derivation_path(derivation_path: str) -> dict:
     derivation_path = derivation_path.replace("'", "h")
 
     sections = derivation_path.split("/")
-
-    if sections[1] == "48h":
-        # So far this helper is only meant for single sig message signing
-        raise Exception("Not implemented")
 
     lookups = {
         "script_types": {
@@ -154,13 +181,21 @@ def parse_derivation_path(derivation_path: str) -> dict:
     }
 
     details = dict()
-    details["script_type"] = lookups["script_types"].get(sections[1])
+
+    # Note: BIP48 (48h) is deliberately not mapped to a script type here. Its script type is a
+    # multisig one, so rendering a single sig address from it would show an address that the
+    # user's wallet will never display. It falls through to CUSTOM_DERIVATION and is confirmed
+    # by pubkey instead.
+    purpose = sections[1] if len(sections) > 1 else None
+    details["script_type"] = lookups["script_types"].get(purpose)
     if not details["script_type"]:
         details["script_type"] = SettingsConstants.CUSTOM_DERIVATION
-    details["network"] = lookups["networks"].get(sections[2])
+
+    coin_type = sections[2] if len(sections) > 2 else None
+    details["network"] = lookups["networks"].get(coin_type)
 
     # Check if there's a standard change path
-    if sections[-2] in ["0", "1"]:
+    if len(sections) > 2 and sections[-2] in ["0", "1"]:
         details["is_change"] = sections[-2] == "1"
     else:
         details["is_change"] = None

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -17,7 +17,7 @@ from seedsigner.models.seed import Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
-from seedsigner.views.view import NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView
+from seedsigner.views.view import OptionDisabledView, View, Destination, BackStackView, MainMenuView
 
 logger = logging.getLogger(__name__)
 
@@ -2132,15 +2132,19 @@ class SeedSignMessageStartView(View):
             self.set_redirect(Destination(OptionDisabledView, view_args=dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)))
             return
 
-        # calculate the actual receive address
-        addr_format = embit_utils.parse_derivation_path(derivation_path)
-        if not addr_format["clean_match"]:
-            self.set_redirect(Destination(NotYetImplementedView, view_args=dict(text=f"Signing messages for custom derivation paths not supported")))
+        # The derivation path arrives unvalidated from the scanned QR; reject garbage here so it
+        # can't blow up later during key derivation.
+        if not embit_utils.is_valid_derivation_path(derivation_path):
+            from seedsigner.views.view import InvalidDerivationPathErrorView
+            self.set_redirect(Destination(InvalidDerivationPathErrorView, view_args=dict(derivation_path=derivation_path)))
             self.controller.resume_main_flow = None
             return
 
-        # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
-        if self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:
+        addr_format = embit_utils.parse_derivation_path(derivation_path)
+
+        # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]. Custom paths may not
+        # encode a network at all, in which case there's nothing to check against.
+        if addr_format["network"] and self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:
             from seedsigner.views.view import NetworkMismatchErrorView
             self.set_redirect(Destination(NetworkMismatchErrorView, view_args=dict(derivation_path=self.derivation_path)))
 
@@ -2192,8 +2196,13 @@ class SeedSignMessageConfirmMessageView(View):
 
         # User clicked "Next"
         if self.page_num == len(self.controller.sign_message_data["paged_message"]) - 1:
-            # We've reached the end of the paged message
-            return Destination(SeedSignMessageConfirmAddressView)
+            # We've reached the end of the paged message. Standard single sig paths can show the
+            # receive address they sign for; any other path (BIP48 multisig, BIP47, custom) has no
+            # meaningful single sig address, so confirm the signing pubkey instead.
+            addr_format = self.controller.sign_message_data["addr_format"]
+            if addr_format["clean_match"] and addr_format["script_type"] != SettingsConstants.CUSTOM_DERIVATION:
+                return Destination(SeedSignMessageConfirmAddressView)
+            return Destination(SeedSignMessageConfirmPubkeyView)
         else:
             return Destination(SeedSignMessageConfirmMessageView, view_args=dict(page_num=self.page_num + 1))
 
@@ -2216,8 +2225,6 @@ class SeedSignMessageConfirmAddressView(View):
         # calculate the actual receive address
         seed = self.controller.storage.seeds[seed_num]
         addr_format = embit_utils.parse_derivation_path(self.derivation_path)
-        if not addr_format["clean_match"] or addr_format["script_type"] == SettingsConstants.CUSTOM_DERIVATION:
-            raise Exception(_("Signing messages for custom derivation paths not supported"))
 
         if addr_format["network"] != SettingsConstants.MAINNET:
             # We're in either Testnet or Regtest or...?
@@ -2244,6 +2251,50 @@ class SeedSignMessageConfirmAddressView(View):
             SeedSignMessageConfirmAddressScreen,
             derivation_path=self.derivation_path,
             address=self.address,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        # User clicked "Sign Message"
+        return Destination(SeedSignMessageSignedMessageQRView)
+
+
+
+class SeedSignMessageConfirmPubkeyView(View):
+    """
+    Confirmation screen for derivation paths that have no meaningful single sig address (BIP48
+    multisig, BIP47, Nostr, custom, etc). Instead of an address, the user confirms the key that
+    will actually sign: seed fingerprint + derivation path + the pubkey derived at that path.
+    """
+    def __init__(self):
+        from seedsigner.helpers import embit_utils
+        super().__init__()
+        data = self.controller.sign_message_data
+        seed_num = data.get("seed_num")
+        self.derivation_path = data.get("derivation_path")
+
+        if seed_num is None or not self.derivation_path:
+            raise Exception("Routing error: sign_message_data hasn't been set")
+
+        seed = self.controller.storage.seeds[seed_num]
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+
+        self.fingerprint = seed.get_fingerprint(network=network)
+        self.pubkey = embit_utils.get_pubkey_hex(
+            seed_bytes=seed.seed_bytes,
+            derivation_path=self.derivation_path,
+            embit_network=embit_utils.get_embit_network_name(network),
+        )
+
+
+    def run(self):
+        from seedsigner.gui.screens.seed_screens import SeedSignMessageConfirmPubkeyScreen
+        selected_menu_num = self.run_screen(
+            SeedSignMessageConfirmPubkeyScreen,
+            fingerprint=self.fingerprint,
+            derivation_path=self.derivation_path,
+            pubkey=self.pubkey,
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -361,6 +361,28 @@ class NetworkMismatchErrorView(ErrorView):
 
 
 @dataclass
+class InvalidDerivationPathErrorView(ErrorView):
+    derivation_path: str = None
+
+    def __post_init__(self):
+        # The QR scanned fine; its derivation path is just malformed. That's bad input rather than
+        # a SeedSigner failure, so use the warning icon, as NetworkMismatchErrorView does.
+        # TRANSLATOR_NOTE: A derivation path (e.g. m/84h/0h/0h/0/0) that can't be interpreted
+        self.title = _("Invalid Derivation")
+        self.status_icon_name = SeedSignerIconConstants.WARNING
+        self.show_back_button = False
+
+        self.button_text = _("Back to main menu")
+        super().__post_init__()
+
+        # TRANSLATOR_NOTE: {derivation_path} is the malformed path that was scanned
+        self.text = _("{derivation_path} is not a valid derivation path.").format(
+            derivation_path=self.derivation_path,
+        )
+
+
+
+@dataclass
 class UnhandledExceptionView(View):
     error: list[str]
 

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -42,7 +42,7 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, RemoveMicroSDWarningView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
-from seedsigner.views.view import CameraConnectionErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView
+from seedsigner.views.view import CameraConnectionErrorView, InvalidDerivationPathErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView
 
 from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
@@ -298,6 +298,20 @@ def generate_screenshots(locale):
 
 
         @contextmanager
+        def mock_sign_message_data_bip48():
+            # The default sign_message_data uses a single sig path, which routes to the address
+            # screen. A BIP48 multisig path is what routes to the pubkey screen.
+            bip48_derivation_path = "m/48h/0h/0h/2h/0/0"
+            sign_message_data = dict(
+                controller.sign_message_data,
+                derivation_path=bip48_derivation_path,
+                addr_format=embit_utils.parse_derivation_path(bip48_derivation_path),
+            )
+            with patch.object(controller, 'sign_message_data', sign_message_data):
+                yield
+
+
+        @contextmanager
         def mock_controller_psbt_seed_empty():
             # Have to ensure this is cleared out in order to get the seed selection screen
             with patch.object(controller, 'psbt_seed', None):
@@ -398,6 +412,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedSelectSeedView, dict(flow=Controller.FLOW__SIGN_MESSAGE), screenshot_name="SeedSelectSeedView_sign_message"),
                 ScreenshotConfig(seed_views.SeedSignMessageConfirmMessageView),
                 ScreenshotConfig(seed_views.SeedSignMessageConfirmAddressView),
+                ScreenshotConfig(seed_views.SeedSignMessageConfirmPubkeyView, mock_context_manager=mock_sign_message_data_bip48),
 
                 ScreenshotConfig(seed_views.SeedElectrumMnemonicStartView),
             ],
@@ -454,6 +469,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(UnhandledExceptionView, dict(error=["IndexError", "line 1, in some_buggy_code.py", "list index out of range"])),
                 ScreenshotConfig(CameraConnectionErrorView),
                 ScreenshotConfig(NetworkMismatchErrorView, dict(derivation_path="m/84'/1'/0'")),
+                ScreenshotConfig(InvalidDerivationPathErrorView, dict(derivation_path="m/foo/bar")),
                 ScreenshotConfig(OptionDisabledView,       dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
                 ScreenshotConfig(scan_views.ScanInvalidQRTypeView)
             ]

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -424,6 +424,16 @@ def test_parse_derivation_path():
         (SC.TESTNET, SC.CUSTOM_DERIVATION, True): "m/45'/1'/0'/1/5",
         (SC.REGTEST, SC.CUSTOM_DERIVATION, True): "m/45'/1'/0'/1/5",
 
+        # BIP48 multisig. 48' is deliberately NOT mapped to a script type; its script type is a
+        # multisig one, so it must not resolve to a single sig script type (see
+        # parse_derivation_path).
+        (SC.MAINNET, SC.CUSTOM_DERIVATION, False, 5): "m/48'/0'/0'/2'/0/5",
+        (SC.TESTNET, SC.CUSTOM_DERIVATION, False, 5): "m/48'/1'/0'/2'/0/5",
+        (SC.MAINNET, SC.CUSTOM_DERIVATION, True, 5): "m/48'/0'/0'/1'/1/5",
+
+        # Nostr keys are likewise just a custom derivation
+        (SC.MAINNET, SC.CUSTOM_DERIVATION, False, 0): "m/1017'/0'/0'/0/0",
+
         # CRAZY custom derivation paths
         (None, SC.CUSTOM_DERIVATION, False, 5): "m/123'/9083270/9083270/9083270/9083270/0/5",
 
@@ -455,3 +465,97 @@ def test_parse_derivation_path():
             assert actual_result["index"] == expected_result[3]
         else:
             assert actual_result["index"] == int(derivation_path.split("/")[-1])
+
+
+def test_parse_derivation_path_without_change_and_index():
+    """
+    Paths that stop above the change/index levels (e.g. BIP47, or signing at the account level)
+    should parse without raising; they just can't resolve a change/index.
+    """
+    for derivation_path in ["m/47'/0'/0'", "m/84'/0'/0'", "m/48'/0'/0'/2'", "m"]:
+        result = embit_utils.parse_derivation_path(derivation_path)
+        assert result["is_change"] is None
+        assert result["index"] is None
+        assert result["wallet_derivation_path"] is None
+        assert result["clean_match"] is False
+
+
+def test_is_valid_derivation_path():
+    for derivation_path in [
+        "m/84'/0'/0'/0/0",
+        "m/84h/0h/0h/0/0",
+        "m/48'/0'/0'/2'/0/0",
+        "m/1017'/0'/0'/0/0",
+        "m",  # the master key itself is a legitimate (if unusual) signing key
+    ]:
+        assert embit_utils.is_valid_derivation_path(derivation_path) is True
+
+    for derivation_path in [
+        "",
+        "m/foo/bar",
+        "not a path at all",
+        "🤡",
+        "m/84'/0'/0'/0/-1",         # negative index
+        "m/84'/0'/0'/0/999999999999999999",  # index >= 2^32; embit's parse_path accepts it but derivation blows up
+    ]:
+        assert embit_utils.is_valid_derivation_path(derivation_path) is False
+
+    # Garbage must not raise out of the parser either; it should just fail to resolve fields
+    for derivation_path in ["", "m/foo/bar", "not a path at all", "🤡", "m"]:
+        result = embit_utils.parse_derivation_path(derivation_path)
+        assert result["clean_match"] is False
+
+
+def test_get_pubkey_hex():
+    # BIP32 test vector 1: seed 000102030405060708090a0b0c0d0e0f, chain m/0h
+    seed_bytes = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
+    assert embit_utils.get_pubkey_hex(seed_bytes, "m/0h") == "035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56"
+
+    # Support either "'" or "h" notation, and the master key itself
+    assert embit_utils.get_pubkey_hex(seed_bytes, "m/0'") == embit_utils.get_pubkey_hex(seed_bytes, "m/0h")
+    assert len(embit_utils.get_pubkey_hex(seed_bytes, "m")) == 66
+
+
+def test_get_pubkey_hex_is_network_independent():
+    """
+    A pubkey at a given path is the same on every network; the network only selects the xprv
+    version bytes. Testnet differs solely because its coin type makes it a different path.
+    """
+    seed_bytes = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
+    derivation_path = "m/48h/0h/0h/2h/0/0"
+
+    mainnet_pubkey = embit_utils.get_pubkey_hex(seed_bytes, derivation_path, embit_network="main")
+    assert embit_utils.get_pubkey_hex(seed_bytes, derivation_path, embit_network="test") == mainnet_pubkey
+    assert embit_utils.get_pubkey_hex(seed_bytes, derivation_path, embit_network="regtest") == mainnet_pubkey
+
+    # ...but the testnet coin type is a different path, so it's a different key
+    assert embit_utils.get_pubkey_hex(seed_bytes, "m/48h/1h/0h/2h/0/0") != mainnet_pubkey
+
+
+def test_sign_message_on_a_non_single_sig_path():
+    """
+    The signature produced for a BIP48 multisig path must be verifiable against the pubkey we
+    display on the confirmation screen; i.e. what the user confirms is what actually signed.
+    """
+    from base64 import b64decode
+    from hashlib import sha256
+
+    from embit import compact, ec
+    from embit.util import secp256k1
+
+    from seedsigner.models.seed import Seed
+
+    seed = Seed(mnemonic=["abandon"] * 11 + ["about"])
+    derivation_path = "m/48h/0h/0h/2h/0/0"
+    message = b"I attest that I control this bitcoin address blah blah blah"
+
+    signature = embit_utils.sign_message(seed_bytes=seed.seed_bytes, derivation=derivation_path, msg=message)
+
+    # Recover the signing pubkey from the signature and compare it to what we'd show the user
+    serialized = b64decode(signature)
+    recovery_id = (serialized[0] - 27) & 0x03
+    message_hash = sha256(sha256(b"\x18Bitcoin Signed Message:\n" + compact.to_bytes(len(message)) + message).digest()).digest()
+    recoverable_sig = secp256k1.ecdsa_recoverable_signature_parse_compact(serialized[1:], recovery_id)
+    recovered_pubkey = ec.PublicKey(secp256k1.ecdsa_recover(recoverable_sig, message_hash)).sec().hex()
+
+    assert recovered_pubkey == embit_utils.get_pubkey_hex(seed.seed_bytes, derivation_path)

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -9,7 +9,7 @@ from base import FlowTestInvalidButtonDataSelectionException
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
-from seedsigner.views.view import MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
+from seedsigner.views.view import InvalidDerivationPathErrorView, MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
 from seedsigner.views import seed_views, scan_views, settings_views
 
 
@@ -572,6 +572,9 @@ class TestMessageSigningFlows(FlowTest):
     MAINNET_DERIVATION_PATH = "m/84h/0h/0h/0/0"
     TESTNET_DERIVATION_PATH = "m/84h/1h/0h/0/0"
     CUSTOM_DERIVATION_PATH = "m/99h/0/0"
+    BIP48_DERIVATION_PATH = "m/48h/0h/0h/2h/0/0"
+    TESTNET_BIP48_DERIVATION_PATH = "m/48h/1h/0h/2h/0/0"
+    BIP47_DERIVATION_PATH = "m/47h/0h/0h"
     SHORT_MESSAGE = "I attest that I control this bitcoin address blah blah blah"
     NO_WHITESPACE_MESSAGE = """{"height":841407,"lightning_bolt12":"lno1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}"""
     MULTIPAGE_MESSAGE = """Chancellor on brink of second bailout for banks
@@ -609,6 +612,18 @@ class TestMessageSigningFlows(FlowTest):
 
     def load_custom_derivation_into_decoder(self, view: View):
         self.load_signmessage_into_decoder(view, self.CUSTOM_DERIVATION_PATH, self.SHORT_MESSAGE)
+
+
+    def load_bip48_message_into_decoder(self, view: View):
+        self.load_signmessage_into_decoder(view, self.BIP48_DERIVATION_PATH, self.SHORT_MESSAGE)
+
+
+    def load_testnet_bip48_message_into_decoder(self, view: View):
+        self.load_signmessage_into_decoder(view, self.TESTNET_BIP48_DERIVATION_PATH, self.SHORT_MESSAGE)
+
+
+    def load_bip47_message_into_decoder(self, view: View):
+        self.load_signmessage_into_decoder(view, self.BIP47_DERIVATION_PATH, self.SHORT_MESSAGE)
 
 
     def inject_mesage_as_paged_message(self, view: View):
@@ -739,6 +754,35 @@ class TestMessageSigningFlows(FlowTest):
         self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST)
         expect_network_mismatch_error(self.load_short_message_into_decoder)
 
+        # The guard must still apply to the paths that now route to the pubkey screen. BIP48
+        # encodes its coin type in the same position, so a testnet BIP48 path is still caught.
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
+        expect_network_mismatch_error(self.load_testnet_bip48_message_into_decoder)
+
+
+    def test_sign_message_testnet_bip48_flow(self):
+        """
+        A testnet BIP48 path should sign on testnet. Note that the pubkey shown is not a
+        "testnet pubkey"; it differs from the mainnet one only because the testnet coin type
+        makes m/48h/1h/... a different derivation path than m/48h/0h/...
+        """
+        # Ensure message signing is enabled
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.TESTNET)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+            FlowStep(scan_views.ScanView, before_run=self.load_testnet_bip48_message_into_decoder),  # simulate read message QR; ret val is ignored
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmPubkeyView, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
+
 
     def test_sign_message_option_disabled(self):
         """
@@ -800,14 +844,17 @@ class TestMessageSigningFlows(FlowTest):
         assert self.controller.resume_main_flow is None
 
 
-    def test_sign_message_unsupported_derivation_flow(self):
+    def test_sign_message_non_single_sig_derivation_flow(self):
         """
-        Should redirect to NotYetImplementedView if a message's derivation path isn't yet supported
+        Derivation paths with no meaningful single sig address (BIP48 multisig, BIP47, Nostr,
+        custom) should route to SeedSignMessageConfirmPubkeyView instead of the address screen,
+        and still complete the signing flow.
         """
         # Ensure message signing is enabled
         self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
 
-        def expect_unsupported_derivation(load_message: Callable):
+        def expect_pubkey_confirmation(load_message: Callable):
             self.run_sequence([
                 FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
                 FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
@@ -815,11 +862,72 @@ class TestMessageSigningFlows(FlowTest):
                 FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
                 FlowStep(scan_views.ScanView, before_run=load_message),  # simulate read message QR; ret val is ignored
                 FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
-                FlowStep(seed_views.NotYetImplementedView),
+                FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+                FlowStep(seed_views.SeedSignMessageConfirmPubkeyView, screen_return_value=0),
+                FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),
+                FlowStep(MainMenuView),
+            ])
+            self.controller.discard_seed(0)
+
+        expect_pubkey_confirmation(self.load_custom_derivation_into_decoder)
+        expect_pubkey_confirmation(self.load_bip48_message_into_decoder)
+        expect_pubkey_confirmation(self.load_bip47_message_into_decoder)
+
+
+    def test_sign_message_standard_single_sig_still_confirms_address(self):
+        """
+        The pubkey screen is a fallback; BIP44/49/84/86 single sig paths must still confirm the
+        receive address they're signing for.
+        """
+        # Ensure message signing is enabled
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+            FlowStep(scan_views.ScanView, before_run=self.load_short_message_into_decoder),  # simulate read message QR; ret val is ignored
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmAddressView, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
+
+
+    def test_sign_message_invalid_derivation_flow(self):
+        """
+        A malformed derivation path is bad input from the scanned QR, not a SeedSigner failure.
+        It must land on InvalidDerivationPathErrorView rather than raising out of key derivation.
+        """
+        # Ensure message signing is enabled
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
+
+        def expect_invalid_derivation(derivation_path: str):
+            def load_message(view: View):
+                self.load_signmessage_into_decoder(view, derivation_path, self.SHORT_MESSAGE)
+
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),  # simulate read SeedQR; ret val is ignored
+                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+                FlowStep(scan_views.ScanView, before_run=load_message),  # simulate read message QR; ret val is ignored
+                FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+                FlowStep(InvalidDerivationPathErrorView),
                 FlowStep(MainMenuView),
             ])
 
-        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
-        expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
+            assert self.controller.resume_main_flow is None
+            self.controller.discard_seed(0)
+
+        expect_invalid_derivation("m/foo/bar")
+        expect_invalid_derivation("m/84h/0h/0h/0/-1")
+
+        # embit's parse_path accepts this index, but it blows up at derivation time
+        expect_invalid_derivation("m/84h/0h/0h/0/999999999999999999")
 
 


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Fixes #519.

Message signing only works for conventional single sig paths (BIP44/49/84/86). Everything else is rejected, and inconsistently: `m/48h/...` throws a bare `Exception("Not implemented")`, `m/45h/0/0` gets a "not supported" screen, and `m/1017h/...` dies on an uncaught `raise` in the confirm view. The root cause is that the confirm screen requires an address, which requires a script type that arbitrary paths don't have.

Approach and rationale discussed here: https://github.com/SeedSigner/seedsigner/issues/519#issuecomment-XXXXXXXXX

### Solution

For any path that isn't a conventional single sig one, confirm the signing **pubkey** instead of an address: seed fingerprint, derivation path, and the compressed pubkey at that exact path (new `SeedSignMessageConfirmPubkeyView`). Standard single sig paths are untouched and still confirm an address. Malformed paths from a scanned QR now route to a new `InvalidDerivationPathErrorView` instead of crashing.

### Additional Information

- BIP48 is deliberately not mapped to a script type; doing so would render a single sig address from a multisig path that no wallet displays.
- The pubkey is network-independent; testnet only differs because its coin type is a different path. The existing network-mismatch guard still applies.
- Replaces the following open PRs: #874 (BIP48), #891 (BIP47), #925 / #923 (any path).

### Screenshots

Review the message (unchanged):

<img width="240" height="240" alt="1-confirm-message" src="https://github.com/user-attachments/assets/88cc6746-1d61-4844-9aed-c3612193fe8a" />

Standard single sig path still confirms an address (unchanged; verified byte-identical):

<img width="240" height="240" alt="2-confirm-address-unchanged" src="https://github.com/user-attachments/assets/e62caa38-0e37-4ad7-b31a-99c67b928281" />

New pubkey confirmation for any other path (shown for a BIP48 path):

<img width="240" height="240" alt="3-confirm-pubkey-new" src="https://github.com/user-attachments/assets/d4d31c09-a833-4f1f-b4b0-2784dfb5ad7c" />

New error screen for a malformed derivation path:

<img width="240" height="240" alt="4-invalid-derivation-new" src="https://github.com/user-attachments/assets/9c7864df-2fc6-4618-a622-e5aa6e0d9ed4" />

---

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens
- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [x] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
- [x] I understand
