### PR TITLE
Parse OP_RETURN payloads that use a minimal push opcode

### DIFF
--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -17,6 +17,9 @@ class OPCODES:
     OP_RETURN = 106
     OP_PUSHDATA1 = 76
 
+    # Any opcode below OP_PUSHDATA1 is itself the number of bytes to push
+    OP_PUSHDATA_MAX_DIRECT = 75
+
 
 
 class PSBTParser():
@@ -188,8 +191,7 @@ class PSBTParser():
                     is_change = True
 
             if self.psbt.tx.vout[i].script_pubkey.data[0] == OPCODES.OP_RETURN:
-                # The data is written as: OP_RETURN + OP_PUSHDATA1 + len(payload) + payload
-                self.op_return_data = self.psbt.tx.vout[i].script_pubkey.data[3:]
+                self.op_return_data = PSBTParser._parse_op_return_payload(self.psbt.tx.vout[i].script_pubkey.data)
 
             elif is_change:
                 addr = self.psbt.tx.vout[i].script_pubkey.address(NETWORKS[SettingsConstants.map_network_to_embit(self.network)])
@@ -225,6 +227,38 @@ class PSBTParser():
 
         self.fee_amount = self.psbt.fee()
         return True
+
+
+    @staticmethod
+    def _parse_op_return_payload(script_data: bytes) -> bytes:
+        """
+            Extracts the pushed payload from an OP_RETURN scriptPubKey.
+
+            The payload can be pushed two different ways and both occur in the wild:
+                * OP_RETURN + <len> + payload            (payloads up to 75 bytes)
+                * OP_RETURN + OP_PUSHDATA1 + <len> + payload
+
+            Bitcoin Core emits the minimal encoding, so the vast majority of real-world
+            OP_RETURNs use the first form. Assuming OP_PUSHDATA1 is always present would
+            chop off the payload's first byte.
+        """
+        if len(script_data) < 2:
+            # OP_RETURN with no payload at all
+            return b""
+
+        push_opcode = script_data[1]
+
+        if push_opcode <= OPCODES.OP_PUSHDATA_MAX_DIRECT:
+            # The opcode is itself the payload length
+            return script_data[2:2 + push_opcode]
+
+        if push_opcode == OPCODES.OP_PUSHDATA1 and len(script_data) >= 3:
+            return script_data[3:3 + script_data[2]]
+
+        # Unrecognized push encoding (OP_PUSHDATA2/4 can't fit in a standard 80-byte
+        # OP_RETURN). Return everything after OP_RETURN so the user still sees the raw
+        # bytes rather than nothing at all.
+        return script_data[1:]
 
 
     @staticmethod

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -485,3 +485,82 @@ def test_parse_op_return_content():
     assert psbt_parser.change_amount == 99992296
     assert psbt_parser.destination_addresses == []
     assert psbt_parser.destination_amounts == []
