### PR TITLE
[CI] Fix for build.yml and writing `version.json`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,15 +83,9 @@ jobs:
             echo "img_version=os${os_version}_sw${source_version}"| tee -a $GITHUB_ENV
           fi
 
-      - name: delete unnecessary files
-        # The seedsigner-os buildroot overlay only needs src/; drop everything
-        # else from the seedsigner checkout (tests, docs, tooling, .git, etc.)
-        # to keep the overlay minimal.
-        run: |
-          cd seedsigner-os/opt/rootfs-overlay/opt
-          find . -mindepth 1 -maxdepth 1 ! -name src -exec rm -rf {} +
-          ls -la .
-          ls -la src
+      # NOTE: trimming the overlay down to src/ is deliberately left to seedsigner-os
+      # build.sh (delete_unnecessary_files). It needs the .git/ and tools/ we would
+      # otherwise delete here in order to write version.json first.
 
       - name: restore build cache
         uses: actions/cache@v4
@@ -124,6 +118,15 @@ jobs:
             seedsigner-os-build \
             --${{ matrix.target }} --skip-repo --no-clean
           sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/buildroot_dl ~/.buildroot-ccache/
+
+      # version.json is written by seedsigner-os build.sh. If it is missing or has a
+      # null field the app raises at the splash screen, which looks like an
+      # unrecoverable boot hang, so fail the build rather than publish the image.
+      - name: verify version.json
+        working-directory: seedsigner-os/opt/rootfs-overlay/opt
+        run: |
+          cat src/seedsigner/version.json
+          jq -e '.name and .fork and .short_commit_hash and .timestamp' src/seedsigner/version.json
 
       - name: list image (before rename)
         run: |


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Build images (.img files) produced by the SeedSigner CI build action hang at the logo after being flashed, even though the build passes.

#858 added a Version screen that reads `src/seedsigner/version.json` during startup. If the file is missing or incomplete, the resulting exception terminates the app.

The `delete unnecessary files` step reduces the checkout to `src/` before the build container starts:

```bash
cd seedsigner-os/opt/rootfs-overlay/opt
find . -mindepth 1 -maxdepth 1 ! -name src -exec rm -rf {} +
```

This removes `.git/` and `tools/`, which `tools/write_versionfile.py` needs to generate `version.json`. The build log confirms that only `src/` remains when the container runs.

### Solution

Remove the `delete unnecessary files` workflow step. The updated seedsigner-os `build.sh` writes the version file first, then calls `delete_unnecessary_files()` before Buildroot packages the image.

I checked its removal list against every top-level entry in this repository. `.git/`, `tools/`, and the other unnecessary files are removed before `make`, so they do not reach the image.

After the build, validate the generated file with `jq`:

```bash
jq -e '.name and .fork and .short_commit_hash and .timestamp' src/seedsigner/version.json
```

A failed version write still stops the build immediately. This additional check catches an incomplete file that might otherwise ship in an unbootable image.

### Additional Information

This requires the matching seedsigner-os PR SeedSigner/seedsigner-os#115 to be merged first. It runs the version-writing step during `--skip-repo` builds and sets Git's `safe.directory` so the container can read the version data.

### Screenshots

N/A. This PR only changes the CI build workflow.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran pytest locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I’m a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand