### PR TITLE
Reject PSBT inputs that carry no utxo data

### DIFF
--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -17,6 +17,9 @@ class OPCODES:
     OP_RETURN = 106
     OP_PUSHDATA1 = 76
 
+    # Any opcode below OP_PUSHDATA1 is itself the number of bytes to push
+    OP_PUSHDATA_MAX_DIRECT = 75
+
 
 
 class PSBTParser():
@@ -188,8 +191,7 @@ class PSBTParser():
                     is_change = True
 
             if self.psbt.tx.vout[i].script_pubkey.data[0] == OPCODES.OP_RETURN:
-                # The data is written as: OP_RETURN + OP_PUSHDATA1 + len(payload) + payload
-                self.op_return_data = self.psbt.tx.vout[i].script_pubkey.data[3:]
+                self.op_return_data = PSBTParser._parse_op_return_payload(self.psbt.tx.vout[i].script_pubkey.data)
 
             elif is_change:
                 addr = self.psbt.tx.vout[i].script_pubkey.address(NETWORKS[SettingsConstants.map_network_to_embit(self.network)])
@@ -225,6 +227,38 @@ class PSBTParser():
 
         self.fee_amount = self.psbt.fee()
         return True
+
+
+    @staticmethod
+    def _parse_op_return_payload(script_data: bytes) -> bytes:
+        """
+            Extracts the pushed payload from an OP_RETURN scriptPubKey.
+
+            The payload can be pushed two different ways and both occur in the wild:
+                * OP_RETURN + <len> + payload            (payloads up to 75 bytes)
+                * OP_RETURN + OP_PUSHDATA1 + <len> + payload
+
+            Bitcoin Core emits the minimal encoding, so the vast majority of real-world
+            OP_RETURNs use the first form. Assuming OP_PUSHDATA1 is always present would
+            chop off the payload's first byte.
+        """
+        if len(script_data) < 2:
+            # OP_RETURN with no payload at all
+            return b""
+
+        push_opcode = script_data[1]
+
+        if push_opcode <= OPCODES.OP_PUSHDATA_MAX_DIRECT:
+            # The opcode is itself the payload length
+            return script_data[2:2 + push_opcode]
+
+        if push_opcode == OPCODES.OP_PUSHDATA1 and len(script_data) >= 3:
+            return script_data[3:3 + script_data[2]]
+
+        # Unrecognized push encoding (OP_PUSHDATA2/4 can't fit in a standard 80-byte
+        # OP_RETURN). Return everything after OP_RETURN so the user still sees the raw
+        # bytes rather than nothing at all.
+        return script_data[1:]
 
 
     @staticmethod

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -108,6 +108,12 @@ class PSBTParser():
                 self.input_amount += inp.utxo.value
                 script_pubkey = inp.script_pubkey
 
+            else:
+                # Without the input's utxo we can neither total its value nor determine
+                # its policy. Must not fall through and silently reuse the previous
+                # iteration's `script_pubkey`.
+                raise RuntimeError("Input is missing its utxo data")
+
             inp_policy = PSBTParser._get_policy(inp, script_pubkey, self.psbt.xpubs)
             if self.policy == None:
                 self.policy = inp_policy

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -485,3 +485,82 @@ def test_parse_op_return_content():
     assert psbt_parser.change_amount == 99992296
     assert psbt_parser.destination_addresses == []
     assert psbt_parser.destination_amounts == []
+
+
+
+def test_parse_op_return_payload_push_encodings():
+    """
+        Should extract the OP_RETURN payload regardless of which push encoding was used.
+
+        Payloads of up to 75 bytes are pushed with a single-byte push opcode (this is
+        the minimal encoding that Bitcoin Core emits); larger payloads require
+        OP_PUSHDATA1 + a 1-byte length.
+    """
+    from seedsigner.models.psbt_parser import OPCODES
+
+    payload = "Chancellor on the brink of third bailout".encode()
+    assert len(payload) < OPCODES.OP_PUSHDATA_MAX_DIRECT
+
+    # Minimal/direct push: OP_RETURN + <len> + payload
+    direct_push = bytes([OPCODES.OP_RETURN, len(payload)]) + payload
+    assert PSBTParser._parse_op_return_payload(direct_push) == payload
+
+    # OP_PUSHDATA1: OP_RETURN + OP_PUSHDATA1 + <len> + payload
+    pushdata1 = bytes([OPCODES.OP_RETURN, OPCODES.OP_PUSHDATA1, len(payload)]) + payload
+    assert PSBTParser._parse_op_return_payload(pushdata1) == payload
+
+    # 75 bytes is the largest payload a direct push can carry
+    payload_75 = bytes(range(75))
+    direct_push_75 = bytes([OPCODES.OP_RETURN, len(payload_75)]) + payload_75
+    assert PSBTParser._parse_op_return_payload(direct_push_75) == payload_75
+
+    # Anything larger requires OP_PUSHDATA1, up to the 80-byte standardness limit
+    payload_80 = bytes(range(80))
+    pushdata1_80 = bytes([OPCODES.OP_RETURN, OPCODES.OP_PUSHDATA1, len(payload_80)]) + payload_80
+    assert PSBTParser._parse_op_return_payload(pushdata1_80) == payload_80
+
+    # Bare OP_RETURN with no payload must not raise
+    assert PSBTParser._parse_op_return_payload(bytes([OPCODES.OP_RETURN])) == b""
+
+    # Trailing bytes beyond the declared push length are not part of the payload
+    over_long = bytes([OPCODES.OP_RETURN, 4]) + b"data" + b"junk"
+    assert PSBTParser._parse_op_return_payload(over_long) == b"data"
+
+
+
+def test_parse_op_return_content_minimal_push():
+    """
+        Should parse an OP_RETURN that uses the minimal (single-byte) push opcode.
+
+        Same PSBT as `test_parse_op_return_content` but the OP_RETURN output is
+        re-encoded the way Bitcoin Core would emit it. Assuming OP_PUSHDATA1 is always
+        present truncates the payload's first byte.
+    """
+    from embit.script import Script
+    from seedsigner.models.psbt_parser import OPCODES
+
+    psbt_base64 = "cHNidP8BAIYCAAAAATpQ10o+gKdZ8ThpKsbfHiHYn3NhvUrQ5DvW0ZWX8jKLAAAAAAD9////AujC9QUAAAAAFgAUY61+2BcXt+tsWoxV1nVw20kVb1UAAAAAAAAAACtqTChDaGFuY2VsbG9yIG9uIHRoZSBicmluayBvZiB0aGlyZCBiYWlsb3V0aQAAAE8BBDWHzwNXmUmVgAAAANRFa7R5gYD84Wbha3d1QnjgfYPOBw87on6cXS32WoyqAsPFtPxB7PRTdbujUnBPUVDh9YUBtwrl4nc0OcRNGvIyEA+4gv9UAACAAQAAgAAAAIAAAQB0AgAAAAGNFK/1X0fP5q+nu5XX7Tk2VRa0EL+jkGI9CHiJvsjZCgAAAAAA/f///wKMw/UFAAAAABYAFIpZMNnUU6cQt8Q0YpZ0pnvsSA5fAAAAAAAAAAAZakwWYml0Y29pbiBpcyBmcmVlIHNwZWVjaGgAAAABAR+Mw/UFAAAAABYAFIpZMNnUU6cQt8Q0YpZ0pnvsSA5fAQMEAQAAACIGAvxDI0eNI1oQ2AU69R7A0jf+hUdilWCgrWHgdzkqlaXMGA+4gv9UAACAAQAAgAAAAIAAAAAAAQAAAAAiAgK9qKtzGWyiRrpmupdA99NVLriz3GQy6cENbyD19sfl/hgPuIL/VAAAgAEAAIAAAACAAAAAAAIAAAAAAA=="
+    tx = PSBT.parse(a2b_base64(psbt_base64))
+
+    payload = "Chancellor on the brink of third bailout".encode()
+
+    # Re-encode the OP_RETURN output with a minimal push. Note that `PSBT.tx` is a
+    # derived property, so the scriptPubKey has to be replaced on the OutputScope.
+    op_return_index = [
+        i for i, out in enumerate(tx.outputs)
+        if out.script_pubkey.data[0] == OPCODES.OP_RETURN
+    ][0]
+    tx.outputs[op_return_index].script_pubkey = Script(
+        bytes([OPCODES.OP_RETURN, len(payload)]) + payload
+    )
+
+    # Round-trip through serialization to confirm the re-encoded output survives
+    tx = PSBT.from_string(tx.to_string())
+    assert tx.tx.vout[op_return_index].script_pubkey.data == bytes([OPCODES.OP_RETURN, len(payload)]) + payload
+
+    mnemonic = "model ensure search plunge galaxy firm exclude brain satoshi meadow cable roast".split()
+    seed = Seed(mnemonic, passphrase="")
+
+    psbt_parser = PSBTParser(p=tx, seed=seed, network=SettingsConstants.REGTEST)
+
+    assert psbt_parser.op_return_data == payload

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -488,6 +488,26 @@ def test_parse_op_return_content():
 
 
 
