### PR TITLE
Add assertions to mnemonic generation

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -17,6 +17,8 @@ from seedsigner.models.seed import Seed
 DICE__NUM_ROLLS__12WORD = 50
 DICE__NUM_ROLLS__24WORD = 99
 
+COIN__NUM_FLIPS__12WORD = 128
+COIN__NUM_FLIPS__24WORD = 256
 
 
 def calculate_checksum(mnemonic: list | str, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
@@ -71,6 +73,8 @@ def generate_mnemonic_from_dice(roll_data: str, wordlist_language_code: str = Se
 
         Important note: This method is NOT compatible with iancoleman's "Dice" mode.
     """
+    assert (len(roll_data) == DICE__NUM_ROLLS__12WORD) or (len(roll_data) == DICE__NUM_ROLLS__24WORD), "Invalid number of dice rolls"
+
     entropy_bytes = hashlib.sha256(roll_data.encode()).digest()
 
     if len(roll_data) == DICE__NUM_ROLLS__12WORD:
@@ -90,9 +94,11 @@ def generate_mnemonic_from_coin_flips(coin_flips: str, wordlist_language_code: s
         * binary digit stream is treated as string data.
         * hashed via SHA256.
     """
+    assert (len(roll_data) == COIN__NUM_FLIPS__12WORD) or (len(roll_data) == COIN__NUM_FLIPS__24WORD), "Invalid number of coin flips"
+
     entropy_bytes = hashlib.sha256(coin_flips.encode()).digest()
 
-    if len(coin_flips) == 128:
+    if len(coin_flips) == COIN__NUM_FLIPS__12WORD:
         # 12-word mnemonic; only use 128bits / 16 bytes
         entropy_bytes = entropy_bytes[:16]
 

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -34,7 +34,7 @@ def test_calculate_checksum_input_type():
     """
         Given an 11-word or 23-word mnemonic, the calculated checksum should yield a
         valid complete mnemonic.
-        
+
         calculate_checksum should accept the mnemonic as:
         * a list of strings
         * string: "A B C", "A, B, C", "A,B,C"
@@ -131,19 +131,6 @@ def test_generate_mnemonic_from_bytes():
     assert mnemonic == expected_mnemonic
 
 
-
-def test_verify_against_coldcard_sample():
-    """ https://coldcard.com/docs/verifying-dice-roll-math """
-    dice_rolls = "123456"
-    expected = "mirror reject rookie talk pudding throw happy era myth already payment own sentence push head sting video explain letter bomb casual hotel rather garment"
-
-    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
-    actual = " ".join(mnemonic)
-    assert bip39.mnemonic_is_valid(actual)
-    assert actual == expected
-
-
-
 def test_known_dice_rolls():
     """ Given 99 known dice rolls, the resulting mnemonic should be valid and match the expected. """
     dice_rolls = "522222222222222222222222222222222222222222222555555555555555555555555555555555555555555555555555555"
@@ -195,3 +182,13 @@ def test_50_dice_rolls():
     actual = " ".join(mnemonic)
     assert bip39.mnemonic_is_valid(actual)
     assert actual == expected
+
+
+def test_invalid_number_of_rolls():
+    for i in range(0, 1000):
+        dice_rolls = [str(random.randint(1, 6)) for _ in range(0, i)]
+        if i not in (mnemonic_generation.DICE__NUM_ROLLS__12WORD, mnemonic_generation.DICE__NUM_ROLLS__24WORD):
+            try:
+                mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
+            except Exception as e:
+                assert type(e) == AssertionError


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

The dice and coin seed generation functions are trusting that the UI will submit the appropriate number of dice rolls or coin flips. Should the UI not do this, for whatever reason, then insufficient entropy could be passed to the hash function.

### Solution

Don't trust the UI (client side validation), do local validation and fail hard if there isn't sufficient entropy.

### Additional Information

Since the asserts are not handled then will probably crash the UI but that's probably desirable.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

Removed ColdCard test as their example has small number of rolls (since it was supposed to be mixed with a HRNG) which fails. Instead tests whether assertion is thrown for invalid rolls.

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand