### PR TITLE
Serialize the Bytewords CRC as a fixed 4 bytes and re-enable the checksum check

### DIFF
--- a/src/seedsigner/helpers/ur2/bytewords.py
+++ b/src/seedsigner/helpers/ur2/bytewords.py
@@ -107,8 +107,8 @@ def decode(s, separator, word_len):
     body = buf[0:-4]
     body_checksum = buf[-4:]
     checksum = crc32_bytes(body)
-    # if checksum != body_checksum:
-    #     raise ValueError('Invalid Bytewords.')
+    if checksum != body_checksum:
+        raise ValueError('Invalid Bytewords.')
 
     return body
 

--- a/src/seedsigner/helpers/ur2/crc32.py
+++ b/src/seedsigner/helpers/ur2/crc32.py
@@ -33,4 +33,8 @@ def crc32(buf):
 
 def crc32n(buf):
     n = crc32(buf)
-    return n.to_bytes((bit_length(n) + 7) // 8, 'big')
+    # The UR spec's Bytewords checksum is a fixed-width 4-byte big-endian CRC32.
+    # Sizing the output to the value's bit length emits 3 bytes whenever the CRC is
+    # below 2**24 (~1 in 256), which produces frames that spec-compliant decoders
+    # reject and that lax decoders truncate by one payload byte.
+    return n.to_bytes(4, 'big')

--- a/tests/test_ur2_bytewords.py
+++ b/tests/test_ur2_bytewords.py
@@ -1,0 +1,60 @@
+import pytest
+
+from seedsigner.helpers.ur2.bytewords import Bytewords, Bytewords_Style_minimal, Bytewords_Style_standard
+from seedsigner.helpers.ur2.crc32 import crc32, crc32n
+
+
+
+class TestBytewordsChecksum:
+    """
+    The Bytewords checksum is a fixed-width 4-byte big-endian CRC32. Sizing it to the
+    value's bit length emits 3 bytes whenever the CRC is below 2**24 (~1 in 256), and
+    `decode()` always strips 4, so the payload silently loses its last byte.
+    """
+
+    # crc32 of this payload is 0x00b6cdbc, i.e. below 2**24
+    SHORT_CRC_PAYLOAD = bytes.fromhex("9cce484ad8a364ed9360fa24ca015240")
+
+
+    def test_crc32n_is_always_four_bytes(self):
+        assert crc32(self.SHORT_CRC_PAYLOAD) < 2**24, "vector no longer exercises the short-CRC case"
+        assert len(crc32n(self.SHORT_CRC_PAYLOAD)) == 4
+
+        # Also cover a CRC below 2**16
+        for i in range(500_000):
+            candidate = i.to_bytes(4, "big")
+            if crc32(candidate) < 2**16:
+                assert len(crc32n(candidate)) == 4
+                break
+        else:
+            pytest.skip("no sub-2**16 CRC found in the search range")
+
+
+    @pytest.mark.parametrize("style", [Bytewords_Style_minimal, Bytewords_Style_standard])
+    def test_round_trip_with_short_crc(self, style):
+        """The payload must survive a round-trip even when its CRC is small."""
+        encoded = Bytewords.encode(style, self.SHORT_CRC_PAYLOAD)
+        decoded = bytes(Bytewords.decode(style, encoded))
+        assert decoded == self.SHORT_CRC_PAYLOAD
+
+
+    def test_round_trip_sweep(self):
+        """Sweep payload lengths and contents; ~1 in 256 hits the short-CRC path."""
+        import os
+        for _ in range(300):
+            for n in [10, 16, 32, 64]:
+                payload = os.urandom(n)
+                encoded = Bytewords.encode(Bytewords_Style_minimal, payload)
+                assert bytes(Bytewords.decode(Bytewords_Style_minimal, encoded)) == payload
+
+
+    def test_corrupted_payload_is_rejected(self):
+        """The checksum comparison in decode() must actually run."""
+        payload = b"the times 03/Jan/2009"
+        encoded = Bytewords.encode(Bytewords_Style_minimal, payload)
+
+        # Corrupt the first byteword (each byte is 2 chars in the minimal style)
+        corrupted = ("ae" if encoded[0:2] != "ae" else "ad") + encoded[2:]
+
+        with pytest.raises(ValueError):
+            Bytewords.decode(Bytewords_Style_minimal, corrupted)


### PR DESCRIPTION
Fixes #964

## Description

### Problem or Issue being addressed

`crc32n()` sizes the Bytewords checksum to the CRC value's bit length instead of the fixed
4 bytes the UR spec requires:

```python
def crc32n(buf):
    n = crc32(buf)
    return n.to_bytes((bit_length(n) + 7) // 8, 'big')
```

A CRC below 2\*\*24 is therefore emitted as 3 bytes. `bytewords.decode()` unconditionally
strips `buf[-4:]` as the checksum, so a short CRC costs the payload its last byte — and it
does so silently, because the checksum comparison in `decode()` is commented out.

This corrupts data the device **emits**. Both `UREncoder.encode()` (single-part) and
`UREncoder.encode_part()` (fountain frames) go through `Bytewords.encode()`.

Measured rate over 200,000 random payloads:

```
  2-byte CRC:       2 / 200,000  (0.001%)
  3-byte CRC:     796 / 200,000  (0.398%)
  4-byte CRC: 199,202 / 200,000  (99.601%)
  theoretical (crc < 2**24) = 1/256 = 0.391%
```

For a single-part UR the frame is deterministic — same seed, same derivation, same CBOR,
same broken QR, every time. So an affected wallet can never export its xpub via UR QR.
Over 600 randomly generated single-sig wallets exporting `m/84h/0h/0h`:

```
single-part xpub URs checked : 600
frames that do not round-trip: 2  (0.33%)
  fingerprint 5d67170e: crc32=0x00ca8727 (< 2**24) -> 115 byte payload decodes to 114
  fingerprint 02e4c892: crc32=0x008858d1 (< 2**24) -> 115 byte payload decodes to 114
```

A spec-compliant reader rejects such a frame on the checksum; a lax reader that strips a
fixed 4 bytes silently accepts an xpub missing its last byte.

The disabled checksum check has a consequence of its own: single-part URs never reach the
fountain layer, so they have no message-level CRC either. A wallet descriptor or small
PSBT received as a single frame gets no payload integrity check at all beyond the QR's own
error correction.

### Solution

Both parts have to change together — with a variable-width `crc32n`, re-enabling the
comparison would not work at all, since `checksum` and `body_checksum` (always `buf[-4:]`)
could differ in length.

```python
def crc32n(buf):
    return crc32(buf).to_bytes(4, 'big')
```

plus uncommenting the checksum check in `decode()`.

Note that `utils.int_to_bytes()` already carries the fixed-width form with the bit-length
version commented out directly above it, so this class of bug was hit and fixed there.

### Additional Information

`helpers/ur2/` is vendored from Foundation Devices' ur-py. I was not able to locate the
current upstream source to check whether it shares this bug, so it may be worth reporting
there as well.

Reproduction:

```python
from seedsigner.helpers.ur2.crc32 import crc32, crc32n
from seedsigner.helpers.ur2.bytewords import Bytewords, Bytewords_Style_minimal

payload = bytes.fromhex("9cce484ad8a364ed9360fa24ca015240")   # crc32 = 0x00b6cdbc
assert len(crc32n(payload)) == 3                              # spec requires 4

encoded = Bytewords.encode(Bytewords_Style_minimal, payload)
assert bytes(Bytewords.decode(Bytewords_Style_minimal, encoded)) == payload   # fails
```

A Bytewords round-trip sweep goes from 6 failures in 800 to 0 with this applied.

### Screenshots

No new or modified screens.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 189 passed with this change. 4 tests in test_seedqr.py that decode QR *images* could not run in my environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout (baseline: 184 passed, same 4 failures). They pass in CI.

---

#### I included screenshots of any new or modified screens
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

> New file: tests/test_ur2_bytewords.py

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. This is the one change here I'd most want verified on-device before merging: it alters what the QR encoder emits and re-enables a decoder check, so an end-to-end scan against a coordinator (Sparrow et al.) would be worth doing. The affected fingerprints above give a reproducible case.

---

#### I have reviewed these notes:

- [x] I understand