+def test_input_without_utxo_data_is_rejected():
+    """
+        Should raise rather than evaluate an input against another input's scriptPubKey.
+
+        `_parse_inputs` assigns `script_pubkey` from whichever utxo field is present. An
+        input carrying neither leaves the local var holding the *previous* iteration's
+        value, so the input's policy would be derived from a different input's script.
+    """
+    psbt: PSBT = PSBT.parse(a2b_base64(PSBTTestData.SINGLE_SIG_NATIVE_SEGWIT_1_INPUT))
+    psbt.outputs.append(create_output(PSBTTestData.SINGLE_SIG_NATIVE_SEGWIT_RECEIVE, 50_000))
+
+    # Strip the input's utxo data
+    psbt.inputs[0].witness_utxo = None
+    psbt.inputs[0].non_witness_utxo = None
+
+    with pytest.raises(RuntimeError, match="utxo"):
+        PSBTParser(p=psbt, seed=PSBTTestData.seed, network=SettingsConstants.REGTEST)
+
+
+
 def test_parse_op_return_payload_push_encodings():
     """
         Should extract the OP_RETURN payload regardless of which push encoding was used.


### PR DESCRIPTION
> **Note:** this touches the same region of `psbt_parser.py` as #965, so it is based on
> that branch and includes its commit. Only the second commit
> ("Reject PSBT inputs that carry no utxo data") belongs to this PR — please review #965
> first. Happy to rebase once that one lands, or to fold the two into a single
> "PSBT parser hardening" PR if you'd prefer fewer moving parts.

## Description

### Problem or Issue being addressed

`PSBTParser._parse_inputs()` assigns `script_pubkey` from whichever utxo field an input
carries:

```python
for inp in self.psbt.inputs:
    if inp.witness_utxo:
        self.input_amount += inp.witness_utxo.value
        script_pubkey = inp.witness_utxo.script_pubkey
    elif inp.non_witness_utxo:
        self.input_amount += inp.utxo.value
        script_pubkey = inp.script_pubkey

    inp_policy = PSBTParser._get_policy(inp, script_pubkey, self.psbt.xpubs)
```

An input with neither field leaves the local variable bound to the *previous* iteration's
value, so that input's policy is derived from a different input's script. On the first
input it raises `UnboundLocalError` instead — confirmed by the added test, which strips
`witness_utxo`/`non_witness_utxo` from a single-input PSBT.

### Solution

An explicit `else` that raises, rather than reading a stale value.

This is defensive rather than a fix for an observed failure: `psbt.fee()` later in
`_parse_outputs()` would most likely raise first on such a PSBT. But silently reusing the
last loop value does not belong in the code that decides whether a transaction has mixed
inputs.

### Additional Information

The error message is short because `Controller.handle_exception` renders it on the error
screen.

### Screenshots

No new or modified screens.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 187 passed with this change. 4 tests in test_seedqr.py that decode QR *images* could not run in my environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout (baseline: 184 passed, same 4 failures) and are unrelated to this change. They pass in CI, which installs libzbar0.

---

#### I included screenshots of any new or modified screens
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. Covered by a unit test. Happy for a maintainer to verify on-device.

---

#### I have reviewed these notes:

- [x] I understand
