### PR TITLE
tests: Added FlowTests for the Seed Backup Verification Flow

### DIFF
--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -603,6 +603,42 @@ class TestSeedFlows(FlowTest):
 
         self.run_sequence(sequence, initial_destination_view_args=dict(seed=seed))
 
+    def test_keep_seed_flow(self):
+        """Verify clicking KEEP on SeedDiscardView returns to the correct view."""
+
+        from seedsigner.views import tools_views
+        mnemonic = ["abandon"] * 11 + ["about"]
+
+        # Flow 1: Pending Seed -> Keep -> SeedFinalizeView
+        # The only way to reach SeedDiscardView with a pending seed is from ToolsCalcFinalWordDoneView
+        self.controller.storage.init_pending_mnemonic(len(mnemonic))
+        for i, word in enumerate(mnemonic):
+            self.controller.storage.update_pending_mnemonic(word, i)
+
+        self.run_sequence(
+            sequence=[
+                FlowStep(tools_views.ToolsCalcFinalWordDoneView, button_data_selection=tools_views.ToolsCalcFinalWordDoneView.DISCARD),
+                FlowStep(seed_views.SeedDiscardView, button_data_selection=seed_views.SeedDiscardView.KEEP),
+                FlowStep(seed_views.SeedFinalizeView),
+            ]
+        )
+        self.setup_method()
+
+        # Flow 2: Finalized Seed -> Keep -> SeedOptionsView
+        seed = Seed(mnemonic=mnemonic)
+        self.controller.storage.set_pending_seed(seed)
+        self.controller.storage.finalize_pending_seed()
+
+        self.run_sequence(
+            initial_destination_view_args=dict(seed=seed),
+            sequence=[
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.DISCARD),
+                FlowStep(seed_views.SeedDiscardView, button_data_selection=seed_views.SeedDiscardView.KEEP),
+                FlowStep(seed_views.SeedOptionsView),
+            ]
+        )
+        self.setup_method()
+        
     def test_discard_seed_flow(self):
         """
             Selecting "Discard Seed" from the SeedOptionsView should enter the Discard Seed flow and 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -6,7 +6,7 @@ import pytest
 from base import BaseTest, FlowTest, FlowStep
 from base import FlowTestInvalidButtonDataSelectionException
 
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
 from seedsigner.views.view import MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
@@ -396,6 +396,212 @@ class TestSeedFlows(FlowTest):
             ]
         )
 
+    def verify_word_index(self, index: int, mnemonic: list[str]):
+        """Helper to target a specific word index during SeedWordsBackupTestView"""
+
+        def before_run(view: seed_views.SeedWordsBackupTestView):
+            view.cur_index = index
+
+        target_word = ButtonOptionWithoutTranslation(mnemonic[index])
+        return before_run, target_word
+
+    def select_wrong_word(self):
+        """Helper to force selecting a wrong decoy word during SeedWordsBackupTestView"""
+
+        def before_run(view: seed_views.SeedWordsBackupTestView):
+            view.cur_index = 0
+            view.rand_seed = 6102  # Guarantees "tornado" is generated as a decoy word
+
+        wrong_word = ButtonOptionWithoutTranslation("tornado")
+        return before_run, wrong_word
+
+    def test_backup_verification_success_loaded_seed_flow(self):
+        """Verify end-to-end backup viewing and verification for loaded 12-word and 24-word seeds."""
+
+        mnemonic_12 = ["abandon"] * 11 + ["about"]
+        mnemonic_24 = ["abandon"] * 23 + ["art"]
+
+        for mnemonic in [mnemonic_12, mnemonic_24]:
+            seed = Seed(mnemonic=mnemonic)
+            self.controller.storage.set_pending_seed(seed)
+            self.controller.storage.finalize_pending_seed()
+
+            # Start flow from SeedOptionsView -> SeedBackupView -> Warning
+            sequence = [
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BACKUP),
+                FlowStep(seed_views.SeedBackupView, button_data_selection=seed_views.SeedBackupView.VIEW_WORDS),
+                FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
+            ]
+
+            # Add SeedWordsView pages dynamically (4 words per page) to the sequence
+            num_pages = len(mnemonic) // 4
+            for _ in range(num_pages - 1):
+                sequence.append(
+                    FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT)
+                )
+            sequence.append(
+                FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE)
+            )
+
+            sequence.append(
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY)
+            )
+
+            # Verify all words sequentially (12 or 24 steps)
+            for i in range(len(mnemonic)):
+                before_run_fn, target_word_option = self.verify_word_index(i, mnemonic)
+                sequence.append(
+                    FlowStep(seed_views.SeedWordsBackupTestView, before_run=before_run_fn, button_data_selection=target_word_option)
+                )
+
+            # Success screen -> Returns to SeedOptionsView
+            sequence += [
+                FlowStep(seed_views.SeedWordsBackupTestSuccessView, screen_return_value=0),
+                FlowStep(seed_views.SeedOptionsView),
+            ]
+
+            self.run_sequence(sequence, initial_destination_view_args=dict(seed=seed))
+            self.setup_method()
+
+    def test_backup_verification_success_pending_seed_flow(self):
+        """Verify end-to-end backup viewing and verification for pending 12-word and 24-word seeds (routes to SeedFinalizeView)."""
+
+        mnemonic_12 = ["abandon"] * 11 + ["about"]
+        mnemonic_24 = ["abandon"] * 23 + ["art"]
+
+        for mnemonic in [mnemonic_12, mnemonic_24]:
+            seed = Seed(mnemonic=mnemonic)
+            self.controller.storage.set_pending_seed(seed)
+            sequence = []
+
+            # Start flow from SeedWordsView
+            num_pages = len(mnemonic) // 4
+            for _ in range(num_pages):
+                sequence.append(
+                    FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT)
+                )
+
+            sequence.append(
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY)
+            )
+
+            # Verify all words sequentially (12 or 24 steps)
+            for i in range(len(mnemonic)):
+                before_run_fn, target_word_option = self.verify_word_index(i, mnemonic)
+                sequence.append(
+                    FlowStep(seed_views.SeedWordsBackupTestView, before_run=before_run_fn, button_data_selection=target_word_option)
+                )
+
+            # Success screen -> Returns to SeedFinalizeView
+            sequence += [
+                FlowStep(seed_views.SeedWordsBackupTestSuccessView, screen_return_value=0),
+                FlowStep(seed_views.SeedFinalizeView),
+            ]
+
+            self.run_sequence(
+                sequence,
+                initial_destination_view_args=dict(seed=None, page_index=0),
+            )
+            self.setup_method()
+
+    def test_backup_verification_skip_loaded_seed_flow(self):
+        """Verify clicking SKIP for a loaded seed -> returns to SeedOptionsView"""
+        mnemonic_12 = ["abandon"] * 11 + ["about"]
+        mnemonic_24 = ["abandon"] * 23 + ["art"]
+
+        for mnemonic in [mnemonic_12, mnemonic_24]:
+            seed = Seed(mnemonic=mnemonic)
+            self.controller.storage.set_pending_seed(seed)
+            self.controller.storage.finalize_pending_seed()
+
+            # Start flow from SeedOptionsView -> SeedBackupView -> Warning
+            sequence = [
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BACKUP),
+                FlowStep(seed_views.SeedBackupView, button_data_selection=seed_views.SeedBackupView.VIEW_WORDS),
+                FlowStep(seed_views.SeedWordsWarningView, screen_return_value=0),
+            ]
+
+            # Add SeedWordsView pages dynamically (4 words per page) to the sequence
+            num_pages = len(mnemonic) // 4
+            for _ in range(num_pages - 1):
+                sequence.append(
+                    FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT)
+                )
+            sequence.append(
+                FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.DONE)
+            )
+
+            sequence += [
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.SKIP),
+                FlowStep(seed_views.SeedOptionsView),
+            ]
+
+            self.run_sequence(sequence, initial_destination_view_args=dict(seed=seed))
+            self.setup_method()
+
+    def test_backup_verification_skip_pending_seed_flow(self):
+        """Verify clicking SKIP for a pending seed -> returns to SeedFinalizeView"""
+        mnemonic_12 = ["abandon"] * 11 + ["about"]
+        mnemonic_24 = ["abandon"] * 23 + ["art"]
+
+        for mnemonic in [mnemonic_12, mnemonic_24]:
+            seed = Seed(mnemonic=mnemonic)
+            self.controller.storage.set_pending_seed(seed)
+            sequence = []
+
+            # Start flow from SeedWordsView
+            for _ in range(len(mnemonic) // 4):
+                sequence.append(
+                    FlowStep(seed_views.SeedWordsView, button_data_selection=seed_views.SeedWordsView.NEXT)
+                )
+
+            sequence += [
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.SKIP),
+                FlowStep(seed_views.SeedFinalizeView),
+            ]
+
+            self.run_sequence(sequence, initial_destination_view_args=dict(seed=None, page_index=0))
+            self.setup_method()
+
+    def test_backup_verification_retry_flow(self):
+        """Verify selecting a wrong word in SeedWordsBackupTestView and selecting RETRY -> returns to SeedWordsBackupTestView."""
+
+        mnemonic = ["abandon"] * 11 + ["about"]
+
+        seed = Seed(mnemonic=mnemonic)
+        self.controller.storage.set_pending_seed(seed)
+        self.controller.storage.finalize_pending_seed()
+        before_run_fn, wrong_word = self.select_wrong_word()
+
+        # Start flow from SeedWordsBackupTestPromptView -> Select Wrong Word -> RETRY -> Back to Verification
+        sequence = [
+            FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY),
+            FlowStep(seed_views.SeedWordsBackupTestView, before_run=before_run_fn, button_data_selection=wrong_word),
+            FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.RETRY),
+            FlowStep(seed_views.SeedWordsBackupTestView),
+        ]
+
+        self.run_sequence(sequence, initial_destination_view_args=dict(seed=seed))
+
+    def test_backup_verification_mistake_review_flow(self):
+        """Verify selecting a wrong word in SeedWordsBackupTestView and selecting REVIEW -> returns to SeedWordsView."""
+
+        mnemonic = ["abandon"] * 11 + ["about"]
+
+        seed = Seed(mnemonic=mnemonic)
+        self.controller.storage.set_pending_seed(seed)
+        self.controller.storage.finalize_pending_seed()
+        before_run_fn, wrong_word = self.select_wrong_word()
+
+        # Start flow from SeedWordsBackupTestPromptView -> Select Wrong Word -> REVIEW -> Back to Words View
+        sequence = [
+            FlowStep(seed_views.SeedWordsBackupTestPromptView, button_data_selection=seed_views.SeedWordsBackupTestPromptView.VERIFY),
+            FlowStep(seed_views.SeedWordsBackupTestView, before_run=before_run_fn, button_data_selection=wrong_word),
+            FlowStep(seed_views.SeedWordsBackupTestMistakeView, button_data_selection=seed_views.SeedWordsBackupTestMistakeView.REVIEW),
+            FlowStep(seed_views.SeedWordsView),
+        ]
+
+        self.run_sequence(sequence, initial_destination_view_args=dict(seed=seed))
 
     def test_discard_seed_flow(self):
         """


