### PR TITLE
Verify PSBT input amounts against the previous transaction

### DIFF
--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -35,6 +35,7 @@ class PSBTParser():
         self.destination_addresses = []
         self.destination_amounts = []
         self.op_return_data: bytes = None
+        self.unverified_input_nums: List[int] = []
 
         self.root = None
 
@@ -83,6 +84,9 @@ class PSBTParser():
         # Try to fix missing fingerprints before parsing
         self._fill_missing_fingerprints()
 
+        # An input's declared amount is an unverified claim until it is checked
+        self._verify_input_amounts()
+
         rt = self._parse_inputs()
         if rt == False:
             return False
@@ -92,6 +96,42 @@ class PSBTParser():
             return False
 
         return True
+
+
+    @property
+    def has_unverified_input_amounts(self) -> bool:
+        """True if any input did not supply a previous tx we could check it against"""
+        return len(self.unverified_input_nums) > 0
+
+
+    def _verify_input_amounts(self):
+        """
+            The amount a PSBT declares for an input is an attacker-controlled claim until it
+            is checked against the previous transaction it says it came from. Trusting it
+            enables the well-known "miner fee attack": a malicious coordinator understates
+            the input values, the user approves what looks like a reasonable fee, and the
+            difference is handed to the miner.
+
+            This is not specific to legacy inputs. BIP-143 commits only to the amount of the
+            input currently being signed, so with two or more inputs an attacker can obtain
+            one valid signature per signing session by telling the truth about exactly one
+            input each time, then combine the sessions.
+
+            `InputScope.verify()` re-hashes the supplied non_witness_utxo and compares it to
+            the outpoint's txid; embit provides it for exactly this purpose. Inputs that
+            supply no previous tx at all cannot be checked here, so they are recorded rather
+            than rejected -- BIP-174 permits a segwit input to carry only witness_utxo, and
+            refusing those outright would break those coordinators.
+        """
+        self.unverified_input_nums = []
+        for i, inp in enumerate(self.psbt.inputs):
+            if inp.non_witness_utxo is None and inp._txhash is None:
+                self.unverified_input_nums.append(i)
+                continue
+            try:
+                inp.verify()
+            except Exception as e:
+                raise RuntimeError(f"Input {i} amount could not be verified: {e}")
 
 
     def _parse_inputs(self):

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -5,6 +5,7 @@ from binascii import a2b_base64
 from embit import bip32
 from embit.psbt import PSBT
 from embit.descriptor import Descriptor
+from embit.networks import NETWORKS
 
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.seed import Seed
@@ -485,3 +486,85 @@ def test_parse_op_return_content():
     assert psbt_parser.change_amount == 99992296
     assert psbt_parser.destination_addresses == []
     assert psbt_parser.destination_amounts == []
+
+
+"""****************************************************************************
+    Input amount verification
+****************************************************************************"""
+def _build_psbt_with_prev_tx(prev_tx_for_input, spend_value=90_000):
+    """
+    Helper: build a 1-in/1-out PSBT that spends `real_prev`'s vout 0, but attaches
+    `prev_tx_for_input` as the input's non_witness_utxo.
+    """
+    from embit import script
+    from embit.psbt import DerivationPath
+    from embit.transaction import Transaction, TransactionInput, TransactionOutput
+
+    seed = PSBTTestData.seed
+    root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["regtest"]["xprv"])
+    derivation = "m/84h/1h/0h/0/0"
+    key = root.derive(derivation)
+    script_pubkey = script.p2wpkh(key)
+
+    real_prev = Transaction(
+        vin=[TransactionInput(b"\x11" * 32, 0)],
+        vout=[TransactionOutput(100_000, script_pubkey)],
+    )
+    tx = Transaction(
+        vin=[TransactionInput(real_prev.txid(), 0)],
+        vout=[TransactionOutput(spend_value, script_pubkey)],
+    )
+    psbt = PSBT(tx)
+    if prev_tx_for_input is not None:
+        psbt.inputs[0].non_witness_utxo = prev_tx_for_input
+    else:
+        psbt.inputs[0].witness_utxo = TransactionOutput(100_000, script_pubkey)
+    psbt.inputs[0].bip32_derivations[key.to_public().key] = DerivationPath(
+        root.child(0).fingerprint, bip32.parse_path(derivation)
+    )
+    return psbt, real_prev, script_pubkey
+
+
+def test_input_amounts_are_verified_for_all_supported_script_types():
+    """All bundled test PSBTs supply a previous tx, so all inputs must verify."""
+    for psbt_base64 in PSBTTestData.ALL_INPUTS:
+        psbt = PSBT.parse(a2b_base64(psbt_base64))
+        psbt_parser = PSBTParser(p=psbt, seed=PSBTTestData.seed, network=SettingsConstants.REGTEST)
+        assert psbt_parser.unverified_input_nums == []
+        assert psbt_parser.has_unverified_input_amounts is False
+
+
+def test_forged_non_witness_utxo_is_rejected():
+    """
+    An input whose non_witness_utxo does not hash to the outpoint's txid is lying about
+    its own value. Trusting it is the "miner fee attack": the understated input value
+    makes the fee look small while the real difference goes to the miner.
+    """
+    from embit.transaction import Transaction, TransactionInput, TransactionOutput
+
+    psbt, real_prev, script_pubkey = _build_psbt_with_prev_tx(None)
+
+    # Same output script, far smaller value, and therefore a different txid
+    forged_prev = Transaction(
+        vin=[TransactionInput(b"\x22" * 32, 0)],
+        vout=[TransactionOutput(1_000, script_pubkey)],
+    )
+    assert forged_prev.txid() != real_prev.txid()
+
+    psbt.inputs[0].witness_utxo = None
+    psbt.inputs[0].non_witness_utxo = forged_prev
+
+    with pytest.raises(RuntimeError, match="could not be verified"):
+        PSBTParser(p=psbt, seed=PSBTTestData.seed, network=SettingsConstants.REGTEST)
+
+
+def test_input_without_previous_tx_is_flagged_but_not_rejected():
+    """
+    BIP-174 permits a segwit input to carry only witness_utxo. Those amounts cannot be
+    verified from the PSBT alone, so they are reported rather than rejected.
+    """
+    psbt, _real_prev, _spk = _build_psbt_with_prev_tx(None)
+
+    psbt_parser = PSBTParser(p=psbt, seed=PSBTTestData.seed, network=SettingsConstants.REGTEST)
+    assert psbt_parser.unverified_input_nums == [0]
+    assert psbt_parser.has_unverified_input_amounts is True


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

