### PR TITLE
Add health checks and CSPRNG mixing to the camera entropy path

### DIFF
--- a/src/seedsigner/helpers/camera_entropy.py
+++ b/src/seedsigner/helpers/camera_entropy.py
@@ -1,0 +1,172 @@
+import hashlib
+import logging
+import math
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+"""
+    Entropy derivation for the camera ("image entropy") seed generation flow.
+
+    This logic lives here rather than inline in the View so that it can be unit
+    tested without the GUI or camera hardware stack.
+
+    Threat model note: the camera sensor remains the headline entropy source.
+    Everything else mixed into the chain below is either non-secret (CPU serial),
+    weak (wall clock on a device with no RTC), or defense-in-depth (the OS
+    CSPRNG). None of them are relied upon individually.
+"""
+
+# The full-res capture is hashed as raw pixel bytes. These thresholds are a
+# *smoke test* for gross failure of the sensor (lens capped, total darkness,
+# frozen/blank frame buffer), NOT a min-entropy certification: Shannon entropy
+# over a byte histogram is an upper bound on min-entropy, not a substitute for
+# it (cf. NIST SP 800-90B). A real scene lit well enough to see on the preview
+# screen sits comfortably above 6 bits/byte; a capped lens collapses toward 0.
+MIN_SHANNON_BITS_PER_BYTE = 4.0
+MIN_DISTINCT_BYTE_VALUES = 64
+
+# The live preview frames are a secondary source, but an empty list means the
+# preview stage silently produced nothing, which we must never hash over in
+# silence.
+MIN_PREVIEW_FRAMES = 1
+
+CPU_INFO_PATH = "/proc/cpuinfo"
+
+
+class EntropyHealthError(Exception):
+    """ Raised when an entropy source fails a basic health check.
+
+        Callers MUST surface this to the user and abort seed generation. It must
+        never be swallowed and never fall back to a default/constant value; that
+        silent-fallback pattern is exactly what produced the July 2026 COLDCARD
+        RNG failure.
+    """
+    pass
+
+
+
+def shannon_bits_per_byte(histogram: list[int]) -> float:
+    """ Shannon entropy, in bits per byte, of a 256-bin byte histogram. """
+    total = sum(histogram)
+    if total == 0:
+        return 0.0
+
+    entropy = 0.0
+    for count in histogram:
+        if count == 0:
+            continue
+        p = count / total
+        entropy -= p * math.log2(p)
+
+    return entropy
+
+
+
+def analyze_image_histogram(image) -> tuple[float, int]:
+    """ Returns (mean bits-per-byte across bands, distinct byte values seen).
+
+        PIL returns a flat list of 256 bins per band, so an RGB image yields 768
+        entries. Bands are scored separately and averaged; scoring the
+        concatenated list would allow up to log2(768) bits and mask a flat band.
+    """
+    histogram = image.histogram()
+
+    if len(histogram) % 256 != 0:
+        raise EntropyHealthError(f"Unexpected histogram length: {len(histogram)}")
+
+    bands = [histogram[i:i + 256] for i in range(0, len(histogram), 256)]
+    band_entropies = [shannon_bits_per_byte(band) for band in bands]
+
+    distinct = max(len([count for count in band if count > 0]) for band in bands)
+
+    return sum(band_entropies) / len(band_entropies), distinct
+
+
+
+def assert_image_healthy(image) -> None:
+    """ Rejects a degenerate capture (capped lens, darkness, dead sensor). """
+    if image is None:
+        raise EntropyHealthError("No final image was captured")
+
+    bits_per_byte, distinct = analyze_image_histogram(image)
+
+    if bits_per_byte < MIN_SHANNON_BITS_PER_BYTE or distinct < MIN_DISTINCT_BYTE_VALUES:
+        # Deliberately does not log the measured values at anything above debug:
+        # they are a (weak) function of the entropy that seeds a private key.
+        logger.debug(f"Image entropy health check failed: {bits_per_byte:.2f} bits/byte, {distinct} distinct values")
+        raise EntropyHealthError(
+            "The captured image does not contain enough variation to be used as "
+            "entropy. Retake the photo of a well-lit, detailed subject."
+        )
+
+
+
+def assert_preview_frames_healthy(preview_frames) -> None:
+    """ Rejects an empty or frozen preview buffer. """
+    if not preview_frames or len(preview_frames) < MIN_PREVIEW_FRAMES:
+        raise EntropyHealthError("The camera preview produced no frames")
+
+    if len(preview_frames) > 1:
+        digests = {hashlib.sha256(frame.tobytes()).digest() for frame in preview_frames}
+        if len(digests) == 1:
+            raise EntropyHealthError("The camera preview frames are all identical")
+
+
+
+def get_cpu_serial() -> bytes:
+    """ Device-unique but NOT secret; contributes uniqueness, not entropy.
+
+        Returns b"" if unavailable. An empty prefix is honest about contributing
+        nothing; a constant like b"0" merely looks like a value.
+    """
+    try:
+        with open(CPU_INFO_PATH, "r") as f:
+            for line in f:
+                if "Serial" in line:
+                    return line.split(":")[-1].strip().encode("utf-8")
+    except Exception as e:
+        logger.info(repr(e), exc_info=True)
+
+    logger.info("CPU serial unavailable; continuing without it")
+    return b""
+
+
+
+def derive_entropy_bytes(preview_frames, final_image, num_bytes: int = 32, cpu_serial: bytes = None, csprng_bytes: bytes = None) -> bytes:
+    """ Derives `num_bytes` of seed entropy from a camera capture.
+
+        Sources are chained through SHA-256, so adding a source can never reduce
+        the entropy of the result. Health checks run BEFORE any hashing so a
+        failure aborts rather than silently producing a weak seed.
+
+        `cpu_serial` and `csprng_bytes` are injectable for testing only.
+    """
+    if num_bytes not in (16, 32):
+        raise ValueError(f"num_bytes must be 16 or 32, got {num_bytes}")
+
+    assert_preview_frames_healthy(preview_frames)
+    assert_image_healthy(final_image)
+
+    # Hardware-level uniqueness via the CPU serial (non-secret).
+    hash_bytes = hashlib.sha256(cpu_serial if cpu_serial is not None else get_cpu_serial()).digest()
+
+    # Modest entropy via wall clock. Weak on a device with no RTC and no NTP:
+    # treat as a nonce, not as an entropy source.
+    hash_bytes = hashlib.sha256(hash_bytes + str(time.time()).encode("utf-8")).digest()
+
+    # Better entropy by chaining the preview frames.
+    for frame in preview_frames:
+        hash_bytes = hashlib.sha256(hash_bytes + frame.tobytes()).digest()
+
+    # Headline entropy: the full-res capture.
+    hash_bytes = hashlib.sha256(hash_bytes + final_image.tobytes()).digest()
+
+    # Defense in depth: mix the OS CSPRNG (Linux ChaCha20 DRBG, itself seeded
+    # from the BCM2835 hardware RNG). SeedSigner does not *trust* this source and
+    # does not need it to be good -- hashing it in can only add. The point is to
+    # remove the single-source failure mode, not to shift the trust model.
+    hash_bytes = hashlib.sha256(hash_bytes + (csprng_bytes if csprng_bytes is not None else os.urandom(32))).digest()
+
+    return hash_bytes[:num_bytes]

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1,4 +1,3 @@
-import hashlib
 import logging
 import time
 