+
+
+
+def test_parse_op_return_payload_push_encodings():
+    """
+        Should extract the OP_RETURN payload regardless of which push encoding was used.
+
+        Payloads of up to 75 bytes are pushed with a single-byte push opcode (this is
+        the minimal encoding that Bitcoin Core emits); larger payloads require
+        OP_PUSHDATA1 + a 1-byte length.
+    """
+    from seedsigner.models.psbt_parser import OPCODES
+
+    payload = "Chancellor on the brink of third bailout".encode()
+    assert len(payload) < OPCODES.OP_PUSHDATA_MAX_DIRECT
+
+    # Minimal/direct push: OP_RETURN + <len> + payload
+    direct_push = bytes([OPCODES.OP_RETURN, len(payload)]) + payload
+    assert PSBTParser._parse_op_return_payload(direct_push) == payload
+
+    # OP_PUSHDATA1: OP_RETURN + OP_PUSHDATA1 + <len> + payload
+    pushdata1 = bytes([OPCODES.OP_RETURN, OPCODES.OP_PUSHDATA1, len(payload)]) + payload
+    assert PSBTParser._parse_op_return_payload(pushdata1) == payload
+
+    # 75 bytes is the largest payload a direct push can carry
+    payload_75 = bytes(range(75))
+    direct_push_75 = bytes([OPCODES.OP_RETURN, len(payload_75)]) + payload_75
+    assert PSBTParser._parse_op_return_payload(direct_push_75) == payload_75
+
+    # Anything larger requires OP_PUSHDATA1, up to the 80-byte standardness limit
+    payload_80 = bytes(range(80))
+    pushdata1_80 = bytes([OPCODES.OP_RETURN, OPCODES.OP_PUSHDATA1, len(payload_80)]) + payload_80
+    assert PSBTParser._parse_op_return_payload(pushdata1_80) == payload_80
+
+    # Bare OP_RETURN with no payload must not raise
+    assert PSBTParser._parse_op_return_payload(bytes([OPCODES.OP_RETURN])) == b""
+
+    # Trailing bytes beyond the declared push length are not part of the payload
+    over_long = bytes([OPCODES.OP_RETURN, 4]) + b"data" + b"junk"
+    assert PSBTParser._parse_op_return_payload(over_long) == b"data"
+
+
+
+def test_parse_op_return_content_minimal_push():
+    """
+        Should parse an OP_RETURN that uses the minimal (single-byte) push opcode.
+
+        Same PSBT as `test_parse_op_return_content` but the OP_RETURN output is
+        re-encoded the way Bitcoin Core would emit it. Assuming OP_PUSHDATA1 is always
+        present truncates the payload's first byte.
+    """
+    from embit.script import Script
+    from seedsigner.models.psbt_parser import OPCODES
+
+    psbt_base64 = "cHNidP8BAIYCAAAAATpQ10o+gKdZ8ThpKsbfHiHYn3NhvUrQ5DvW0ZWX8jKLAAAAAAD9////AujC9QUAAAAAFgAUY61+2BcXt+tsWoxV1nVw20kVb1UAAAAAAAAAACtqTChDaGFuY2VsbG9yIG9uIHRoZSBicmluayBvZiB0aGlyZCBiYWlsb3V0aQAAAE8BBDWHzwNXmUmVgAAAANRFa7R5gYD84Wbha3d1QnjgfYPOBw87on6cXS32WoyqAsPFtPxB7PRTdbujUnBPUVDh9YUBtwrl4nc0OcRNGvIyEA+4gv9UAACAAQAAgAAAAIAAAQB0AgAAAAGNFK/1X0fP5q+nu5XX7Tk2VRa0EL+jkGI9CHiJvsjZCgAAAAAA/f///wKMw/UFAAAAABYAFIpZMNnUU6cQt8Q0YpZ0pnvsSA5fAAAAAAAAAAAZakwWYml0Y29pbiBpcyBmcmVlIHNwZWVjaGgAAAABAR+Mw/UFAAAAABYAFIpZMNnUU6cQt8Q0YpZ0pnvsSA5fAQMEAQAAACIGAvxDI0eNI1oQ2AU69R7A0jf+hUdilWCgrWHgdzkqlaXMGA+4gv9UAACAAQAAgAAAAIAAAAAAAQAAAAAiAgK9qKtzGWyiRrpmupdA99NVLriz3GQy6cENbyD19sfl/hgPuIL/VAAAgAEAAIAAAACAAAAAAAIAAAAAAA=="
+    tx = PSBT.parse(a2b_base64(psbt_base64))
+
+    payload = "Chancellor on the brink of third bailout".encode()
+
+    # Re-encode the OP_RETURN output with a minimal push. Note that `PSBT.tx` is a
+    # derived property, so the scriptPubKey has to be replaced on the OutputScope.
+    op_return_index = [
+        i for i, out in enumerate(tx.outputs)
+        if out.script_pubkey.data[0] == OPCODES.OP_RETURN
+    ][0]
+    tx.outputs[op_return_index].script_pubkey = Script(
+        bytes([OPCODES.OP_RETURN, len(payload)]) + payload
+    )
+
+    # Round-trip through serialization to confirm the re-encoded output survives
+    tx = PSBT.from_string(tx.to_string())
+    assert tx.tx.vout[op_return_index].script_pubkey.data == bytes([OPCODES.OP_RETURN, len(payload)]) + payload
+
+    mnemonic = "model ensure search plunge galaxy firm exclude brain satoshi meadow cable roast".split()
+    seed = Seed(mnemonic, passphrase="")
+
+    psbt_parser = PSBTParser(p=tx, seed=seed, network=SettingsConstants.REGTEST)
+
+    assert psbt_parser.op_return_data == payload


