### PR TITLE
Reject malformed signmessage QR data instead of raising

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -970,15 +970,25 @@ class SignMessageQrDecoder(BaseSingleFrameQrDecoder):
 
             signmessage {derivation_path} ascii:{message}
         """
-        parts = segment.split()
-        self.derivation_path = parts[1].replace("h", "'")
-        fmt = parts[2].split(":")[0]
-        self.message = segment.split(f"{fmt}:")[1]
+        # Split off the two leading fields; everything after them is the payload, which
+        # may itself contain spaces and colons.
+        parts = segment.split(maxsplit=2)
+        if len(parts) < 3:
+            logger.info("Sign message: missing derivation path and/or message")
+            return DecodeQRStatus.INVALID
+
+        fmt, separator, message = parts[2].partition(":")
+        if not separator:
+            logger.info("Sign message: missing the format separator")
+            return DecodeQRStatus.INVALID
 
         # TODO: support formats other than ascii?
         if fmt != "ascii":
             logger.info(f"Sign message: Unsupported format: {fmt}")
             return DecodeQRStatus.INVALID
+
+        self.derivation_path = parts[1].replace("h", "'")
+        self.message = message
 
         self.complete = True
         self.collected_segments = 1

--- a/tests/test_signmessage_qr_decoder.py
+++ b/tests/test_signmessage_qr_decoder.py
@@ -1,0 +1,64 @@
+from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus, SignMessageQrDecoder
+from seedsigner.models.qr_type import QRType
+
+
+
+class TestSignMessageQrDecoder:
+    """
+    Expected QR data format:
+
+        signmessage {derivation_path} ascii:{message}
+    """
+    derivation_path = "m/84h/0h/0h/0/0"
+
+
+    def test_decode_sign_message_request(self):
+        message = "I attest that I control this bitcoin address"
+        data = f"signmessage {self.derivation_path} ascii:{message}"
+
+        decoder = DecodeQR()
+        assert decoder.add_data(data) == DecodeQRStatus.COMPLETE
+        assert decoder.is_sign_message
+
+        qr_data = decoder.get_qr_data()
+        assert qr_data["derivation_path"] == self.derivation_path.replace("h", "'")
+        assert qr_data["message"] == message
+
+
+    def test_message_may_contain_spaces_and_colons(self):
+        """ Only the first colon separates the format from the payload """
+        message = "notice: the times 03/Jan/2009 ascii:not a separator"
+        data = f"signmessage {self.derivation_path} ascii:{message}"
+
+        decoder = SignMessageQrDecoder()
+        assert decoder.add(data) == DecodeQRStatus.COMPLETE
+        assert decoder.get_qr_data()["message"] == message
+
+
+    def test_malformed_data_is_rejected_without_raising(self):
+        """
+            Should return INVALID rather than raise on malformed data.
+
+            An uncaught exception here propagates out of `ScanScreen._run()` and routes
+            the user to the generic "System Error" screen instead of the "Unknown QR
+            Type" warning. The scanner is the device's primary untrusted input, so no
+            QR payload should be able to raise from the decoder.
+        """
+        for data in [
+            "signmessage",                                  # no derivation path, no message
+            f"signmessage {self.derivation_path}",          # no message
+            f"signmessage {self.derivation_path} nocolon",  # no format separator
+        ]:
+            decoder = SignMessageQrDecoder()
+            assert decoder.add(data) == DecodeQRStatus.INVALID, f"should have rejected {data!r}"
+
+            # Same via the top-level DecodeQR entry point used by the scanner
+            decoder = DecodeQR()
+            assert decoder.detect_segment_type(data) == QRType.SIGN_MESSAGE
+            assert decoder.add_data(data) == DecodeQRStatus.INVALID
+
+
+    def test_unsupported_format_is_rejected(self):
+        data = f"signmessage {self.derivation_path} utf8:¡hola!"
+        decoder = SignMessageQrDecoder()
+        assert decoder.add(data) == DecodeQRStatus.INVALID


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

`SignMessageQrDecoder.add()` indexes into the split payload with no bounds checks:

```python
parts = segment.split()
self.derivation_path = parts[1].replace("h", "'")
fmt = parts[2].split(":")[0]
self.message = segment.split(f"{fmt}:")[1]
```

All three of these raise `IndexError`:

```
signmessage
signmessage m/84h/0h/0h/0/0
signmessage m/84h/0h/0h/0/0 nocolon
```

`detect_segment_type()` routes anything starting with `signmessage` here, so a QR
containing just that one word is enough to trigger it.

`ScanScreen._run()` (`gui/screens/scan_screens.py:239`) calls
`self.decoder.add_image(frame)` with no exception handling, so the error unwinds to
`Controller.handle_exception` → `UnhandledExceptionView`. The user sees
`System Error / IndexError` instead of the intended "Unknown QR Type" warning, and the
camera's video stream is left running — `ScanScreen` only calls
`camera.stop_video_stream_mode()` on its normal exit paths, and `BaseScreen.display()`'s
`finally` stops threads but not the camera. It self-heals on the next scan, since
`start_video_stream_mode()` stops an existing stream first.

Separately, `segment.split(f"{fmt}:")[1]` splits on *every* occurrence and takes index 1,
so a message that itself contains `ascii:` is silently truncated at the second occurrence.

### Solution

`split(maxsplit=2)` plus `partition(":")`, with explicit `DecodeQRStatus.INVALID` returns
and no assignment to `self` before validation succeeds. The truncation is fixed as a side
effect, since only the first colon now separates format from payload.

### Additional Information

Two follow-ups I deliberately kept out of scope, happy to submit either if you agree with
the approach:

* Wrapping the `add_image()` call in `ScanScreen._run()` so that no decoder can take down
  the scan flow.
* Moving `camera.stop_video_stream_mode()` into a `finally`.

Note also that this does not fix every crash in the sign-message flow: the decoder
validates the *number* of fields, not the shape of the derivation path, and
`embit_utils.parse_derivation_path()` raises `IndexError` on paths with fewer than three
components. I've reported that separately.

### Screenshots

No new or modified screens — a malformed payload now reaches the existing
`ScanInvalidQRTypeView` instead of `UnhandledExceptionView`. Both are unchanged.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 188 passed with this change. 4 tests in test_seedqr.py that decode QR *images* could not run in my environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout (baseline: 184 passed, same 4 failures). They pass in CI.

---

#### I included screenshots of any new or modified screens
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

> New file: tests/test_signmessage_qr_decoder.py

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. Covered by unit tests against the decoder.

---

#### I have reviewed these notes:

- [x] I understand
