### PR TITLE
Report an unclean match for unparseable derivation paths

### DIFF
--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -136,9 +136,29 @@ def parse_derivation_path(derivation_path: str) -> dict:
 
     sections = derivation_path.split("/")
 
+    # The derivation path can arrive from an untrusted QR (e.g. a `signmessage` request),
+    # so anything that can't be parsed has to be reported as an unclean match rather than
+    # raising into the caller.
+    if len(sections) < 3:
+        return dict(
+            script_type=None,
+            network=None,
+            is_change=None,
+            index=None,
+            wallet_derivation_path=None,
+            clean_match=False,
+        )
+
     if sections[1] == "48h":
         # So far this helper is only meant for single sig message signing
-        raise Exception("Not implemented")
+        return dict(
+            script_type=None,
+            network=None,
+            is_change=None,
+            index=None,
+            wallet_derivation_path=None,
+            clean_match=False,
+        )
 
     lookups = {
         "script_types": {

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -374,6 +374,25 @@ def test_get_multisig_policy():
         ))
 
 
+def test_parse_derivation_path_rejects_malformed_input():
+    """
+        Should report an unclean match rather than raise.
+
+        The derivation path can arrive from an untrusted QR: a `signmessage` request
+        supplies it verbatim and SeedSignMessageStartView.__init__ parses it before
+        anything else. An IndexError here reaches Controller.handle_exception and puts
+        the user on the generic "System Error" screen.
+    """
+    for derivation_path in ["", "m", "x", "m/", "m/84h", "m/84'"]:
+        result = embit_utils.parse_derivation_path(derivation_path)
+        assert result["clean_match"] is False, f"should not have cleanly matched {derivation_path!r}"
+
+    # Multisig paths are out of scope for this helper, but must not raise either
+    result = embit_utils.parse_derivation_path("m/48h/0h/0h/2h/0/0")
+    assert result["clean_match"] is False
+
+
+
 def test_parse_derivation_path():
     # Shouldn't care if input uses "'" or "h"
     derivation_path = "m/84'/0'/0'/0/0"


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

`embit_utils.parse_derivation_path()` indexes `sections[1]` and `sections[2]` without
checking how many components the path actually has, so any path with fewer than three
raises `IndexError`:

```
''  'm'  'x'  'm/'  'm/84h'   ->  IndexError: list index out of range
```

The derivation path can arrive from an untrusted QR. A `signmessage {path} ascii:{msg}`
request supplies it verbatim, and `SeedSignMessageStartView.__init__`
(`views/seed_views.py:2127`) parses it before anything else:

```python
addr_format = embit_utils.parse_derivation_path(derivation_path)
if not addr_format["clean_match"]:
    self.set_redirect(Destination(NotYetImplementedView, ...))
```

The `clean_match` guard is already there and does the right thing — but the exception
fires before it can run. So scanning `signmessage m ascii:hello` routes to
`Controller.handle_exception` and lands the user on `System Error / IndexError` instead of
the intended "not supported" message.

The `m/48h` branch has the same outcome by a different route: it raises deliberately,
which also surfaces as "System Error".

### Solution

Return a result with `clean_match=False` instead of raising, for both the short-path case
and the `m/48h` case. The one caller in the app already handles that, and the helper's
docstring already says it "may return None for fields it cannot parse".

### Additional Information

This is independent of the `SignMessageQrDecoder` bounds-checking fix I submitted
separately — that one validates the *number* of fields, not the shape of the path, so
fixing it does not fix this.

### Screenshots

No new or modified screens — the malformed case now reaches the existing
`NotYetImplementedView` instead of `UnhandledExceptionView`. Both are unchanged.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

> 185 passed with this change. 4 tests in test_seedqr.py that decode QR *images* could not run in my environment because libzbar does not load on Windows; they fail identically on an unmodified `dev` checkout (baseline: 184 passed, same 4 failures). They pass in CI.

---

#### I included screenshots of any new or modified screens
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

> Not tested on hardware or the emulator — I don't have a device. Covered by a unit test.

---

#### I have reviewed these notes:

- [x] I understand
