### PR TITLE
tests: Added FlowTests for Tools Entropy Generation and Calc Final Word Flows

### DIFF
--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -43,13 +43,13 @@ class TestToolsFlows(FlowTest):
                 FlowStep(tools_views.ToolsMenuView,button_data_selection=tools_views.ToolsMenuView.IMAGE),
 
                 # Enter live preview; mock the camera returning preview frames
-                FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Image.new('RGB', (10, 10))]),
+                FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Image.new('RGB', (10, 10))] * 50),
 
                 # Inject and View a dummy captured high-res frame, but simulate the user pressing BACK to "Reshoot"
                 FlowStep(tools_views.ToolsImageEntropyFinalImageView, before_run=self.inject_mock_camera_images,screen_return_value=RET_CODE__BACK_BUTTON),
 
                 # Re-enter live preview for the second attempt; mock the preview frames again
-                FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Image.new('RGB', (10, 10))]),
+                FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Image.new('RGB', (10, 10))] * 50),
 
                 # Accept the second captured high-res frame to proceed
                 FlowStep(tools_views.ToolsImageEntropyFinalImageView, before_run=self.inject_mock_camera_images),

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -8,9 +8,231 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.views.view import ErrorView, MainMenuView
 from seedsigner.views import scan_views, seed_views, tools_views
 
+from PIL import Image
+
 
 
 class TestToolsFlows(FlowTest):