`PSBTParser` reads each input's amount straight out of the PSBT and never checks it ([`psbt_parser.py#L97-L106`](https://github.com/SeedSigner/seedsigner/blob/dev/src/seedsigner/models/psbt_parser.py#L97-L106)):

```python
if inp.witness_utxo:
    self.input_amount += inp.witness_utxo.value
elif inp.non_witness_utxo:
    self.input_amount += inp.utxo.value
```

`witness_utxo` / `non_witness_utxo` are supplied by whoever built the PSBT. Nothing in `src/` calls `PSBT.verify()` or `InputScope.verify()` — `grep -rn "non_witness_utxo" src/` returns the single hit above. The input total, and therefore the fee on `PSBTMathScreen`, is an unverified claim from the coordinator.

embit provides `InputScope.verify()` for exactly this, and its docstring is explicit about why:

> Verifies the hash of previous transaction provided in non_witness_utxo. We must verify on a hardware wallet **even on segwit transactions** to avoid miner fee attack described here: https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-1-and-trezor-model-t-version-2-3-1-1eba8f60f2dd

The "even on segwit" part is the non-obvious bit. BIP-143 commits only to the amount of the input **currently being signed**, so segwit is not inherently safe once a transaction has two or more inputs: an attacker can collect one valid signature per signing session by being truthful about exactly one input each time, then combine the sessions.

### Solution

A bare `psbt.verify()` is too strict — it defaults to `ignore_missing=False` and raises for any input carrying no previous transaction, and BIP-174 permits a segwit input to supply only `witness_utxo`. That would reject PSBTs from coordinators that omit it.

So `_verify_input_amounts()` splits the two cases:

- previous tx present but its txid does not match the outpoint → **raise** (this is the actual attack signature)
- no previous tx at all → **record** in `unverified_input_nums`, so the UI can warn rather than refuse

`has_unverified_input_amounts` is exposed for a follow-up warning screen. **This PR changes no UI**, to keep it reviewable.

No extra memory cost: `PSBT.parse()` already defaults to `CompressMode.KEEP_ALL`, so the previous transaction is retained in RAM today and simply never used. The added work is one SHA256d per input over data already in memory. (`CompressMode.PARTIAL` keeps only the needed txout plus `_txhash` if memory ever matters — the check handles that case too.)

### Additional Information

**Compatibility.** All seven bundled test PSBTs already carry the previous transaction and verify cleanly, so no currently-supported flow regresses:

| fixture | with previous tx | `verify()` |
|---|---|---|
| `SINGLE_SIG_NATIVE_SEGWIT_1_INPUT` | 1/1 | pass |
| `SINGLE_SIG_NESTED_SEGWIT_1_INPUT` | 1/1 | pass |
| `SINGLE_SIG_TAPROOT_1_INPUT` | 1/1 | pass |
| `SINGLE_SIG_LEGACY_P2PKH_1_INPUT` | 1/1 | pass |
| `MULTISIG_NATIVE_SEGWIT_1_INPUT` | 1/1 | pass |
| `MULTISIG_NESTED_SEGWIT_1_INPUT` | 1/1 | pass |
| `MULTISIG_LEGACY_P2SH_1_INPUT` | 1/1 | pass |

**Overlapping PRs.** #965 and #966 touch the same region of `psbt_parser.py`. This PR is independent of both and inserts its call in `parse()` rather than inside `_parse_inputs()`, but it will need a trivial rebase depending on merge order — happy to do that whenever suits.

**Not hands-on tested.** Verified via the unit test suite only; I have not run this on a Pi or the emulator. Since the change is confined to parsing and adds no screen, I did not want to claim hardware validation I did not do. Grateful if a reviewer with a device can confirm a normal signing flow is unaffected.

**Exception type.** I used `RuntimeError` to match the existing `"Mixed inputs in the transaction"` raise in the same file. A dedicated exception routed to a `DireWarningScreen` may fit the codebase better — happy to change it.

### Screenshots

N/A — no new or modified screens. The parser exposes `has_unverified_input_amounts` but nothing renders it yet.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

<sub>191 passed (translations submodule initialised and catalogs compiled).</sub>

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

<sub>Three cases in `tests/test_psbt_parser.py`: every bundled PSBT verifies; a forged previous tx is rejected; a `witness_utxo`-only input is flagged but not rejected. No flow sequences changed, so no FlowTests.</sub>

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

<sub>None — unit tests only, as noted above.</sub>

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

<sub>Scope kept to the parser; the warning screen is deliberately left for a follow-up.</sub>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