### PR DESCRIPTION
## Description
This PR implements **end-to-end FlowTests** for the **Seed Backup Verification Flow.**

### Problem or Issue being addressed
My AST Navigation Graph Extractor or the _**"SeedSigner Views Edge Crawler"**_ (Summer of Bitcoin Project) identified that the entire SeedWords backup verification flow has no FlowTest coverage.

<!--
Describe the problem this PR solves.
Include background context, links to relevant issues, BIPs, discussions, etc.
-->

### Solution

* **Backup Verification Success Flows:** Added full sequential word verification tests for both loaded and pending seeds.
* **Mistake Review & Retry Flow:** Added tests to verify routing when a user selects a wrong word.
* **Skip Flow:** Verified the `SKIP` button routes pending seeds back to `SeedFinalizeView` and finalized seeds back to `SeedOptionsView`.
* **Seed Keep Flow**: Added FlowTests to cover the `Keep` button routing on the `SeedDiscardView`. Verified that pending seeds correctly return to `SeedFinalizeView` and finalized seeds correctly return to `SeedOptionsView` when the user chooses to keep their seed.
* **Test Utilities:** Implemented `verify_word_index` and `select_wrong_word` helper methods to handle the randomized button layout deterministically during testing.

<!--
Describe your approach and key technical implementation details.
Explain why this approach was chosen.
-->

