### PR TITLE
Validate the BIP-39 checksum when decoding a Standard SeedQR

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -383,7 +383,10 @@ class DecodeQR:
                 return QRType.WALLET__GENERIC
 
             # Seed
-            if re.search(r'\d{48,96}', s):
+            # A SeedQR is *only* 4-digit wordlist indices: exactly 48 digits (12 words)
+            # or 96 digits (24 words). Must be a full match; a loose search would claim
+            # any QR that merely contains a long run of digits (e.g. a SettingsQR).
+            if re.fullmatch(r'\d{48}|\d{96}', s.strip()):
                 return QRType.SEED__SEEDQR
 
             # Bitcoin Address
@@ -841,6 +844,13 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
         if qr_type == QRType.SEED__SEEDQR:
             try:
                 self.seed_phrase = []
+                segment = segment.strip()
+
+                # 4 digits per word; only 12- or 24-word mnemonics are supported. Reject
+                # anything else outright rather than decoding a prefix and silently
+                # discarding the remaining digits.
+                if len(segment) not in [48, 96]:
+                    return DecodeQRStatus.INVALID
 
                 # Parse 12 or 24-word QR code
                 num_words = int(len(segment) / 4)
@@ -848,15 +858,19 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
                     index = int(segment[i * 4: (i*4) + 4])
                     word = self.wordlist[index]
                     self.seed_phrase.append(word)
-                if len(self.seed_phrase) > 0:
-                    if self.is_12_or_24_word_phrase() == False:
-                        return DecodeQRStatus.INVALID
-                    self.complete = True
-                    self.collected_segments = 1
-                    return DecodeQRStatus.COMPLETE
-                else:
-                    return DecodeQRStatus.INVALID
+
+                # Validate the BIP-39 checksum. Raises if it doesn't match. A SeedQR
+                # that was hand-transcribed incorrectly must be rejected here; otherwise
+                # it is handed off to the seed loading flow which will raise an
+                # InvalidSeedException and dump the user out to the generic error screen.
+                bip39.mnemonic_to_bytes(" ".join(self.seed_phrase), wordlist=self.wordlist)
+
+                self.complete = True
+                self.collected_segments = 1
+                return DecodeQRStatus.COMPLETE
             except Exception as e:
+                logger.info(repr(e), exc_info=True)
+                self.seed_phrase = []
                 return DecodeQRStatus.INVALID
 
         if qr_type == QRType.SEED__COMPACTSEEDQR:

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -1,9 +1,10 @@
 import os
 from embit import bip39
 from seedsigner.helpers.qr import QR
-from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
+from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus, SeedQrDecoder
 from seedsigner.models.encode_qr import SeedQrEncoder, CompactSeedQrEncoder
 from seedsigner.models.qr_type import QRType
+from seedsigner.models.settings_definition import SettingsConstants
 
 
 
@@ -128,3 +129,86 @@ def test_compact_seedqr_bytes_interpretable_as_str():
         entropy_bytes.decode()  # should not raise an exception
         mnemonic_length = 12 if len(entropy_bytes) == 16 else 24
         run_encode_decode_test(entropy_bytes, mnemonic_length=mnemonic_length, qr_type=QRType.SEED__COMPACTSEEDQR)
