### PR TITLE
Bound seq_len when decoding UR2 fountain parts

### DIFF
--- a/src/seedsigner/helpers/ur2/fountain_decoder.py
+++ b/src/seedsigner/helpers/ur2/fountain_decoder.py
@@ -14,6 +14,19 @@ class InvalidPart(Exception):
 class InvalidChecksum(Exception):
     pass
 
+# A part's `seq_len` is attacker-controlled: it comes straight off a scanned QR and the
+# UR parser only rejects values < 1 or > 2**64. Both `validate_part()` (which builds a
+# set of that many indexes) and `choose_fragments()` (whose Fisher-Yates shuffle is
+# quadratic in seq_len) scale with it, so a single frame can exhaust the device's memory
+# or hang it indefinitely.
+#
+# The shuffle itself cannot be optimized: its exact permutation is part of the UR fountain
+# code, so changing it would break interoperability. Bounding seq_len is the fix.
+#
+# 10,000 fragments is far beyond any real-world message: even at a 10-byte minimum
+# fragment length that covers a 100 KB payload.
+MAX_SEQ_LEN = 10000
+
 class FountainDecoder:
     class Part:
         def __init__(self, indexes, data):
@@ -268,6 +281,10 @@ class FountainDecoder:
             self.mixed_parts[p2.indexes] = p2
 
     def validate_part(self, p):
+        # Reject implausible part counts before allocating anything sized by them
+        if p.seq_len < 1 or p.seq_len > MAX_SEQ_LEN:
+            return False
+
         # If this is the first part we've seen
         if self.expected_part_indexes == None:
             # Record the things that all the other parts we see will have to match to be valid.

--- a/tests/test_ur2_decoder.py
+++ b/tests/test_ur2_decoder.py
@@ -1,0 +1,68 @@
+import time
+
+from seedsigner.helpers.ur2.bytewords import Bytewords, Bytewords_Style_minimal
+from seedsigner.helpers.ur2.fountain_decoder import FountainDecoder, MAX_SEQ_LEN
+from seedsigner.helpers.ur2.fountain_encoder import Part
+from seedsigner.helpers.ur2.ur_decoder import URDecoder
+
+
+
+class TestFountainDecoderSeqLen:
+    """
+    `seq_len` arrives from a scanned QR. `validate_part()` builds a set of that many
+    indexes and `choose_fragments()` runs a shuffle that is quadratic in seq_len, so an
+    unbounded value lets a single frame exhaust memory or hang the device.
+    """
+
+    def make_part(self, seq_num: int, seq_len: int) -> Part:
+        return Part(seq_num=seq_num, seq_len=seq_len, message_len=32, checksum=0,
+                    data=b"\x00" * 32)
+
+
+    def test_plausible_seq_len_is_accepted(self):
+        decoder = FountainDecoder()
+        assert decoder.validate_part(self.make_part(1, 50)) is True
+        assert decoder.expected_part_count() == 50
+
+
+    def test_oversized_seq_len_is_rejected(self):
+        for seq_len in [MAX_SEQ_LEN + 1, 10**6, 2**32, 2**64 - 1]:
+            decoder = FountainDecoder()
+            assert decoder.validate_part(self.make_part(1, seq_len)) is False, seq_len
+            # Nothing was allocated
+            assert decoder.expected_part_indexes is None
+
+
+    def test_zero_and_negative_seq_len_are_rejected(self):
+        for seq_len in [0, -1]:
+            decoder = FountainDecoder()
+            assert decoder.validate_part(self.make_part(1, seq_len)) is False
+
+
+    def test_oversized_seq_len_returns_promptly(self):
+        """
+            A frame declaring a huge seq_len must not do work proportional to it.
+
+            Without the bound this allocates a set of `seq_len` ints and then runs an
+            O(seq_len^2) shuffle in choose_fragments().
+        """
+        part = self.make_part(seq_num=10**7 + 1, seq_len=10**7)
+        decoder = FountainDecoder()
+
+        start = time.time()
+        assert decoder.receive_part(part) is False
+        assert time.time() - start < 1.0
+
+
+    def test_oversized_seq_len_rejected_through_the_ur_decoder(self):
+        """Same thing via the scanner's actual entry point."""
+        seq_len = 10**7
+        part = self.make_part(seq_num=1, seq_len=seq_len)
+        body = Bytewords.encode(Bytewords_Style_minimal, bytes(part.cbor()))
+        frame = f"ur:crypto-psbt/1-{seq_len}/{body}"
+
+        decoder = URDecoder()
+        start = time.time()
+        assert decoder.receive_part(frame) is False
+        assert time.time() - start < 1.0
+        assert not decoder.is_complete()


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

