### PR TITLE
screenshot generator: add translation overflow scanner

### DIFF
--- a/tests/screenshot_generator/conftest.py
+++ b/tests/screenshot_generator/conftest.py
@@ -4,8 +4,21 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--locale", action="store", default=None)
+    parser.addoption("--overflow-scan", action="store_true", default=False)
+    parser.addoption("--overflow-json", action="store", default=None,
+                     help="also write the overflow events to this path as JSON")
 
 
 @pytest.fixture(scope='session')
 def target_locale(request):
     return request.config.option.locale
+
+
+@pytest.fixture(scope='session')
+def overflow_scan(request):
+    return request.config.option.overflow_scan
+
+
+@pytest.fixture(scope='session')
+def overflow_json(request):
+    return request.config.option.overflow_json

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -52,7 +52,7 @@ import warnings; warnings.warn = lambda *args, **kwargs: None
 
 # Dynamically generate a pytest test run for each locale
 @pytest.mark.parametrize("locale", [x for x, y in SettingsConstants.get_detected_languages()])
-def test_generate_all(locale, target_locale):
+def test_generate_all(locale, target_locale, overflow_scan, overflow_json):
     """
     `target_locale` is a fixture created in conftest.py via the `--locale` command line arg.
 
@@ -60,13 +60,13 @@ def test_generate_all(locale, target_locale):
     """
     if target_locale and locale != target_locale:
         pytest.skip(f"Skipping {locale}")
-    
+
     if not ImageFont.core.HAVE_RAQM:
         # We can't generate pixel-perfect screenshots that match what gets rendered on
         # the device if we don't have libraqm.
         pytest.fail("libraqm is not installed.")
-    
-    generate_screenshots(locale)
+
+    generate_screenshots(locale, overflow_scan=overflow_scan, overflow_json=overflow_json)
 
 
 