### PR DESCRIPTION
Fixes #963

## Description

### Problem or Issue being addressed

`PSBTParser._parse_outputs()` extracts the OP_RETURN payload at a fixed offset:

```python
if self.psbt.tx.vout[i].script_pubkey.data[0] == OPCODES.OP_RETURN:
    # The data is written as: OP_RETURN + OP_PUSHDATA1 + len(payload) + payload
    self.op_return_data = self.psbt.tx.vout[i].script_pubkey.data[3:]
```

That comment only holds for payloads of 76–80 bytes. Bitcoin Core emits the *minimal*
push encoding, so a payload of 75 bytes or fewer is written as
`OP_RETURN + <len> + payload` — the prefix is two bytes, not three, and `[3:]` eats the
payload's first byte.

Reproduction (40-byte payload, so a direct push is used):

```
scriptPubKey:  6a 28 "Chancellor on the brink of third bailout"
parsed:           b'hancellor on the brink of third bailout'
expected:         b'Chancellor on the brink of third bailout'
```

`PSBTOpReturnView` is a pre-signing review screen, so the user approves a transaction
whose OP_RETURN content was displayed incorrectly. When the payload isn't human-readable
it renders as hex, where a one-byte shift isn't noticeable at all.

This wasn't caught because every existing test vector encodes `OP_PUSHDATA1` explicitly:
`tests/screenshot_generator/generator.py:84-88` builds it by hand, and the regtest PSBT in
`test_parse_op_return_content` was built the same way (`... 2b 6a 4c 28 43 68 61 6e ...`).

### Solution

Added `PSBTParser._parse_op_return_payload()`, which reads the push opcode instead of
assuming its width, and slices to the *declared* length so trailing script bytes aren't
swept into the payload. Handles:

* direct push (`0x01`–`0x4b`) — the opcode is the length
* `OP_PUSHDATA1` + 1-byte length
* bare `OP_RETURN` with no payload → `b""`
* anything else → everything after `OP_RETURN`, so the user still sees raw bytes rather
  than nothing (`OP_PUSHDATA2`/`4` can't fit in a standard 80-byte OP_RETURN)

### Additional Information

Two tests added to `tests/test_psbt_parser.py`:

* `test_parse_op_return_payload_push_encodings` — both encodings plus the 75/80-byte
  boundaries, empty payload, and over-long script data.
* `test_parse_op_return_content_minimal_push` — the existing regtest PSBT with its
  OP_RETURN output re-encoded minimally. On `dev` this fails with `b'hancellor...'`.

Note for anyone writing a similar test: `embit`'s `PSBT.tx` is a derived property, so
mutating `psbt.tx.vout[i]` is silently discarded — the scriptPubKey has to be replaced on
`psbt.outputs[i]`. My first attempt at this test passed against both patched and unpatched
code for exactly that reason.

### Screenshots

No new or modified screens — `PSBTOpReturnScreen` is unchanged; it now receives the
correct bytes.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 186 passed. 4 tests in test_seedqr.py that decode QR *images* could not run in my local environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout and are unrelated to this change. They pass in CI, which installs libzbar0.

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. The change is confined to byte-slicing in the parser and is covered by unit tests. Happy for a maintainer to verify on-device, or I can follow up once I have a board.

---

#### I have reviewed these notes:

- [x] I understand