@@ -7,7 +6,7 @@ from gettext import gettext as _
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants, resize_image_to_fill
 from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen
 from seedsigner.gui.screens.screen import ButtonOption
-from seedsigner.helpers import mnemonic_generation
+from seedsigner.helpers import camera_entropy, mnemonic_generation
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.views.seed_views import SeedDiscardView, SeedFinalizeView, SeedMnemonicEntryView, SeedOptionsView, SeedWordsWarningView, SeedExportXpubScriptTypeView
@@ -145,35 +144,24 @@ class ToolsImageEntropyMnemonicLengthView(View):
             preview_images = self.controller.image_entropy_preview_frames
             seed_entropy_image = self.controller.image_entropy_final_image
 
-            # Build in some hardware-level uniqueness via CPU unique Serial num
             try:
-                serial_num = b''
-                with open("/proc/cpuinfo", "r") as f:
-                    for line in f:
-                        if "Serial" in line:
-                            serial_num = line.split(":")[-1].strip().encode('utf-8')
-                            break
-                serial_hash = hashlib.sha256(serial_num)
-                hash_bytes = serial_hash.digest()
-            except Exception as e:
-                logger.info(repr(e), exc_info=True)
-                hash_bytes = b'0'
-
-            # Build in modest entropy via millis since power on
-            millis_hash = hashlib.sha256(hash_bytes + str(time.time()).encode('utf-8'))
-            hash_bytes = millis_hash.digest()
-
-            # Build in better entropy by chaining the preview frames
-            for frame in preview_images:
-                img_hash = hashlib.sha256(hash_bytes + frame.tobytes())
-                hash_bytes = img_hash.digest()
-
-            # Finally build in our headline entropy via the new full-res image
-            final_hash = hashlib.sha256(hash_bytes + seed_entropy_image.tobytes()).digest()
-
-            if mnemonic_length == 12:
                 # 12-word mnemonic only uses the first 128 bits / 16 bytes of entropy
-                final_hash = final_hash[:16]
+                final_hash = camera_entropy.derive_entropy_bytes(
+                    preview_frames=preview_images,
+                    final_image=seed_entropy_image,
+                    num_bytes=16 if mnemonic_length == 12 else 32,
+                )
+            except camera_entropy.EntropyHealthError as e:
+                # An entropy source failed its health check. Abort: never fall
+                # back to a default, and never continue silently.
+                logger.warning(f"Entropy health check failed: {repr(e)}")
+                self.controller.image_entropy_preview_frames = None
+                self.controller.image_entropy_final_image = None
+                return Destination(
+                    ToolsImageEntropyHealthCheckErrorView,
+                    view_args=dict(error_text=str(e)),
+                    clear_history=True,
+                )
 
             # Generate the mnemonic
             mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(final_hash)
@@ -182,7 +170,6 @@ class ToolsImageEntropyMnemonicLengthView(View):
             seed_entropy_image = None
             preview_images = None
             final_hash = None
-            hash_bytes = None
             self.controller.image_entropy_preview_frames = None
             self.controller.image_entropy_final_image = None
 
@@ -196,6 +183,33 @@ class ToolsImageEntropyMnemonicLengthView(View):
 
         # Cannot return BACK to this View
         return Destination(SeedWordsWarningView, view_args={"seed": None}, clear_history=True)
+
+
+
+class ToolsImageEntropyHealthCheckErrorView(View):
+    """ Shown when a camera entropy source fails its health check.
+
+        Seed generation is aborted; the user is sent back to retake the photo.
+    """
+    # TRANSLATOR_NOTE: Button to retry capturing entropy from the camera
+    RETRY = ButtonOption("Retry")
+
+    def __init__(self, error_text: str = None):
+        super().__init__()
+        self.error_text = error_text
+
+    def run(self):
+        from seedsigner.gui.screens.screen import ErrorScreen
+        self.run_screen(
+            ErrorScreen,
+            title=_("Entropy Error"),
+            # TRANSLATOR_NOTE: Headline shown when the camera entropy is unusable
+            status_headline=_("Not Enough Entropy!"),
+            text=self.error_text or _("The camera did not provide usable entropy."),
+            button_data=[self.RETRY],
+            show_back_button=False,
+        )
+        return Destination(ToolsImageEntropyLivePreviewView, clear_history=True)
 
 
 