+
+
+
+def seedqr_str(mnemonic: list[str]) -> str:
+    """ Helper: render a mnemonic as its Standard SeedQR digit string """
+    return SeedQrEncoder(mnemonic=mnemonic).next_part()
+
+
+def make_decoder() -> SeedQrDecoder:
+    return SeedQrDecoder(wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+
+
+def test_standard_seedqr_rejects_invalid_checksum():
+    """
+        Should reject a Standard SeedQR whose mnemonic fails BIP-39 checksum validation.
+
+        A hand-transcribed SeedQR can be drawn incorrectly. Accepting it here hands an
+        invalid mnemonic to the seed loading flow, which raises an InvalidSeedException
+        and dumps the user out to the generic "System Error" screen.
+    """
+    # "abandon" x12 is a valid wordlist sequence but an invalid mnemonic; the checksum
+    # requires the 12th word to be "about".
+    invalid = seedqr_str(["abandon"] * 12)
+    assert len(invalid) == 48
+
+    decoder = make_decoder()
+    assert decoder.add(invalid, QRType.SEED__SEEDQR) == DecodeQRStatus.INVALID
+    assert decoder.get_seed_phrase() == []
+
+    # The valid version of the same mnemonic must still decode
+    valid_mnemonic = ["abandon"] * 11 + ["about"]
+    decoder = make_decoder()
+    assert decoder.add(seedqr_str(valid_mnemonic), QRType.SEED__SEEDQR) == DecodeQRStatus.COMPLETE
+    assert decoder.get_seed_phrase() == valid_mnemonic
+
+    # Same for a 24-word mnemonic
+    mnemonic_24 = bip39.mnemonic_from_bytes(os.urandom(32)).split()
+    decoder = make_decoder()
+    assert decoder.add(seedqr_str(mnemonic_24), QRType.SEED__SEEDQR) == DecodeQRStatus.COMPLETE
+    assert decoder.get_seed_phrase() == mnemonic_24
+
+
+
+def test_standard_seedqr_rejects_wrong_digit_count():
+    """
+        Should reject digit strings that aren't exactly 48 (12 words) or 96 (24 words).
+
+        Decoding a prefix and discarding the remaining digits would silently load a
+        different seed than the one the QR actually encodes.
+    """
+    valid = seedqr_str(["abandon"] * 11 + ["about"])
+
+    for candidate in [
+        valid + "77",       # trailing junk digits
+        valid[:-4],         # 11 words
+        valid + valid[:4],  # 13 words
+        "",
+        "0000",
+    ]:
+        decoder = make_decoder()
+        assert decoder.add(candidate, QRType.SEED__SEEDQR) == DecodeQRStatus.INVALID, f"accepted {len(candidate)} digits"
+        assert decoder.get_seed_phrase() == []
+
+
+
+def test_seedqr_detection_requires_exact_digit_count():
+    """
+        Should only classify a QR as a SeedQR when its entire payload is 48 or 96 digits.
+
+        A loose search claims any QR that merely *contains* a long run of digits. Note
+        that the SeedQR check runs before the SettingsQR check in `detect_segment_type`.
+    """
+    english = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
+
+    valid = seedqr_str(["abandon"] * 11 + ["about"])
+    assert DecodeQR.detect_segment_type(valid, english) == QRType.SEED__SEEDQR
+
+    # A SettingsQR that happens to contain a long digit run is not a SeedQR
+    assert DecodeQR.detect_segment_type("settings::v1 " + "1" * 48, english) == QRType.SETTINGS
+
+    # Neither is arbitrary data with digits embedded in it
+    assert DecodeQR.detect_segment_type("xxxxx" + "0" * 60, english) == QRType.INVALID


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

`SeedQrDecoder.add()` decodes a Standard (numeric) SeedQR by mapping 4-digit indices to
words and returns `COMPLETE` without ever validating the mnemonic. The plaintext-mnemonic
path directly below it *does* validate, because it constructs a `Seed`.

Two consequences:

**a) A SeedQR with an invalid checksum is accepted by the decoder.** A 48-digit payload
encoding `abandon × 12` (valid words, invalid checksum) decodes to `COMPLETE`.
`ScanView.run()` then does:

```python
self.controller.storage.set_pending_seed(
    Seed(mnemonic=seed_mnemonic, wordlist_language_code=self.wordlist_language_code)
)
```

with no `try`, so the resulting `InvalidSeedException` propagates to
`Controller.handle_exception` and the user lands on `System Error / InvalidSeedException`.

Hand-transcribing SeedQRs from the project's own printable templates is exactly the
workflow where a wrong checksum is expected to happen, and the checksum is what exists to
catch it. Today it surfaces as a crash rather than an explanation.

**b) Extra digits are silently discarded.** `num_words = int(len(segment) / 4)` decodes a
prefix and ignores the remainder, so a 50-digit payload loads a 12-word seed from the
first 48 digits.

**c) Detection over-matches.** `detect_segment_type()` used `re.search(r'\d{48,96}', s)`,
a loose search that claims any QR merely *containing* a long digit run. That check runs
*before* the `settings::` check, so `"settings::v1 " + "1"*48` was classified as a SeedQR.

### Solution

* Require exactly 48 or 96 digits.
* Validate via `bip39.mnemonic_to_bytes()` — checksum only, no PBKDF2, so no meaningful
  cost in the scan loop.
* Clear `seed_phrase` on the failure path.
* Anchor the detection regex with `re.fullmatch(r'\d{48}|\d{96}', s.strip())`.

An invalid SeedQR now routes to the existing `ScanInvalidQRTypeView` ("Unknown QR Type")
instead of crashing.

### Additional Information

Open question for maintainers: would you prefer a dedicated error screen ("Invalid
SeedQR — checksum failed") over the generic "Unknown QR Type"? That's a UX decision and
I kept it out of this PR.

### Screenshots

No new or modified screens — an invalid SeedQR now reaches the existing
`ScanInvalidQRTypeView` instead of `UnhandledExceptionView`. Both screens are unchanged.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 187 passed with this change. 4 tests in test_seedqr.py that decode QR *images* could not run in my environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout (baseline: 184 passed, same 4 failures). They pass in CI, which installs libzbar0.

---

#### I included screenshots of any new or modified screens
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. Covered by unit tests against the decoder. This one would benefit from an on-device check with a deliberately mis-drawn SeedQR; happy for a maintainer to try that.

---

#### I have reviewed these notes:

- [x] I understand