@@ -143,7 +143,7 @@ class SeedExportXpubQR_ScreenBrightnessView(seed_views.SeedExportXpubQRDisplayVi
 
 
 
-def generate_screenshots(locale):
+def generate_screenshots(locale, overflow_scan: bool = False, overflow_json: str = None):
     """
         The `Renderer` class is mocked so that calls in the normal code are ignored
         (necessary to avoid having it trying to wire up hardware dependencies).
@@ -490,6 +490,10 @@ def generate_screenshots(locale):
 
 
     def screencap_view(screenshot_config: ScreenshotConfig):
+        """
+        Render a single screenshot. Returns the View's Screen instance (if
+        available) for post-render inspection (e.g. the overflow scan).
+        """
         # Block until we have exclusive access to the screenshot renderer. Without this
         # we were occasionally running into confusing race conditions where the next
         # screenshot would begin rendering over the previous one. Claiming the lock
@@ -499,6 +503,7 @@ def generate_screenshots(locale):
 
         controller = Controller.get_instance()
         toast_thread = screenshot_config.toast_thread
+        view = None
         try:
             print(f"Running {screenshot_config.screenshot_name}")
             try:
@@ -507,8 +512,10 @@ def generate_screenshots(locale):
                 # Activate the (optional) context manager for this screenshot to activate
                 # any specialized mocks.
                 with screenshot_config.mock_context_manager():
-                    # Set up and run the target View
-                    screenshot_config.View_cls(**screenshot_config.view_kwargs).run()
+                    # Set up and run the target View. Keep the View instance so its
+                    # fully-constructed screen can be inspected after rendering.
+                    view = screenshot_config.View_cls(**screenshot_config.view_kwargs)
+                    view.run()
 
                 if screenshot_renderer.render_count == cur_count:
                     # The View didn't actually render anything
@@ -534,6 +541,8 @@ def generate_screenshots(locale):
             if toast_thread and toast_thread.is_alive():
                 toast_thread.stop()
                 toast_thread.join()
+
+        return getattr(view, 'screen', None)
 
 
     # Parse the main `l10n/messages.pot` for overall stats
@@ -566,6 +575,13 @@ def generate_screenshots(locale):
             from traceback import print_exc
             print_exc()
 
+    # Overflow scan setup; each flagged screen also remembers its section subdir
+    # so the composite can locate the rendered .png afterward.
+    all_overflow_events = []
+    screenshot_subdirs = {}
+    if overflow_scan or overflow_json:
+        from .overflow_scanner.overflow import scan_for_overflow, write_reports
+
     for section_name, screenshot_list in setup_screenshots(locale).items():
         subdir = section_name.lower().replace(" ", "_")
         screenshot_renderer.set_screenshot_path(os.path.join(screenshot_root, locale, subdir))
@@ -574,7 +590,14 @@ def generate_screenshots(locale):
         locale_readme += """<table style="border: 0;">"""
         locale_readme += f"""<tr><td align="center">"""
         for screenshot_config in screenshot_list:
-            screencap_view(screenshot_config)
+            screen = screencap_view(screenshot_config)
+
+            if (overflow_scan or overflow_json) and screen is not None:
+                events = scan_for_overflow(screen, screenshot_config.screenshot_name, locale)
+                if events:
+                    all_overflow_events.extend(events)
+                    screenshot_subdirs[screenshot_config.screenshot_name] = subdir
+
             locale_readme += """  <table align="left" style="border: 1px solid gray;">"""
             locale_readme += f"""<tr><td align="center">{screenshot_config.screenshot_name}<br/><br/><img src="{subdir}/{screenshot_config.screenshot_name}.png"></td></tr>"""
             locale_readme += """</table>\n"""
@@ -591,10 +614,14 @@ def generate_screenshots(locale):
     with open(os.path.join("tests", "screenshot_generator", "template.md"), 'r') as readme_template:
         main_readme = readme_template.read()
 
-    for locale, display_name in SettingsConstants.get_detected_languages():
-        main_readme += f"* [{display_name}]({locale}/README.md)\n"
+    for detected_locale, display_name in SettingsConstants.get_detected_languages():
+        main_readme += f"* [{display_name}]({detected_locale}/README.md)\n"
 
     with open(os.path.join(screenshot_root, "README.md"), 'w') as readme_file:
         readme_file.write(main_readme)
 
     print(f"Screenshots rendered: {screenshot_renderer.render_count}")
+
+    if overflow_scan or overflow_json:
+        write_reports(all_overflow_events, screenshot_subdirs, screenshot_root,
+                      locale, json_path=overflow_json, human_report=overflow_scan)

--- a/tests/screenshot_generator/overflow_scanner/README.md
+++ b/tests/screenshot_generator/overflow_scanner/README.md
@@ -1,0 +1,96 @@
+# Translation Overflow Scanner
+
+Detects layout overflow caused by translated text on SeedSigner's 240x240
+screens. Runs as part of the screenshot generator with zero production code
+changes.
+
+## What it detects
+
+- **Bounds overflow**: a component extends past the 240px canvas bottom.
+- **Body-vs-button collision**: body content overlaps bottom-anchored buttons
+  (only flagged when the overlap exceeds the English baseline).
+
+## How it works
+
+After each screen is fully constructed by the screenshot generator, the
+scanner inspects the live component positions (`screen_y`, `height`) to check
+for overflow. For fixed-height `TextArea` components, where text can render
+past the allocated box, it recomputes the true rendered height from the
+component's own attributes.
+
+Flagged component text is resolved back to its `msgid`/`msgstr` pair through
+the locale's `.po` catalog (parsed with Babel; plural forms map back to their
+singular `msgid`, and format strings whose placeholders were substituted at
+render time are matched by pattern).
+
+For each flagged screen a composite PNG is generated with:
+
+- English screenshot on the left, translated on the right
+- red (bounds) / yellow (collision) outlines on the overflow areas
+- the `msgid`, `msgstr`, and overflow amount in pixels
+
+## Usage
+
+### Single locale (via pytest)
+
+```bash
+PYTHONPATH=src python -m pytest tests/screenshot_generator/generator.py \
+    --locale ja --overflow-scan -s
+```
+
+### Machine-readable output (for CI)
+
+`--overflow-json <path>` writes the events as JSON, keyed by locale. An empty
+list means the locale was scanned and came up clean. It can be combined with
+`--overflow-scan` (human report + JSON) or used alone (JSON only, no
+composites):
+
+```bash
+PYTHONPATH=src python -m pytest tests/screenshot_generator/generator.py \
+    --locale ja --overflow-scan --overflow-json overflow.json -s
+```
+
+### Reviewing a translation change locally
+
+Point the translations submodule at the catalogs to check (e.g. check out the
+PR branch inside `src/seedsigner/resources/seedsigner-translations`), compile
+and scan. English must be rendered first so the composites have their
+left-hand side:
+
+```bash
+pybabel compile -d src/seedsigner/resources/seedsigner-translations/l10n -l ja --use-fuzzy
+PYTHONPATH=src python -m pytest tests/screenshot_generator/generator.py --locale en
+PYTHONPATH=src python -m pytest tests/screenshot_generator/generator.py \
+    --locale ja --overflow-scan -s
+```
+
+## Output
+
+```
+seedsigner-screenshots/
+  reports/
+    <locale>/
+      <ScreenName>_overflow.png    # annotated side-by-side composite
+      summary.txt                  # one line per issue
+```
+
+The core scanner lives in `overflow.py`: `scan_for_overflow()`, the msgid
+reverse lookup, the composite image generator and the report writers. Unit
+tests live in `tests/screenshot_generator/test_overflow_scanner.py` and run
+as part of the main suite.
+
+## Known false positives and limitations
+
+Overflow detection is advisory; a flagged screen needs human judgment:
+
+- Translation PRs must be based on a commit that includes the `fonts/`
+  directory in the translations submodule. Older PRs (predating
+  seedsigner-translations PR #65) render with wrong font metrics and need a
+  rebase onto `dev` first.
+- `PSBTOpReturnView_raw_hex_data` overflow is caused by the long hex payload,
+  not translation length. It appears in every locale identically.
+- Untranslated literals can overflow without being a translation defect, e.g.
+  `seedsigner.com` on `DonateView` is the same string in every locale.
+- Placeholder bugs in a translation (e.g. positional `{}` where the source
+  uses named `{mnemonic_length}`) crash at render time; that class of defect
+  is caught by the translations repo's placeholder check, not this scanner.

--- a/tests/screenshot_generator/overflow_scanner/overflow.py
+++ b/tests/screenshot_generator/overflow_scanner/overflow.py
@@ -1,0 +1,530 @@
+"""Translation overflow detection scanner.
+
+Scans fully-constructed Screen instances for layout overflow caused by
+translated text. Detects two kinds of issues:
+
+  1. Bounds overflow: a component extends past the 240px canvas bottom.
+  2. Body-vs-button collision: body content overlaps bottom-anchored buttons.
+
+All detection is post-construction inspection of live component geometry; no
+production GUI code is changed or involved.
+
+Known false positives (overflow is advisory, not a hard failure):
+
+  * Translation PRs based on a commit that predates the fonts/ submodule
+    reorganization (seedsigner-translations PR #65) render with wrong metrics.
+  * PSBTOpReturnView_raw_hex_data overflows because of the long hex payload,
+    identically in every locale; it is not a translation issue.
+  * Untranslated literals (e.g. "seedsigner.com" on DonateView) can overflow
+    in any locale without being a translation defect.
+"""
+import json
+import os
+import pathlib
+import re
+import shutil
+from dataclasses import asdict, dataclass
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+# SettingsEntryUpdateSelectionScreen already overlaps in English when there are
+# many options. Only flag when overflow exceeds this threshold.
+KNOWN_OVERLAP_PREFIXES = {
+    "SettingsEntryUpdateSelectionView_": 22,  # px; pre-existing EN overlap
+}
+
+
+@dataclass
+class OverflowEvent:
+    event_type: str          # "bounds" or "collision"
+    screen_name: str
+    locale: str
+    component_text: str      # rendered text on the component
+    overflow_px: int         # pixels past the boundary
+    component_type: str      # class name, e.g. "TextArea"
+    screen_y: int            # component's Y position
+    effective_height: int    # computed actual height
+    msgid: str = ""          # English source string (filled in post-scan)
+    msgstr: str = ""         # translated string (filled in post-scan)
+
+
+def get_true_text_height(textarea) -> int:
+    """
+    Recalculate actual rendered text height from TextArea instance attributes.
+    Mirrors the height calculation in components.py. For fixed-height
+    TextAreas, .height is the allocated box; the actual text may render past
+    it.
+    """
+    n = len(textarea.text_lines)
+    if n == 1:
+        h = textarea.text_height_above_baseline
+        if not textarea.height_ignores_below_baseline:
+            h += textarea.text_height_below_baseline
+    else:
+        h = (textarea.text_height_above_baseline * n
+             + textarea.line_spacing * (n - 1))
+        if not textarea.height_ignores_below_baseline:
+            h += textarea.text_lines[-1].get("px_below_baseline", 0)
+    return h
+
+
+def get_effective_height(component) -> int:
+    """Return the actual rendered height for a component."""
+    from seedsigner.gui.components import TextArea
+    if isinstance(component, TextArea):
+        return max(component.height or 0, get_true_text_height(component))
+    return component.height or 0
+
+
+def _get_component_text(component) -> str:
+    """Extract display text from a component, if it has one."""
+    return getattr(component, 'text', '') or ''
+
+
+def scan_for_overflow(screen, screen_name: str, locale: str,
+                      canvas_height: int = 240) -> list:
+    """
+    Scan all visual elements for bounds violations and body-vs-button
+    collisions. Returns a list of OverflowEvent instances.
+    """
+    events = []
+
+    def add_event(event_type, component_text, overflow_px, component_type,
+                  screen_y, effective_height):
+        events.append(OverflowEvent(
+            event_type=event_type,
+            screen_name=screen_name,
+            locale=locale,
+            component_text=component_text,
+            overflow_px=overflow_px,
+            component_type=component_type,
+            screen_y=screen_y,
+            effective_height=effective_height,
+        ))
+
+    has_buttons = hasattr(screen, 'buttons') and screen.buttons
+    has_scroll = getattr(screen, 'has_scroll_arrows', False)
+    is_bottom_list = getattr(screen, 'is_bottom_list', False)
+
+    # Determine known overlap threshold for this screen
+    acceptable_overlap = 0
+    for prefix, threshold in KNOWN_OVERLAP_PREFIXES.items():
+        if screen_name.startswith(prefix):
+            acceptable_overlap = threshold
+            break
+
+    # Check 1: Bounds overflow on components
+    for comp in screen.components:
+        comp_y = getattr(comp, 'screen_y', None)
+        if comp_y is None:
+            continue
+        eff_h = get_effective_height(comp)
+        if comp_y + eff_h > canvas_height:
+            add_event("bounds", _get_component_text(comp),
+                      comp_y + eff_h - canvas_height,
+                      type(comp).__name__, comp_y, eff_h)
+
+    # Bounds overflow on buttons (only when not scrollable)
+    if has_buttons and not has_scroll:
+        for btn in screen.buttons:
+            btn_h = btn.height or 0
+            if btn.screen_y + btn_h > canvas_height:
+                add_event("bounds", _get_component_text(btn),
+                          btn.screen_y + btn_h - canvas_height,
+                          type(btn).__name__, btn.screen_y, btn_h)
+
+    # Check 2: Body-vs-button collision
+    if has_buttons and is_bottom_list and not has_scroll:
+        # Find the top of the button area (accounting for scroll offset)
+        button_top_y = min(
+            btn.screen_y - getattr(btn, 'scroll_y', 0)
+            for btn in screen.buttons
+        )
+
+        button_set = set(id(btn) for btn in screen.buttons)
+        for comp in screen.components:
+            if id(comp) in button_set:
+                continue
+            comp_y = getattr(comp, 'screen_y', None)
+            if comp_y is None:
+                continue
+            eff_h = get_effective_height(comp)
+            overlap = comp_y + eff_h - button_top_y
+            if overlap > acceptable_overlap:
+                add_event("collision", _get_component_text(comp), overlap,
+                          type(comp).__name__, comp_y, eff_h)
+
+    # Bounds overflow on directly pasted images
+    for img, coords in screen.paste_images:
+        x, y = coords
+        if y + img.height > canvas_height:
+            add_event("bounds", "", y + img.height - canvas_height,
+                      "paste_image", y, img.height)
+
+    return events
+
+
+# msgid reverse lookup: rendered component text back to its English source
+# string, via the locale's .po catalog (parsed with Babel, cached per locale).
+
+_po_cache = {}
+
+
+def _po_path(locale: str) -> str:
+    repo_root = pathlib.Path(__file__).resolve().parents[3]
+    return os.path.join(repo_root, "src", "seedsigner", "resources",
+                        "seedsigner-translations", "l10n", locale,
+                        "LC_MESSAGES", "messages.po")
+
+
+def _load_translation_mapping(locale: str) -> dict:
+    """Return a msgstr -> msgid mapping for a locale, cached.
+
+    Every translated form (including each plural form) maps back to the
+    singular msgid, which is the key the source code and messages.pot use.
+    """
+    if locale in _po_cache:
+        return _po_cache[locale]
+
+    mapping = {}
+    path = _po_path(locale)
+    if os.path.exists(path):
+        from babel.messages.pofile import read_po
+        with open(path, "rb") as fh:
+            catalog = read_po(fh)
+        for message in catalog:
+            if not message.id:
+                # The header message has an empty id; skip it.
+                continue
+            if isinstance(message.id, (list, tuple)):
+                singular = message.id[0]
+                forms = message.string or ()
+            else:
+                singular = message.id
+                forms = (message.string,)
+            for form in forms:
+                if form:
+                    mapping[form] = singular
+
+    _po_cache[locale] = mapping
+    return mapping
+
+
+def reverse_lookup_msgid(text: str, locale: str) -> tuple:
+    """
+    Find the English msgid for a translated string.
+    Returns (msgid, msgstr). Falls back to pattern matching for format
+    strings, whose placeholders have already been substituted in the rendered
+    text.
+    """
+    if not text or locale == "en":
+        return (text, text)
+
+    mapping = _load_translation_mapping(locale)
+
+    # Direct match
+    if text in mapping:
+        return (mapping[text], text)
+
+    # Fallback for format strings: match each msgstr containing placeholders
+    # by replacing the {} / {name} fields with wildcards.
+    for msgstr, msgid in mapping.items():
+        if '{' not in msgstr:
+            continue
+        pattern_parts = re.split(r'\{[^}]*\}', msgstr)
+        pattern = '.+'.join(re.escape(p) for p in pattern_parts)
+        try:
+            if re.fullmatch(pattern, text, re.DOTALL):
+                return (msgid, msgstr)
+        except re.error:
+            continue
+
+    return ("", text)
+
+
+# Composite image generation
+
+def _get_annotation_font(size: int, locale: str) -> ImageFont.FreeTypeFont:
+    """Load a font that can render the locale's glyphs for composite annotations."""
+    from seedsigner.gui.components import GUIConstants, Fonts
+    font_name = GUIConstants.BASE_LOCALE_FONTS.get(locale, "OpenSans-Regular")
+    for font_dir in Fonts.font_paths:
+        path = os.path.join(font_dir, f"{font_name}.ttf")
+        if os.path.exists(path):
+            return ImageFont.truetype(path, size)
+    return ImageFont.load_default()
+
+
+def generate_composite_image(en_screenshot_path: str,
+                             translated_screenshot_path: str,
+                             events: list,
+                             screen_name: str) -> Image.Image:
+    """
+    Create a side-by-side composite image with EN on the left and translated
+    on the right. Draws red (bounds) / yellow (collision) outlines on the
+    translated side at overflow locations. Adds header and annotation text.
+    """
+    SCREEN_SIZE = 240
+    PADDING = 16
+    HEADER_HEIGHT = 60
+    TITLE_FONT_SIZE = 20
+    ANNOTATION_FONT_SIZE = 18
+    ANNOTATION_LINE_HEIGHT = ANNOTATION_FONT_SIZE + 6
+    ANNOTATION_FIELD_SPACING = ANNOTATION_LINE_HEIGHT + 8
+    ANNOTATION_COLOR = (192, 192, 192)
+    LABEL_COLOR = (230, 180, 80)
+
+    try:
+        en_img = Image.open(en_screenshot_path).convert('RGB')
+    except (FileNotFoundError, OSError):
+        en_img = Image.new('RGB', (SCREEN_SIZE, SCREEN_SIZE), color=(40, 40, 40))
+        draw = ImageDraw.Draw(en_img)
+        draw.text((10, 110), "EN screenshot\nnot available", fill=(128, 128, 128))
+
+    translated_img = Image.open(translated_screenshot_path).convert('RGB')
+
+    # Draw debug outlines on a copy of the translated screenshot
+    annotated = translated_img.copy()
+    draw = ImageDraw.Draw(annotated)
+    for event in events:
+        y_top = max(0, event.screen_y)
+        y_bottom = min(event.screen_y + event.effective_height, SCREEN_SIZE - 1)
+        if y_bottom <= y_top:
+            continue
+        color = "red" if event.event_type == "bounds" else "yellow"
+        draw.rectangle(
+            [(0, y_top), (SCREEN_SIZE - 1, y_bottom)],
+            outline=color, width=1
+        )
+
+    # Pick fonts that can render the locale's glyphs
+    locale = events[0].locale if events else "en"
+    title_font = _get_annotation_font(TITLE_FONT_SIZE, locale)
+    annotation_font = _get_annotation_font(ANNOTATION_FONT_SIZE, locale)
+
+    total_width = PADDING + SCREEN_SIZE + PADDING + SCREEN_SIZE + PADDING
+    usable_text_width = total_width - 2 * PADDING
+
+    # Build annotation lines. Each entry is (text, is_field_start, label_prefix).
+    # The label_prefix (if set) renders in a different color than the content.
+    annotation_lines = []
+
+    def _add_wrapped(text, font, width, is_first, label_prefix=""):
+        if label_prefix:
+            # Measure label width so wrapped content accounts for it
+            label_w = font.getbbox(label_prefix)[2] - font.getbbox(label_prefix)[0]
+            wrapped = _wrap_text(text, font, width - label_w)
+            annotation_lines.append((wrapped[0], is_first, label_prefix))
+        else:
+            wrapped = _wrap_text(text, font, width)
+            annotation_lines.append((wrapped[0], is_first, ""))
+        for cont in wrapped[1:]:
+            annotation_lines.append((cont, False, ""))
+
+    for event in events:
+        _add_wrapped(
+            f"[{event.event_type.upper()}] {event.component_type}: overflow {event.overflow_px}px",
+            annotation_font, usable_text_width, is_first=True)
+        if event.msgid:
+            _add_wrapped(
+                event.msgid,
+                annotation_font, usable_text_width, is_first=True, label_prefix="msgid: ")
+        if event.msgstr:
+            _add_wrapped(
+                event.msgstr,
+                annotation_font, usable_text_width, is_first=True, label_prefix="msgstr: ")
+
+    annotation_height = PADDING
+    for i, (_, is_field_start, _label) in enumerate(annotation_lines):
+        annotation_height += ANNOTATION_FIELD_SPACING if (is_field_start and i > 0) else ANNOTATION_LINE_HEIGHT
+    annotation_height += PADDING
+
+    total_height = HEADER_HEIGHT + SCREEN_SIZE + annotation_height
+
+    composite = Image.new('RGB', (total_width, total_height), color=(0, 0, 0))
+    comp_draw = ImageDraw.Draw(composite)
+
+    # Header, centered
+    title_bbox = title_font.getbbox(screen_name)
+    title_w = title_bbox[2] - title_bbox[0]
+    comp_draw.text(((total_width - title_w) // 2, PADDING), screen_name,
+                   fill=(255, 255, 255), font=title_font)
+
+    # Paste screenshots with border outlines
+    en_x, en_y = PADDING, HEADER_HEIGHT
+    tr_x, tr_y = PADDING + SCREEN_SIZE + PADDING, HEADER_HEIGHT
+    composite.paste(en_img, (en_x, en_y))
+    composite.paste(annotated, (tr_x, tr_y))
+    border_color = (80, 80, 80)
+    comp_draw.rectangle([(en_x - 1, en_y - 1), (en_x + SCREEN_SIZE, en_y + SCREEN_SIZE)], outline=border_color)
+    comp_draw.rectangle([(tr_x - 1, tr_y - 1), (tr_x + SCREEN_SIZE, tr_y + SCREEN_SIZE)], outline=border_color)
+
+    # Annotations
+    y = HEADER_HEIGHT + SCREEN_SIZE + PADDING
+    for i, (text, is_field_start, label_prefix) in enumerate(annotation_lines):
+        if is_field_start and i > 0:
+            y += ANNOTATION_FIELD_SPACING - ANNOTATION_LINE_HEIGHT
+        x = PADDING
+        if label_prefix:
+            comp_draw.text((x, y), label_prefix, fill=LABEL_COLOR, font=annotation_font)
+            label_bbox = annotation_font.getbbox(label_prefix)
+            x += label_bbox[2] - label_bbox[0]
+        comp_draw.text((x, y), text, fill=ANNOTATION_COLOR, font=annotation_font)
+        y += ANNOTATION_LINE_HEIGHT
+
+    return composite
+
+
+def _wrap_text(text: str, font, max_width: int) -> list:
+    """Word-wrap text to fit within max_width pixels. Splits on newlines
+    first, then wraps each line on word boundaries. Falls back to
+    character-level breaking for words that exceed max_width (common with
+    CJK)."""
+    result = []
+    for paragraph in text.split('\n'):
+        if not paragraph:
+            result.append("")
+            continue
+        result.extend(_wrap_line(paragraph, font, max_width))
+    return result or [""]
+
+
+def _wrap_line(text: str, font, max_width: int) -> list:
+    """Wrap a single line of text (no embedded newlines)."""
+    words = text.split(' ')
+    lines = []
+    current = ""
+    for word in words:
+        test = f"{current} {word}".strip() if current else word
+        bbox = font.getbbox(test)
+        if bbox[2] - bbox[0] <= max_width:
+            current = test
+        else:
+            if current:
+                lines.append(current)
+            # Check if this single word fits; if not, break it by character
+            bbox = font.getbbox(word)
+            if bbox[2] - bbox[0] <= max_width:
+                current = word
+            else:
+                current = ""
+                for char in word:
+                    test = current + char
+                    bbox = font.getbbox(test)
+                    if bbox[2] - bbox[0] <= max_width:
+                        current = test
+                    else:
+                        if current:
+                            lines.append(current)
+                        current = char
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
+def write_summary(events: list, output_dir: str, locale: str) -> str:
+    """Write a summary.txt with one line per overflow event."""
+    os.makedirs(output_dir, exist_ok=True)
+    summary_path = os.path.join(output_dir, "summary.txt")
+
+    with open(summary_path, 'w', encoding='utf-8') as f:
+        f.write(f"Overflow Report for locale: {locale}\n")
+        f.write(f"Total issues: {len(events)}\n")
+        f.write("-" * 80 + "\n\n")
+
+        for event in sorted(events, key=lambda e: -e.overflow_px):
+            msgid_str = f' | msgid: {event.msgid}' if event.msgid else ''
+            msgstr_str = f' | msgstr: {event.msgstr}' if event.msgstr else ''
+            f.write(
+                f"[{event.event_type.upper():9s}] {event.screen_name} | "
+                f"{event.component_type} | overflow: {event.overflow_px}px"
+                f"{msgid_str}{msgstr_str}\n"
+            )
+
+    return summary_path
+
+
+def write_json(events: list, path: str, locale: str) -> str:
+    """Merge this locale's events into a machine-readable report at ``path``.
+
+    The file maps locale -> list of event dicts, so a multi-locale run
+    accumulates each locale's results and rescanning a locale replaces its
+    entry. An empty list still gets written: it records "scanned and clean",
+    which downstream consumers must be able to distinguish from "not scanned".
+    """
+    data = {}
+    if os.path.exists(path):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+
+    data[locale] = [asdict(event) for event in sorted(events, key=lambda e: -e.overflow_px)]
+
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False, sort_keys=True)
+        fh.write("\n")
+    return path
+
+
+def resolve_msgids(events: list, locale: str):
+    """Fill each event's msgid/msgstr by looking up its rendered text."""
+    for event in events:
+        if event.component_text:
+            event.msgid, event.msgstr = reverse_lookup_msgid(event.component_text, locale)
+
+
+def write_reports(events: list, screenshot_subdirs: dict, screenshot_root: str,
+                  locale: str, json_path: str = None, human_report: bool = True):
+    """Write all overflow outputs for one locale's scan.
+
+    ``screenshot_subdirs`` maps each flagged screen name to its section subdir
+    so the composites can locate the rendered .png files. When ``json_path``
+    is set the events are merged into that JSON report. ``human_report``
+    controls summary.txt and the composite images, written under
+    ``<screenshot_root>/reports/<locale>/`` (cleared first, so a rescan never
+    leaves stale composites behind).
+    """
+    resolve_msgids(events, locale)
+
+    if json_path:
+        write_json(events, json_path, locale)
+        print(f"Overflow JSON written to: {json_path}")
+
+    if not human_report:
+        return
+
+    report_dir = os.path.join(screenshot_root, "reports", locale)
+    if os.path.isdir(report_dir):
+        shutil.rmtree(report_dir)
+
+    if not events:
+        print("\nNo overflow issues detected.")
+        return
+
+    summary_path = write_summary(events, report_dir, locale)
+    print(f"\nOverflow report written to: {summary_path}")
+
+    # Composite images (the EN screenshots must already have been rendered)
+    en_base = os.path.join(screenshot_root, "en")
+    composites_generated = 0
+    events_by_screen = {}
+    for event in events:
+        events_by_screen.setdefault(event.screen_name, []).append(event)
+
+    for screen_name, screen_events in events_by_screen.items():
+        subdir = screenshot_subdirs.get(screen_name, "")
+        en_path = os.path.join(en_base, subdir, f"{screen_name}.png")
+        translated_path = os.path.join(screenshot_root, locale, subdir, f"{screen_name}.png")
+
+        if os.path.exists(translated_path):
+            composite = generate_composite_image(en_path, translated_path, screen_events, screen_name)
+            composite.save(os.path.join(report_dir, f"{screen_name}_overflow.png"))
+            composites_generated += 1
+
+    print(f"Overflow issues found: {len(events)}")
+    print(f"Composite images generated: {composites_generated}")

--- a/tests/screenshot_generator/test_overflow_scanner.py
+++ b/tests/screenshot_generator/test_overflow_scanner.py
@@ -1,0 +1,371 @@
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+# Prevent importing modules w/Raspi hardware dependencies.
+# These must precede any SeedSigner imports.
+sys.modules['seedsigner.gui.renderer'] = MagicMock()
+sys.modules['seedsigner.hardware.buttons'] = MagicMock()
+sys.modules['seedsigner.hardware.st7789_mpy'] = MagicMock()
+sys.modules['seedsigner.hardware.ili9341'] = MagicMock()
+
+from screenshot_generator.overflow_scanner import overflow
+
+
+
+@dataclass
+class FakeComponent:
+    """Positioned like a gui component, but not a TextArea, so its effective
+    height is just .height."""
+    screen_y: int = 0
+    height: int = 0
+    text: str = ""
+
+
+@dataclass
+class FakeTextLine:
+    px_below_baseline: int = 0
+
+    def get(self, key, default=0):
+        return getattr(self, key, default)
+
+
+@dataclass
+class FakeScreen:
+    components: List = field(default_factory=list)
+    buttons: List = field(default_factory=list)
+    paste_images: List = field(default_factory=list)
+    has_scroll_arrows: bool = False
+    is_bottom_list: bool = False
+
+
+
+class TestGetTrueTextHeight:
+    def make_textarea(self, num_lines, above=20, below=5, spacing=4, ignores_below=False):
+        textarea = MagicMock()
+        textarea.text_lines = [FakeTextLine(px_below_baseline=below) for _ in range(num_lines)]
+        textarea.text_height_above_baseline = above
+        textarea.text_height_below_baseline = below
+        textarea.line_spacing = spacing
+        textarea.height_ignores_below_baseline = ignores_below
+        return textarea
+
+
+    def test_single_line(self):
+        assert overflow.get_true_text_height(self.make_textarea(1)) == 25  # 20 + 5
+
+
+    def test_single_line_ignores_below_baseline(self):
+        assert overflow.get_true_text_height(self.make_textarea(1, ignores_below=True)) == 20
+
+
+    def test_multi_line(self):
+        # 3 lines: 3*20 above + 2*4 spacing + 5 below the last line
+        assert overflow.get_true_text_height(self.make_textarea(3)) == 73
+
+
+
+class TestScanForOverflow:
+    def test_clean_screen_yields_no_events(self):
+        screen = FakeScreen(components=[FakeComponent(screen_y=50, height=100)])
+        assert overflow.scan_for_overflow(screen, "SomeView", "de") == []
+
+
+    def test_component_past_canvas_bottom_is_bounds_overflow(self):
+        screen = FakeScreen(components=[FakeComponent(screen_y=200, height=52, text="zu lang")])
+        events = overflow.scan_for_overflow(screen, "SomeView", "de")
+
+        assert len(events) == 1
+        assert events[0].event_type == "bounds"
+        assert events[0].overflow_px == 12
+        assert events[0].component_text == "zu lang"
+        assert events[0].screen_name == "SomeView"
+        assert events[0].locale == "de"
+
+
+    def test_component_ending_exactly_at_bottom_is_fine(self):
+        screen = FakeScreen(components=[FakeComponent(screen_y=140, height=100)])
+        assert overflow.scan_for_overflow(screen, "SomeView", "de") == []
+
+
+    def test_button_overflow_flagged_only_without_scroll_arrows(self):
+        button = FakeComponent(screen_y=230, height=32)
+        screen = FakeScreen(buttons=[button])
+        events = overflow.scan_for_overflow(screen, "SomeView", "de")
+        assert len(events) == 1
+        assert events[0].event_type == "bounds"
+
+        # Scroll arrows mean the button is reachable by scrolling: not a defect
+        screen = FakeScreen(buttons=[button], has_scroll_arrows=True)
+        assert overflow.scan_for_overflow(screen, "SomeView", "de") == []
+
+
+    def test_body_colliding_with_buttons(self):
+        body = FakeComponent(screen_y=100, height=100, text="langer Text")
+        button = FakeComponent(screen_y=190, height=40)
+        screen = FakeScreen(components=[body], buttons=[button], is_bottom_list=True)
+        events = overflow.scan_for_overflow(screen, "SomeView", "de")
+
+        assert len(events) == 1
+        assert events[0].event_type == "collision"
+        assert events[0].overflow_px == 10  # body bottom 200 vs button top 190
+
+
+    def test_known_overlap_prefix_raises_collision_threshold(self):
+        body = FakeComponent(screen_y=100, height=100, text="opts")
+        button = FakeComponent(screen_y=190, height=40)
+        screen = FakeScreen(components=[body], buttons=[button], is_bottom_list=True)
+
+        # 10px overlap is within the known 22px EN baseline for this screen
+        assert overflow.scan_for_overflow(screen, "SettingsEntryUpdateSelectionView_persistent", "de") == []
+
+        # but not past it
+        body.height = 115  # 25px overlap
+        events = overflow.scan_for_overflow(screen, "SettingsEntryUpdateSelectionView_persistent", "de")
+        assert len(events) == 1
+
+
+    def test_pasted_image_overflow(self):
+        img = MagicMock()
+        img.height = 100
+        screen = FakeScreen(paste_images=[(img, (0, 180))])
+        events = overflow.scan_for_overflow(screen, "SomeView", "de")
+
+        assert len(events) == 1
+        assert events[0].component_type == "paste_image"
+        assert events[0].overflow_px == 40
+
+
+
+PO_HEADER = 'msgid ""\nmsgstr ""\n"Content-Type: text/plain; charset=UTF-8\\n"\n\n'
+
+# Entries kept as escapes so this file stays ASCII: "L\u00e4nge" etc.
+PO_BODY = (
+    'msgid "Passphrase"\n'
+    'msgstr "Passphrase eingeben"\n\n'
+    'msgid "Enter {name} length"\n'
+    'msgstr "L\u00e4nge von {name} eingeben"\n\n'
+    'msgid "{} word"\n'
+    'msgid_plural "{} words"\n'
+    'msgstr[0] "{} Wort"\n'
+    'msgstr[1] "{} W\u00f6rter"\n'
+)
+
+
+@pytest.fixture
+def po_mapping(tmp_path, monkeypatch):
+    po_file = tmp_path / "messages.po"
+    po_file.write_text(PO_HEADER + PO_BODY, encoding="utf-8")
+    monkeypatch.setattr(overflow, "_po_path", lambda locale: str(po_file))
+    monkeypatch.setattr(overflow, "_po_cache", {})
+
+
+
+class TestReverseLookupMsgid:
+    def test_direct_match(self, po_mapping):
+        assert overflow.reverse_lookup_msgid("Passphrase eingeben", "de") == \
+            ("Passphrase", "Passphrase eingeben")
+
+
+    def test_english_passthrough(self):
+        assert overflow.reverse_lookup_msgid("Some text", "en") == ("Some text", "Some text")
+
+
+    def test_format_string_with_substituted_placeholder(self, po_mapping):
+        # The rendered text has the placeholder already filled in
+        msgid, msgstr = overflow.reverse_lookup_msgid("L\u00e4nge von Seed A eingeben", "de")
+        assert msgid == "Enter {name} length"
+        assert msgstr == "L\u00e4nge von {name} eingeben"
+
+
+    def test_plural_forms_map_to_singular_msgid(self, po_mapping):
+        assert overflow.reverse_lookup_msgid("{} Wort", "de")[0] == "{} word"
+        assert overflow.reverse_lookup_msgid("{} W\u00f6rter", "de")[0] == "{} word"
+
+
+    def test_unknown_text_returns_empty_msgid(self, po_mapping):
+        assert overflow.reverse_lookup_msgid("nicht vorhanden", "de") == ("", "nicht vorhanden")
+
+
+    def test_missing_po_file_degrades_gracefully(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(overflow, "_po_path", lambda locale: str(tmp_path / "nope.po"))
+        monkeypatch.setattr(overflow, "_po_cache", {})
+        assert overflow.reverse_lookup_msgid("irgendwas", "de") == ("", "irgendwas")
+
+
+
+class TestWrapText:
+    def setup_method(self):
+        from PIL import ImageFont
+        self.font = ImageFont.load_default()
+
+
+    def test_short_text_is_one_line(self):
+        assert overflow._wrap_text("hello", self.font, 500) == ["hello"]
+
+
+    def test_wraps_on_word_boundaries(self):
+        lines = overflow._wrap_text("aaa bbb ccc ddd", self.font, 30)
+        assert len(lines) > 1
+        assert "".join(lines).replace(" ", "") == "aaabbbcccddd"
+
+
+    def test_unbroken_word_falls_back_to_character_break(self):
+        # No spaces to break on (the CJK case): must still wrap
+        lines = overflow._wrap_text("a" * 200, self.font, 40)
+        assert len(lines) > 1
+        assert "".join(lines) == "a" * 200
+
+
+    def test_preserves_explicit_newlines(self):
+        assert overflow._wrap_text("one\ntwo", self.font, 500) == ["one", "two"]
+
+
+
+class TestReports:
+    def make_event(self, **over):
+        defaults = dict(
+            event_type="bounds", screen_name="SomeView", locale="de",
+            component_text="text", overflow_px=12, component_type="TextArea",
+            screen_y=200, effective_height=52, msgid="src", msgstr="text",
+        )
+        defaults.update(over)
+        return overflow.OverflowEvent(**defaults)
+
+
+    def test_write_summary(self, tmp_path):
+        events = [self.make_event(), self.make_event(event_type="collision", overflow_px=30)]
+        path = overflow.write_summary(events, str(tmp_path), "de")
+
+        content = open(path, encoding="utf-8").read()
+        assert "Total issues: 2" in content
+        # Sorted by descending overflow
+        assert content.index("30px") < content.index("12px")
+
+
+    def test_write_json_round_trip(self, tmp_path):
+        path = str(tmp_path / "overflow.json")
+        overflow.write_json([self.make_event()], path, "de")
+
+        data = json.loads(open(path, encoding="utf-8").read())
+        assert list(data.keys()) == ["de"]
+        assert data["de"][0]["event_type"] == "bounds"
+        assert data["de"][0]["overflow_px"] == 12
+        assert data["de"][0]["msgid"] == "src"
+
+
+    def test_write_json_merges_locales_and_replaces_rescans(self, tmp_path):
+        path = str(tmp_path / "overflow.json")
+        overflow.write_json([self.make_event(locale="de")], path, "de")
+        overflow.write_json([self.make_event(locale="ja"), self.make_event(locale="ja")], path, "ja")
+        # Rescan of de comes up clean; its entry must be replaced, not appended
+        overflow.write_json([], path, "de")
+
+        data = json.loads(open(path, encoding="utf-8").read())
+        assert data["de"] == []
+        assert len(data["ja"]) == 2
+
+
+    def test_write_json_empty_scan_still_records_the_locale(self, tmp_path):
+        path = str(tmp_path / "overflow.json")
+        overflow.write_json([], path, "de")
+
+        data = json.loads(open(path, encoding="utf-8").read())
+        assert data == {"de": []}
+
+
+    def test_write_json_recovers_from_corrupt_file(self, tmp_path):
+        path = tmp_path / "overflow.json"
+        path.write_text("{ not json", encoding="utf-8")
+        overflow.write_json([self.make_event()], str(path), "de")
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert len(data["de"]) == 1
+
+
+
+class TestCompositeImage:
+    def test_composite_layout(self, tmp_path):
+        from PIL import Image
+
+        en_path = tmp_path / "en.png"
+        tr_path = tmp_path / "tr.png"
+        Image.new("RGB", (240, 240), color=(10, 10, 10)).save(en_path)
+        Image.new("RGB", (240, 240), color=(20, 20, 20)).save(tr_path)
+
+        event = overflow.OverflowEvent(
+            event_type="bounds", screen_name="SomeView", locale="de",
+            component_text="text", overflow_px=12, component_type="TextArea",
+            screen_y=200, effective_height=52, msgid="src", msgstr="text")
+        composite = overflow.generate_composite_image(
+            str(en_path), str(tr_path), [event], "SomeView")
+
+        # Side-by-side + padding wide; taller than one screen (header + annotations)
+        assert composite.width == 16 + 240 + 16 + 240 + 16
+        assert composite.height > 240
+
+
+    def test_missing_en_screenshot_uses_placeholder(self, tmp_path):
+        from PIL import Image
+
+        tr_path = tmp_path / "tr.png"
+        Image.new("RGB", (240, 240), color=(20, 20, 20)).save(tr_path)
+
+        composite = overflow.generate_composite_image(
+            str(tmp_path / "missing.png"), str(tr_path), [], "SomeView")
+        assert composite.width == 528
+
+
+class TestWriteReports:
+    def setup_screens(self, tmp_path):
+        from PIL import Image
+        for rel in ["en/section_a/SomeView.png", "de/section_a/SomeView.png"]:
+            path = tmp_path / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            Image.new("RGB", (240, 240), color=(10, 10, 10)).save(path)
+
+    def make_event(self):
+        return overflow.OverflowEvent(
+            event_type="bounds", screen_name="SomeView", locale="de",
+            component_text="zu lang", overflow_px=12, component_type="TextArea",
+            screen_y=200, effective_height=52)
+
+    def test_full_report(self, tmp_path, monkeypatch):
+        # No .po available: msgid resolution degrades to an empty msgid
+        monkeypatch.setattr(overflow, "_po_path", lambda locale: str(tmp_path / "nope.po"))
+        monkeypatch.setattr(overflow, "_po_cache", {})
+        self.setup_screens(tmp_path)
+        json_path = tmp_path / "overflow.json"
+
+        overflow.write_reports([self.make_event()], {"SomeView": "section_a"},
+                               str(tmp_path), "de", json_path=str(json_path))
+
+        report_dir = tmp_path / "reports" / "de"
+        assert (report_dir / "summary.txt").exists()
+        assert (report_dir / "SomeView_overflow.png").exists()
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert data["de"][0]["msgstr"] == "zu lang"
+
+    def test_rescan_clears_stale_report(self, tmp_path):
+        self.setup_screens(tmp_path)
+        stale = tmp_path / "reports" / "de" / "OldView_overflow.png"
+        stale.parent.mkdir(parents=True)
+        stale.write_bytes(b"stale")
+
+        overflow.write_reports([], {}, str(tmp_path), "de")
+
+        assert not stale.exists()
+
+    def test_json_only_mode_writes_no_human_report(self, tmp_path):
+        self.setup_screens(tmp_path)
+        json_path = tmp_path / "overflow.json"
+
+        overflow.write_reports([], {}, str(tmp_path), "de",
+                               json_path=str(json_path), human_report=False)
+
+        assert json.loads(json_path.read_text(encoding="utf-8")) == {"de": []}
+        assert not (tmp_path / "reports").exists()


### PR DESCRIPTION
> [!NOTE]
> Most of the diff in this PR is ~900 lines in the test suite.

## Description

### Problem or Issue being addressed

Translated text can silently break layouts: a German or Thai string that is longer than its English source can run past the bottom of the canvas or under the bottom-anchored buttons. Today nothing detects this; it is only caught if a human happens to eyeball the right screenshot in the right locale.

### Solution

Adapted from @kdmukai's overflow scanner, which we had been running manually against each translation PR; this integrates it into the screenshot generator so it can run unattended in CI, activated with:

```bash
pytest tests/screenshot_generator/generator.py --locale <loc> --overflow-scan [--overflow-json <path>]
```

After each screen is fully constructed, the scanner inspects the live component geometry (no production GUI code is touched) and flags:

- **Bounds overflow**: a component extends past the 240px canvas bottom. For fixed-height `TextArea`s, where text can render past the allocated box, the true rendered height is recomputed from the component's own attributes.
- **Body-vs-button collision**: body content overlaps bottom-anchored buttons, with a threshold allowance for screens that already overlap in English.

Flagged text is resolved back to its `msgid`/`msgstr` through the locale's `.po` catalog via Babel (plural forms map to their singular msgid; format strings whose placeholders were substituted at render time are matched by pattern). Each flagged screen gets an annotated EN-vs-translated composite PNG plus a `summary.txt` under `seedsigner-screenshots/reports/<locale>/`, and `--overflow-json` additionally emits the events as JSON keyed by locale for machine consumption (an empty list means scanned-and-clean).

This is the main-repo half of the translation-review automation: the seedsigner-translations repo's review workflow invokes the scanner via these pytest flags on every translation PR. The PR is fully self-contained and useful on its own.

### Additional Information

Overflow detection is advisory by nature; the README documents the known false-positive classes (untranslated literals like `seedsigner.com`, the long-hex `PSBTOpReturnView` case, and stale-fonts submodule states). Placeholder bugs that crash at render time are out of scope here; they are caught by a separate blocking check in the translations repo.

### Screenshots

Example scanner output (annotated EN-vs-translated composite for a current `de` collision):

<img width="528" height="492" alt="PSBTNoChangeWarningView_overflow" src="https://github.com/user-attachments/assets/b057cb70-2b57-43c9-9c81-cd1243d18e11" />

---

This pull request is categorized as a:
- [x] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens
- [x] N/A

---

#### I added or updated tests
- [x] Yes

---

#### I tested this PR hands-on on the following platform(s):
- [x] Screenshot Generator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand
