### PR TITLE
[bugfix] Minor error in `SeedFinalizeView` if/else `has_passphrase` logic

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -307,8 +307,9 @@ class SeedFinalizeView(View):
         super().__init__()
         self.seed = self.controller.storage.get_pending_seed()
 
-        if self.seed.get_fingerprint == "":
-            # Expected normal user flow
+        if not self.seed.has_passphrase:
+            # Expected normal user flow. A freshly-loaded seed has no passphrase yet, so
+            # we can just get the fingerprint directly.
             self.fingerprint = self.seed.get_fingerprint(network=self.settings.get_value(SettingsConstants.SETTING__NETWORK))
 
         else:


### PR DESCRIPTION
## Description

The current code's initial `if` branch has two errors, but important note: neither negatively affect the user. Despite being improperly pushed to the `else` branch, the outcome is the SAME in actual use.

### Problem 1:
`get_fingerprint` is a function, not a property. It is correctly called with parentheses. The current python is (mistakenly) testing if the function itself (not its return value) equals a string, which is inherently always `False`.

### Problem 2:
Even if `get_fingerprint` were a property, it would never equal the empty string.

It seems clear that the intention was instead to verify the expected state that the passphrase is empty when a seed is initially loaded (guaranteed to be the case in the main app; the `else` is only there for the unusual circumstance that the screenshot generator requires).

---

Blame: I haven't checked the git history but this is almost definitely a bug I created. Mea culpa.

--- 

### Solution

Trivial fix to check the correct condition in the initial `if`.

### Additional Information

This was discovered while testing on the esp32-P4's MicroPython port. Loading a new seed caused a ~0.5s delay before advancing to the next screen. That delay is not present on the Pi Zero.

While investigating, Claude found:

The current implementation re-derives the BIP-39 seed three times per seed load: once when the `Seed` is constructed at scan time, then twice more in the always-taken `else` branch (which strips and restores the passphrase, each `set_passphrase()` call triggering a fresh derivation).

BIP-39 derivation is a fixed 2048-round PBKDF2-HMAC-SHA512 — cheap against the Pi Zero's native library, but the dominant cost on the MicroPython target (ESP32-P4), where it becomes a visible post-scan pause. The fix takes the naked-seed path, deriving exactly once.

Measured on an ESP32-P4:

| | Derivations | Seed-load time |
| --- | --- | --- |
| Current | 3× | ~470 ms |
| Fixed | 1× | ~160 ms |

A single derivation (~155 ms) is spec-mandated and irreducible; this change removes only the two redundant ones, cutting the pause by roughly two-thirds. No effect on the Pi Zero beyond eliminating wasted work.


### Screenshots

n/a

---

This pull request is categorized as a:
- [x] Bug fix

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] N/A

Our existing FlowTests already cover this, but they couldn't detect the flaw in the `if` case because the outcome for the main app is successful through either `if`/`else` route. The only consequence is the noted performance churn on devices like the esp32-P4.

Confirmed that the screenshot generator still builds the SeedFinalizeView and SeedReviewPassphraseView screens as expected.

---

#### I tested this PR hands-on on the following platform(s):
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.