A UR2 part's `seq_len` comes straight off a scanned QR and is effectively unbounded:
`URDecoder.parse_sequence_component()` only rejects values below 1, and `Part.from_cbor()`
only rejects values above 2\*\*64. Two things then scale with it.

**1. Set allocation** in `FountainDecoder.validate_part()`:

```python
self.expected_part_indexes = set()
for i in range(p.seq_len):
    self.expected_part_indexes.add(i)
```

Measured on an x86 desktop: `seq_len = 1,000,000` costs 67 MB and 0.37s for one frame.

**2. Quadratic shuffle** in `choose_fragments()`, reached whenever `seq_num > seq_len`.
Its Fisher-Yates shuffle uses `list.pop(index)`, which is O(n) per step:

```
seq_len   time (x86 desktop)
 16,000   0.15s
 50,000   1.29s
```

Scaling measured at ~3.5x per doubling. Extrapolating, 500,000 is roughly two minutes and
5,000,000 is hours — on x86. A Pi Zero has 512 MB and a single ~1 GHz ARMv6 core, so it is
considerably worse there: the device appears frozen and the only recourse is to pull
power, which discards any seeds held in memory.

Both are reachable from one scanned frame, with `seq_num` and `seq_len` fully chosen by
whoever produced the QR. This is denial of service, not key compromise.

### Solution

Bound `seq_len` in `FountainDecoder.validate_part()`, which runs before both the set
allocation and `choose_fragments()`.

The shuffle itself cannot be made linear: its exact permutation is part of the UR fountain
code, so changing it would break interoperability with other wallets. The bound is the fix.

`MAX_SEQ_LEN` is set to 10,000, which at the 10-byte minimum fragment length still covers
a 100 KB message — far beyond any real PSBT. **That number is a suggestion**; please pick
whatever ceiling you're comfortable with, the bound itself is the point.

### Additional Information

Reproduction:

```python
from seedsigner.helpers.ur2.bytewords import Bytewords, Bytewords_Style_minimal
from seedsigner.helpers.ur2.fountain_encoder import Part
from seedsigner.models.decode_qr import DecodeQR

seq_len = 1_000_000
part = Part(seq_num=1, seq_len=seq_len, message_len=32, checksum=0, data=b"\x00" * 32)
body = Bytewords.encode(Bytewords_Style_minimal, bytes(part.cbor()))
DecodeQR().add_data(f"ur:crypto-psbt/1-{seq_len}/{body}")
```

Use `seq_num = seq_len + 1` for the quadratic path.

`helpers/ur2/` is vendored from Foundation Devices' ur-py. I couldn't locate the current
upstream source to check whether it shares this, so it may be worth reporting there too.

### Screenshots

No new or modified screens.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 189 passed with this change. 4 tests in test_seedqr.py that decode QR *images* could not run in my environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout (baseline: 184 passed, same 4 failures). They pass in CI.

---

#### I included screenshots of any new or modified screens
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

> New file: tests/test_ur2_decoder.py

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. Worth confirming on-device that normal animated-QR scanning from a coordinator still completes, since this adds a rejection path to the decoder.

---

#### I have reviewed these notes:

- [x] I understand