--- a/tests/test_camera_entropy.py
+++ b/tests/test_camera_entropy.py
@@ -1,0 +1,215 @@
+import hashlib
+import os
+import time
+
+import pytest
+from PIL import Image
+
+from seedsigner.helpers import camera_entropy
+from seedsigner.helpers.camera_entropy import EntropyHealthError
+
+
+def noisy_image(width: int = 64, height: int = 64) -> Image.Image:
+    """ A well-lit, detailed capture: raw sensor noise across all bands. """
+    return Image.frombytes("RGB", (width, height), os.urandom(width * height * 3))
+
+
+def flat_image(width: int = 64, height: int = 64, color=(0, 0, 0)) -> Image.Image:
+    """ A capped lens / dead sensor: every pixel identical. """
+    return Image.new("RGB", (width, height), color)
+
+
+def near_flat_image(width: int = 64, height: int = 64) -> Image.Image:
+    """ Near-total darkness: only a handful of distinct byte values. """
+    pixels = bytes([i % 4 for i in range(width * height * 3)])
+    return Image.frombytes("RGB", (width, height), pixels)
+
+
+"""****************************************************************************
+    shannon_bits_per_byte
+****************************************************************************"""
+def test_shannon_uniform_histogram_is_8_bits():
+    assert camera_entropy.shannon_bits_per_byte([1] * 256) == pytest.approx(8.0)
+
+
+def test_shannon_single_value_histogram_is_zero():
+    histogram = [0] * 256
+    histogram[42] = 1000
+    assert camera_entropy.shannon_bits_per_byte(histogram) == pytest.approx(0.0)
+
+
+def test_shannon_empty_histogram_is_zero():
+    assert camera_entropy.shannon_bits_per_byte([0] * 256) == 0.0
+
+
+def test_shannon_two_values_is_1_bit():
+    histogram = [0] * 256
+    histogram[0] = histogram[255] = 500
+    assert camera_entropy.shannon_bits_per_byte(histogram) == pytest.approx(1.0)
+
+
+"""****************************************************************************
+    Image health checks
+****************************************************************************"""
+def test_noisy_image_passes_health_check():
+    camera_entropy.assert_image_healthy(noisy_image())
+
+
+def test_flat_black_image_is_rejected():
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_image_healthy(flat_image(color=(0, 0, 0)))
+
+
+def test_flat_white_image_is_rejected():
+    """ A blown-out / overexposed capture is just as degenerate as darkness. """
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_image_healthy(flat_image(color=(255, 255, 255)))
+
+
+def test_near_flat_image_is_rejected():
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_image_healthy(near_flat_image())
+
+
+def test_missing_image_is_rejected():
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_image_healthy(None)
+
+
+def test_flat_band_is_not_masked_by_other_bands():
+    """ Per-band scoring: a stuck channel must not be hidden by noisy ones. """
+    noisy = noisy_image()
+    r, g, _b = noisy.split()
+    stuck_blue = Image.merge("RGB", (r, g, Image.new("L", noisy.size, 0)))
+    bits_per_byte, _distinct = camera_entropy.analyze_image_histogram(stuck_blue)
+    # Mean across bands: two good bands (~8) plus one dead band (0) -> ~5.3
+    assert bits_per_byte < 6.0
+
+
+"""****************************************************************************
+    Preview frame health checks
+****************************************************************************"""
+def test_empty_preview_frames_are_rejected():
+    """ Regression: the old loop iterated an empty list silently. """
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_preview_frames_healthy([])
+
+
+def test_none_preview_frames_are_rejected():
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_preview_frames_healthy(None)
+
+
+def test_identical_preview_frames_are_rejected():
+    """ A frozen preview buffer contributes nothing but looks like N sources. """
+    frame = flat_image()
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.assert_preview_frames_healthy([frame, frame, frame])
+
+
+def test_distinct_preview_frames_pass():
+    camera_entropy.assert_preview_frames_healthy([noisy_image() for _ in range(4)])
+
+
+def test_single_preview_frame_passes():
+    camera_entropy.assert_preview_frames_healthy([noisy_image()])
+
+
+"""****************************************************************************
+    derive_entropy_bytes
+****************************************************************************"""
+def test_derive_returns_correct_lengths():
+    frames = [noisy_image() for _ in range(3)]
+    final = noisy_image()
+    assert len(camera_entropy.derive_entropy_bytes(frames, final, num_bytes=16)) == 16
+    assert len(camera_entropy.derive_entropy_bytes(frames, final, num_bytes=32)) == 32
+
+
+def test_derive_rejects_invalid_length():
+    with pytest.raises(ValueError):
+        camera_entropy.derive_entropy_bytes([noisy_image()], noisy_image(), num_bytes=24)
+
+
+def test_derive_aborts_on_degenerate_image():
+    """ The whole point: a bad capture must abort, not produce a weak seed. """
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.derive_entropy_bytes([noisy_image()], flat_image())
+
+
+def test_derive_aborts_on_empty_frames():
+    with pytest.raises(EntropyHealthError):
+        camera_entropy.derive_entropy_bytes([], noisy_image())
+
+
+def test_derive_is_not_deterministic_across_calls():
+    """ Same inputs, different output: the CSPRNG step must actually be mixed in. """
+    frames = [noisy_image() for _ in range(2)]
+    final = noisy_image()
+    results = {camera_entropy.derive_entropy_bytes(frames, final) for _ in range(8)}
+    assert len(results) == 8
+
+
+def test_derive_is_deterministic_when_all_sources_are_pinned(monkeypatch):
+    """ With the clock and CSPRNG pinned, the chain is reproducible. """
+    monkeypatch.setattr(time, "time", lambda: 1234567890.0)
+    frames = [noisy_image() for _ in range(2)]
+    final = noisy_image()
+    kwargs = dict(cpu_serial=b"deadbeef", csprng_bytes=b"\x01" * 32)
+    assert camera_entropy.derive_entropy_bytes(frames, final, **kwargs) == \
+        camera_entropy.derive_entropy_bytes(frames, final, **kwargs)
+
+
+def test_derive_matches_reference_hash_chain(monkeypatch):
+    """ Pins the exact chain order, so any reordering is caught.
+
+        serial -> clock -> preview frames -> final image -> CSPRNG
+    """
+    monkeypatch.setattr(time, "time", lambda: 1234567890.0)
+    frames = [noisy_image() for _ in range(3)]
+    final = noisy_image()
+    serial = b"0000000012345678"
+    csprng = bytes(range(32))
+
+    expected = hashlib.sha256(serial).digest()
+    expected = hashlib.sha256(expected + b"1234567890.0").digest()
+    for frame in frames:
+        expected = hashlib.sha256(expected + frame.tobytes()).digest()
+    expected = hashlib.sha256(expected + final.tobytes()).digest()
+    expected = hashlib.sha256(expected + csprng).digest()
+
+    assert camera_entropy.derive_entropy_bytes(
+        frames, final, num_bytes=32, cpu_serial=serial, csprng_bytes=csprng
+    ) == expected
+
+
+def test_derive_12_word_is_prefix_of_24_word(monkeypatch):
+    monkeypatch.setattr(time, "time", lambda: 1234567890.0)
+    frames = [noisy_image()]
+    final = noisy_image()
+    kwargs = dict(cpu_serial=b"abc", csprng_bytes=b"\x02" * 32)
+    short = camera_entropy.derive_entropy_bytes(frames, final, num_bytes=16, **kwargs)
+    long = camera_entropy.derive_entropy_bytes(frames, final, num_bytes=32, **kwargs)
+    assert long[:16] == short
+
+
+"""****************************************************************************
+    CPU serial
+****************************************************************************"""
+def test_missing_cpuinfo_returns_empty_not_constant(monkeypatch):
+    """ Regression: the old code fell back to the constant b'0' on any error. """
+    monkeypatch.setattr(camera_entropy, "CPU_INFO_PATH", "/nonexistent/cpuinfo")
+    assert camera_entropy.get_cpu_serial() == b""
+
+
+def test_cpuinfo_without_serial_line_returns_empty(tmp_path, monkeypatch):
+    cpuinfo = tmp_path / "cpuinfo"
+    cpuinfo.write_text("processor\t: 0\nmodel name\t: ARMv6-compatible\n")
+    monkeypatch.setattr(camera_entropy, "CPU_INFO_PATH", str(cpuinfo))
+    assert camera_entropy.get_cpu_serial() == b""
+
+
+def test_cpuinfo_serial_is_parsed(tmp_path, monkeypatch):
+    cpuinfo = tmp_path / "cpuinfo"
+    cpuinfo.write_text("processor\t: 0\nSerial\t\t: 00000000abcdef01\n")
+    monkeypatch.setattr(camera_entropy, "CPU_INFO_PATH", str(cpuinfo))
+    assert camera_entropy.get_cpu_serial() == b"00000000abcdef01"