+
+    def inject_mock_camera_images(self,view):
+        # Inject a 240×240 black square PIL image to bypass camera hardware capture
+        view.controller.image_entropy_final_image = Image.new('RGB',(240,240))
+        
+        # The screen Renderer is mocked during tests, so view.canvas_width would 
+        # normally return a MagicMock object. We must inject real integers here 
+        # so that PIL doesn't crash when it tries to resize the image!
+        view.canvas_width = 240
+        view.canvas_height = 240
+
+    def test_tools_image_entropy_flow(self):
+        """
+        Verify the full camera entropy flow for both 12 and 24-word seeds.
+
+        This test also covers the "Reshoot" edge case by simulating a user
+        capturing an initial frame, pressing BACK to discard it, and then capturing
+        a second final frame before proceeding to mnemonic length selection.
+
+        Hardware camera dependencies (live preview frames and the final high-res capture)
+        are bypassed by injecting mock PIL Images via `screen_return_value` and a custom `before_run` function.
+        """
+
+        mnemonic_lengths = ["TWELVE_WORDS","TWENTYFOUR_WORDS"]
+        for mnemonic_length in mnemonic_lengths:
+            sequence=[
+                FlowStep(MainMenuView,button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView,button_data_selection=tools_views.ToolsMenuView.IMAGE),
+
+                # Enter live preview; mock the camera returning preview frames
+                FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Image.new('RGB', (10, 10))]),
+
+                # Inject and View a dummy captured high-res frame, but simulate the user pressing BACK to "Reshoot"
+                FlowStep(tools_views.ToolsImageEntropyFinalImageView, before_run=self.inject_mock_camera_images,screen_return_value=RET_CODE__BACK_BUTTON),
+
+                # Re-enter live preview for the second attempt; mock the preview frames again
+                FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Image.new('RGB', (10, 10))]),
+
+                # Accept the second captured high-res frame to proceed
+                FlowStep(tools_views.ToolsImageEntropyFinalImageView, before_run=self.inject_mock_camera_images),
+            ]
+
+            if mnemonic_length == "TWELVE_WORDS":
+                sequence.append(FlowStep(tools_views.ToolsImageEntropyMnemonicLengthView,button_data_selection=tools_views.ToolsImageEntropyMnemonicLengthView.TWELVE_WORDS))
+            else:
+                sequence.append(FlowStep(tools_views.ToolsImageEntropyMnemonicLengthView,button_data_selection=tools_views.ToolsImageEntropyMnemonicLengthView.TWENTYFOUR_WORDS))
+
+            sequence.append(FlowStep(seed_views.SeedWordsWarningView))
+            self.run_sequence(sequence)
+            self.setup_method()
+
+    def test_tools_dice_roll_entropy_flow(self):
+        """
+        Verify the dice entropy flow for both 12 and 24-word seeds.
+
+        Bypasses manual keypad entry by injecting the required number of dice rolls
+        (50 rolls for 12-word, 99 rolls for 24-word) directly via `screen_return_value`
+        to successfully generate the seed.
+        """
+
+        mnemonic_lengths = ["TWELVE_WORDS","TWENTYFOUR_WORDS"]
+        for mnemonic_length in mnemonic_lengths:
+            sequence=[
+                FlowStep(MainMenuView,button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView,button_data_selection=tools_views.ToolsMenuView.DICE),
+                ]
+
+            if mnemonic_length == "TWELVE_WORDS":
+                sequence+=[
+                    FlowStep(tools_views.ToolsDiceEntropyMnemonicLengthView,screen_return_value=0),
+                    FlowStep(tools_views.ToolsDiceEntropyEntryView,screen_return_value="1" * 50)
+                ]
+
+            else:
+                sequence+=[
+                    FlowStep(tools_views.ToolsDiceEntropyMnemonicLengthView,screen_return_value=1),
+                    FlowStep(tools_views.ToolsDiceEntropyEntryView,screen_return_value="1" * 99)
+            ]
+
+            sequence.append(FlowStep(seed_views.SeedWordsWarningView))
+
+            self.run_sequence(sequence)
+            self.setup_method()
+
+    def test_tools_calc_final_word_using_zeros_flow(self):
+        """
+        Verify the "Finalize with Zeros" branch of the 12th/24th word calculator.
+
+        Simulates providing the initial 11 or 23 words, then skipping the entropy prompt
+        by selecting ZEROS to use 0-bits for the checksum calculation.
+        Tests the final routing to both the `SeedFinalizeView` (Load) and `SeedDiscardView` (Discard).
+        """
+
+        mnemonic_lengths = ["TWELVE_WORDS","TWENTYFOUR_WORDS"]
+        final_actions = ["LOAD","DISCARD"]
+
+        for mnemonic_length in mnemonic_lengths:
+            for final_action in final_actions:
+                sequence=[
+                    FlowStep(MainMenuView,button_data_selection=MainMenuView.TOOLS),
+                    FlowStep(tools_views.ToolsMenuView,button_data_selection=tools_views.ToolsMenuView.KEYBOARD),
+                ]
+
+                if mnemonic_length == "TWELVE_WORDS":
+                    sequence+=[FlowStep(tools_views.ToolsCalcFinalWordNumWordsView,button_data_selection=tools_views.ToolsCalcFinalWordNumWordsView.TWELVE)]
+                    sequence+=[FlowStep(seed_views.SeedMnemonicEntryView,screen_return_value="abandon") for _ in range(11)]
+                else:
+                    sequence+=[FlowStep(tools_views.ToolsCalcFinalWordNumWordsView,button_data_selection=tools_views.ToolsCalcFinalWordNumWordsView.TWENTY_FOUR)]
+                    sequence+=[FlowStep(seed_views.SeedMnemonicEntryView,screen_return_value="abandon") for _ in range(23)]
+
+                sequence+=[
+                    FlowStep(tools_views.ToolsCalcFinalWordFinalizePromptView,button_data_selection=tools_views.ToolsCalcFinalWordFinalizePromptView.ZEROS),
+                    FlowStep(tools_views.ToolsCalcFinalWordShowFinalWordView,button_data_selection=tools_views.ToolsCalcFinalWordShowFinalWordView.NEXT)
+                ]
+
+                if final_action == "LOAD":
+                    sequence+=[
+                        FlowStep(tools_views.ToolsCalcFinalWordDoneView,button_data_selection=tools_views.ToolsCalcFinalWordDoneView.LOAD),
+                        FlowStep(seed_views.SeedFinalizeView)
+                    ]
+                else:
+                    sequence+=[
+                        FlowStep(tools_views.ToolsCalcFinalWordDoneView,button_data_selection=tools_views.ToolsCalcFinalWordDoneView.DISCARD),
+                        FlowStep(seed_views.SeedDiscardView)
+                    ]
+
+                self.run_sequence(sequence)
+                self.setup_method()
+
+    def test_tools_calc_final_word_using_coin_flips_flow(self):
+        """
+        Verify the "Coin flip entropy" branch of the 12th/24th word calculator.
+
+        Bypasses the manual keypad entry by injecting the required coin flips
+        (7 flips for 12-word, 3 flips for 24-word) via `screen_return_value`.
+        Tests the final routing to both the `SeedFinalizeView` (Load) and `SeedDiscardView` (Discard).
+        """
+
+        mnemonic_lengths = ["TWELVE_WORDS","TWENTYFOUR_WORDS"]
+        final_actions = ["LOAD","DISCARD"]
+
+        for mnemonic_length in mnemonic_lengths:
+            for final_action in final_actions:
+                sequence=[
+                    FlowStep(MainMenuView,button_data_selection=MainMenuView.TOOLS),
+                    FlowStep(tools_views.ToolsMenuView,button_data_selection=tools_views.ToolsMenuView.KEYBOARD),
+                        ]
+
+                if mnemonic_length == "TWELVE_WORDS":
+                    sequence+=[FlowStep(tools_views.ToolsCalcFinalWordNumWordsView,button_data_selection=tools_views.ToolsCalcFinalWordNumWordsView.TWELVE)]
+                    sequence+=[FlowStep(seed_views.SeedMnemonicEntryView,screen_return_value="abandon") for _ in range(11)]
+                else:
+                    sequence+=[FlowStep(tools_views.ToolsCalcFinalWordNumWordsView,button_data_selection=tools_views.ToolsCalcFinalWordNumWordsView.TWENTY_FOUR)]
+                    sequence+=[FlowStep(seed_views.SeedMnemonicEntryView,screen_return_value="abandon") for _ in range(23)]
+
+                sequence+=[
+                    FlowStep(tools_views.ToolsCalcFinalWordFinalizePromptView,button_data_selection=tools_views.ToolsCalcFinalWordFinalizePromptView.COIN_FLIPS),
+                    FlowStep(tools_views.ToolsCalcFinalWordCoinFlipsView, screen_return_value="1" * 7 if mnemonic_length == "TWELVE_WORDS" else "1" * 3),
+                    FlowStep(tools_views.ToolsCalcFinalWordShowFinalWordView,button_data_selection=tools_views.ToolsCalcFinalWordShowFinalWordView.NEXT),
+                ]
+
+                if final_action == "LOAD":
+                    sequence+=[
+                        FlowStep(tools_views.ToolsCalcFinalWordDoneView,button_data_selection=tools_views.ToolsCalcFinalWordDoneView.LOAD),
+                        FlowStep(seed_views.SeedFinalizeView)
+                    ]
+                else:
+                    sequence+=[
+                        FlowStep(tools_views.ToolsCalcFinalWordDoneView,button_data_selection=tools_views.ToolsCalcFinalWordDoneView.DISCARD),
+                        FlowStep(seed_views.SeedDiscardView)
+                    ]
+
+                self.run_sequence(sequence)
+                self.setup_method()
+
+    def test_tools_calc_final_word_using_word_selection_flow(self):
+        """
+        Verify the "Word selection entropy" branch of the 12th/24th word calculator.
+
+        Simulates providing the initial 11 or 23 words ("abandon"), then manually typing the final
+        12th/24th word ("about" or "art") to contribute entropy for the checksum calculation.
+        Tests the final routing to both the `SeedFinalizeView` (Load) and `SeedDiscardView` (Discard).
+        """
+
+        mnemonic_lengths = ["TWELVE_WORDS","TWENTYFOUR_WORDS"]
+        final_actions = ["LOAD","DISCARD"]
+
+        for mnemonic_length in mnemonic_lengths:
+            for final_action in final_actions:
+                sequence=[
+                    FlowStep(MainMenuView,button_data_selection=MainMenuView.TOOLS),
+                    FlowStep(tools_views.ToolsMenuView,button_data_selection=tools_views.ToolsMenuView.KEYBOARD),
+                        ]
+
+                if mnemonic_length == "TWELVE_WORDS":
+                    sequence+=[FlowStep(tools_views.ToolsCalcFinalWordNumWordsView,button_data_selection=tools_views.ToolsCalcFinalWordNumWordsView.TWELVE)]
+                    sequence+=[FlowStep(seed_views.SeedMnemonicEntryView,screen_return_value="abandon") for _ in range(11)]
+                else:
+                    sequence+=[FlowStep(tools_views.ToolsCalcFinalWordNumWordsView,button_data_selection=tools_views.ToolsCalcFinalWordNumWordsView.TWENTY_FOUR)]
+                    sequence+=[FlowStep(seed_views.SeedMnemonicEntryView,screen_return_value="abandon") for _ in range(23)]
+
+                sequence+=[
+                    FlowStep(tools_views.ToolsCalcFinalWordFinalizePromptView,button_data_selection=tools_views.ToolsCalcFinalWordFinalizePromptView.SELECT_WORD),
+                    FlowStep(tools_views.SeedMnemonicEntryView, screen_return_value="about" if mnemonic_length == "TWELVE_WORDS" else "art"),
+                    FlowStep(tools_views.ToolsCalcFinalWordShowFinalWordView,button_data_selection=tools_views.ToolsCalcFinalWordShowFinalWordView.NEXT),
+                ]
+
+                if final_action == "LOAD":
+                    sequence+=[
+                        FlowStep(tools_views.ToolsCalcFinalWordDoneView,button_data_selection=tools_views.ToolsCalcFinalWordDoneView.LOAD),
+                        FlowStep(seed_views.SeedFinalizeView)
+                    ]
+                else:
+                    sequence+=[
+                        FlowStep(tools_views.ToolsCalcFinalWordDoneView,button_data_selection=tools_views.ToolsCalcFinalWordDoneView.DISCARD),
+                        FlowStep(seed_views.SeedDiscardView)
+                    ]
+
+                self.run_sequence(sequence)
+                self.setup_method()
 
     def test__address_explorer__flow(self):
         """


### PR DESCRIPTION
## Description
This PR implements end-to-end **FlowTests** for the **Tools Entropy Generation** (Image & Dice Roll) and **Calc Final Word** flows.

### Problem or Issue being addressed

<!--
Describe the problem this PR solves.
Include background context, links to relevant issues, BIPs, discussions, etc.
-->

The "SeedSigner Views' Edge Crawler" (Summer of Bitcoin Project) identified that the Image Entropy, Dice Entropy, and Calc Final Word flows in `tools_views.py` previously had zero FlowTest coverage.

 
### Solution

<!--
Describe your approach and key technical implementation details.
Explain why this approach was chosen.
-->

- **Image Entropy Flow**: Added tests to verify routing from Live Preview to Mnemonic Length selection. Mocked the hardware camera's `capture_frame()` output by injecting a PIL Image via a `before_run` hook.
- **Dice Entropy Flow**: Added tests for both 12-word and 24-word dice entropy generation flows.
- **Calc Final Word Flows**: Added tests covering all three entropy branches (`Finalize with Zeros`, `Coin Flip Entropy`, and `Word Selection Entropy`). 
- **Load/Discard Verification**: Verified that completing the Calc Final Word flow correctly routes to `SeedFinalizeView` (Load) and `SeedDiscardView` (Discard).


### Additional Information

<!--
Tradeoffs, follow-ups, limitations, or anything reviewers should be aware of.
-->

The _**Crawler**_ identified 16 edges in the Tools and Calc Final Word flows that previously had 0% FlowTest coverage. The tests added in this PR successfully cover 100% of the previously untested edges listed below:

| Source | Target |
|--------|--------|
| ToolsMenuView | ToolsDiceEntropyMnemonicLengthView |
| ToolsMenuView | ToolsImageEntropyLivePreviewView |
| ToolsDiceEntropyMnemonicLengthView | ToolsDiceEntropyEntryView |
| ToolsDiceEntropyEntryView | SeedWordsWarningView |
| ToolsImageEntropyLivePreviewView | ToolsImageEntropyFinalImageView |
| ToolsImageEntropyFinalImageView | ToolsImageEntropyMnemonicLengthView |
| ToolsImageEntropyMnemonicLengthView | SeedWordsWarningView |
| ToolsCalcFinalWordCoinFlipsView | ToolsCalcFinalWordShowFinalWordView |
| ToolsCalcFinalWordShowFinalWordView | ToolsCalcFinalWordDoneView |
| ToolsCalcFinalWordFinalizePromptView | SeedMnemonicEntryView |
| ToolsCalcFinalWordFinalizePromptView | ToolsCalcFinalWordCoinFlipsView |
| ToolsCalcFinalWordFinalizePromptView | ToolsCalcFinalWordShowFinalWordView |
| ToolsCalcFinalWordDoneView | SeedDiscardView |
| ToolsCalcFinalWordDoneView | SeedFinalizeView |
| SeedMnemonicEntryView | ToolsCalcFinalWordFinalizePromptView |
| SeedMnemonicEntryView | ToolsCalcFinalWordShowFinalWordView |

---

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Testing

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---