### Additional Information

<!--
Tradeoffs, follow-ups, limitations, or anything reviewers should be aware of.
-->


The **_Crawler_**  identified 16 edges in the Seed Backup Flow that previously had 0% FlowTest coverage. The tests added in this PR successfully cover 100% of the previously untested edges listed below:

| Source | Target |
|--------|--------|
| SeedWordsWarningView | SeedWordsView |
| SeedWordsView | SeedWordsView |
| SeedWordsView | SeedWordsBackupTestPromptView |
| SeedWordsBackupTestPromptView | SeedFinalizeView |
| SeedWordsBackupTestPromptView | SeedOptionsView |
| SeedWordsBackupTestPromptView | SeedWordsBackupTestView |
| SeedWordsBackupTestView | SeedWordsBackupTestMistakeView |
| SeedWordsBackupTestView | SeedWordsBackupTestSuccessView |
| SeedWordsBackupTestView | SeedWordsBackupTestView |
| SeedWordsBackupTestMistakeView | SeedWordsBackupTestView |
| SeedWordsBackupTestMistakeView | SeedWordsView |
| SeedWordsBackupTestSuccessView | SeedFinalizeView |
| SeedWordsBackupTestSuccessView | SeedOptionsView |
| SeedBackupView | SeedWordsWarningView |
| SeedDiscardView | SeedFinalizeView |
| SeedDiscardView | SeedOptionsView |


---

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Testing

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---