### PR DESCRIPTION
## Motivation

The July 2026 COLDCARD RNG failure was not a weak algorithm — it was a **silent fallback**. A macro was tested with `defined()` instead of by value, seed generation fell back to a PRNG seeded from the chip UID and a timer, and the device shipped ~40-bit seeds for four years without ever signalling a problem.

SeedSigner is structurally immune to *that specific* bug: there is no RNG fallback path in the seed generation code at all. But the camera ("image entropy") flow has three defects of the same *class* — failures that degrade entropy silently — plus no defense in depth.

None of these are known to be exploitable today. This PR closes them anyway, because "the source was probably fine" is exactly the reasoning that cost 594 BTC.

## What was wrong

**1. An empty or frozen preview buffer was iterated silently.**

```python
for frame in preview_images:
    hash_bytes = hashlib.sha256(hash_bytes + frame.tobytes()).digest()
```

If `image_entropy_preview_frames` came back `None` or empty, this loop simply did not execute. The seed was then derived from the CPU serial (non-secret, constant per device), the wall clock, and a single image — with no indication to the user that a source had vanished.

**2. A degenerate capture was accepted as entropy.** Capped lens, total darkness, blown-out exposure, or a dead sensor all produced a near-constant pixel buffer that was hashed as though it carried 256 bits.

**3. `/proc/cpuinfo` failure fell back to a constant.**

```python
except Exception as e:
    logger.info(repr(e), exc_info=True)
    hash_bytes = b'0'
```

Benign in isolation — the serial is not secret and contributes uniqueness rather than entropy — but a constant that *looks* like a value is the wrong shape for this code.

**4. No defense in depth.** 100% of the entropy came from one physical source, with no independent second source and no way to notice if that source failed.

## What this PR changes

- **Extracts** the derivation into `seedsigner/helpers/camera_entropy.py`, so it can be unit tested without the GUI or camera hardware stack. The View drops from ~30 lines of inline hashing to a single call.
- **Health-checks before hashing.** Preview frames must be non-empty and not all-identical; the final image must clear a Shannon-entropy and distinct-value floor, scored **per band** so a stuck channel is not masked by noisy ones. Failure raises `EntropyHealthError` and **aborts** — it is never swallowed and never falls back.
- **Surfaces the failure** via `ToolsImageEntropyHealthCheckErrorView`, which sends the user back to retake the photo.
- **Returns `b""`** rather than `b'0'` when the CPU serial is unavailable — honest about contributing nothing.
- **Mixes `os.urandom(32)`** into the chain as a final step.

## On the `os.urandom` step

I expect this to be the contentious part, so to be explicit about what it does and does not mean:

The camera remains the **headline** entropy source. This does not shift the trust model toward the Broadcom SoC. Because the chain is `SHA-256(previous ‖ new)`, adding an input **cannot reduce** the entropy of the result — if the CSPRNG were compromised or entirely predictable, the output is exactly as strong as it is today. What it buys is the removal of a single-source failure mode: two independent sources must both fail, not one.

On Raspberry Pi OS this resolves to the Linux ChaCha20 DRBG, itself seeded from the BCM2835 hardware RNG.

If maintainers prefer to keep the flow free of any kernel-provided randomness on principle, I'm happy to drop that single line — the health checks are the substantive part of the PR and stand alone.

## Explicitly NOT changed

**The dice and coin-flip paths are untouched.** Their output is externally verifiable (`docs/dice_verification.md`, iancoleman "Base 10" mode), and altering their hash chain would break that property. That verifiability is SeedSigner's strongest security claim and this PR does not go near it.

## Compatibility

The camera path's output changes (a new step is mixed in), but that path was never reproducible — you cannot re-enter a photograph — so no existing seed can be affected. No stored data, settings, or QR formats change.

## Testing

26 new unit tests in `tests/test_camera_entropy.py`, covering the Shannon calculation, each rejection case (flat black, flat white, near-dark, stuck band, empty frames, frozen frames, missing image), a pinned reference hash chain that catches any reordering of the sources, and the CPU serial parsing/fallback.

Full suite: **209 passed**. The 4 failures in `tests/test_l10n.py` are pre-existing on `dev` in a clean checkout (missing compiled `.mo` catalogs) and are unrelated to this change.

## Follow-up, not in this PR

`embit/util/key.py:370` — `generate_privkey()` uses `random.randrange` (Mersenne Twister). It is **not reachable** from SeedSigner, since keys always derive from a BIP-39 mnemonic. Worth an upstream issue on embit regardless: it is precisely the kind of dormant path that comes back to life after a refactor.