### PR TITLE
Fix multiline layout with libraqm 0.11 and document macOS setup

### DIFF
--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -20,6 +20,16 @@ from seedsigner.models.threads import BaseThread
 logger = logging.getLogger(__name__)
 
 
+def _get_single_paragraph_text_bbox(font, text: str):
+    """Measure text without passing paragraph separators to libraqm.
+
+    libraqm 0.11 rejects text spanning multiple paragraphs. TextArea handles explicit
+    line breaks itself when it reflows and renders the text, so replacing newlines with
+    spaces here only affects the initial font-metrics calculation.
+    """
+    return font.getbbox(text.replace("\n", " "), anchor="ls")
+
+
 
 # TODO: Remove all pixel hard coding
 class GUIConstants:
@@ -398,7 +408,7 @@ class TextArea(BaseComponent):
         # Note: from the baseline anchor, `top` is a negative number while `bottom`
         # conveys the height of the pixels that rendered below the baseline, if any
         # (e.g. "py" in "python").
-        (left, top, full_text_width, bottom) = font.getbbox(self.text, anchor="ls")
+        (left, top, full_text_width, bottom) = _get_single_paragraph_text_bbox(font, self.text)
         self.text_height_above_baseline = -1 * top
         self.text_height_below_baseline = bottom
 
@@ -1393,7 +1403,9 @@ class Button(BaseComponent):
             self.font = Fonts.get_font(self.font_name, self.font_size)
 
             # Calc true pixel height (any anchor from "baseline" will work)
-            (left, top, self.text_width, bottom) = self.font.getbbox(self.text, anchor="ls")
+            (left, top, self.text_width, bottom) = _get_single_paragraph_text_bbox(
+                self.font, self.text
+            )
             # print(f"left: {left} |  top: {top} | right: {self.text_width} | bottom: {bottom}")
 
             # Note: "top" is negative when measured from a "baseline" anchor. Intentionally
@@ -1833,7 +1845,7 @@ def reflow_text_for_width(text: str,
     #   font.
     font = Fonts.get_font(font_name=font_name, size=font_size)
     # Measure from left baseline ("ls")
-    (left, top, full_text_width, px_below_baseline) = font.getbbox(text, anchor="ls")
+    (left, top, full_text_width, px_below_baseline) = _get_single_paragraph_text_bbox(font, text)
 
     # Assume we can break Asian text on any character
     treat_chars_as_words = Settings.get_instance().get_value(SettingsConstants.SETTING__LOCALE) in [

--- a/tests/screenshot_generator/README.md
+++ b/tests/screenshot_generator/README.md
@@ -1,15 +1,70 @@
 # Screenshot Generator
 
+The screenshot generator is implemented as a pytest test and writes its output to the
+`seedsigner-screenshots` directory in the project root.
+
+## Setup
+
+Follow the [general test setup](../README.md#setup) before running the generator. The
+translation catalogs are stored in a submodule and must be compiled before non-English
+locales can be detected:
+
+```bash
+git submodule update --init --recursive \
+    src/seedsigner/resources/seedsigner-translations
+pip install -r l10n/requirements-l10n.txt
+python setup.py compile_catalog
+```
+
+### macOS
+
+The screenshot generator also needs the native `zbar` and `libraqm` libraries. These
+steps use Python 3.12, which is included in the project's CI test matrix:
+
+```bash
+brew install python@3.12 zbar libraqm
+
+"$(brew --prefix python@3.12)/bin/python3.12" -m venv .venv
+source .venv/bin/activate
+
+python -m pip install -r requirements.txt
+python -m pip install -r tests/requirements.txt
+python -m pip install -r l10n/requirements-l10n.txt
+python -m pip install -e .
+
+# Rebuild Pillow so it detects Homebrew's libraqm installation.
+python -m pip install --force-reinstall --no-binary Pillow Pillow==10.3.0
+
+git submodule update --init --recursive \
+    src/seedsigner/resources/seedsigner-translations
+python setup.py compile_catalog
+
+# Allow pyzbar to find Homebrew's libzbar at runtime.
+export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib"
+```
+
+Verify that Pillow was built with RAQM support:
+
+```bash
+python -c "from PIL import features; print(features.check('raqm'))"
+```
+
+The command should print `True`.
+
+## Running the generator
+
 From the project root, run:
+
 ```bash
 # Generate screenshots for a specific locale
-pytest tests/screenshot_generator/generator.py --locale es
+python -m pytest tests/screenshot_generator/generator.py --locale es
 
 # Generate screenshots for all supported locales
-pytest tests/screenshot_generator/generator.py
+python -m pytest tests/screenshot_generator/generator.py
 ```
 
 You can also run a `coverage` report to see exactly what the screenshots are and are not hitting:
+
 ```bash
 coverage erase
 coverage run -m pytest tests/screenshot_generator/generator.py --locale es && coverage combine && coverage report
@@ -17,5 +72,3 @@ coverage run -m pytest tests/screenshot_generator/generator.py --locale es && co
 # Generate the interactive html report
 coverage html
 ```
-
-Writes the screenshots to a dir in the project root: `seedsigner-screenshots`.

--- a/tests/screenshot_generator/README.md
+++ b/tests/screenshot_generator/README.md
@@ -19,9 +19,11 @@ python setup.py compile_catalog
 <details><summary>macOS instructions</summary>
 <p>
 
-The screenshot generator also needs the native `zbar` and `libraqm` libraries.
-SeedSigner requires Python 3.10 or newer. These instructions use Python 3.12 as a
-known-good development version:
+The general test setup assumes that Python is already installed. The following
+end-to-end macOS setup includes those general test dependencies as well as the native
+`zbar` and `libraqm` libraries required by the screenshot generator. SeedSigner
+requires Python 3.10 or newer; these instructions use Python 3.12 as a known-good
+development version:
 
 ```bash
 brew install python@3.12 zbar libraqm

--- a/tests/screenshot_generator/README.md
+++ b/tests/screenshot_generator/README.md
@@ -16,7 +16,8 @@ pip install -r l10n/requirements-l10n.txt
 python setup.py compile_catalog
 ```
 
-### macOS
+<details><summary>macOS instructions</summary>
+<p>
 
 The screenshot generator also needs the native `zbar` and `libraqm` libraries. These
 steps use Python 3.12, which is included in the project's CI test matrix:
@@ -50,6 +51,9 @@ python -c "from PIL import features; print(features.check('raqm'))"
 ```
 
 The command should print `True`.
+
+</p>
+</details>
 
 ## Running the generator
 

--- a/tests/screenshot_generator/README.md
+++ b/tests/screenshot_generator/README.md
@@ -19,8 +19,9 @@ python setup.py compile_catalog
 <details><summary>macOS instructions</summary>
 <p>
 
-The screenshot generator also needs the native `zbar` and `libraqm` libraries. These
-steps use Python 3.12, which is included in the project's CI test matrix:
+The screenshot generator also needs the native `zbar` and `libraqm` libraries.
+SeedSigner requires Python 3.10 or newer. These instructions use Python 3.12 as a
+known-good development version:
 
 ```bash
 brew install python@3.12 zbar libraqm

--- a/tests/test_gui_components.py
+++ b/tests/test_gui_components.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock
+
+from seedsigner.gui.components import _get_single_paragraph_text_bbox
+
+
+def test_get_single_paragraph_text_bbox_replaces_newlines():
+    font = Mock()
+    expected_bbox = (0, -16, 241, 0)
+    font.getbbox.return_value = expected_bbox
+
+    bbox = _get_single_paragraph_text_bbox(
+        font,
+        "You must remove the\nMicroSD card to continue.",
+    )
+
+    assert bbox == expected_bbox
+    font.getbbox.assert_called_once_with(
+        "You must remove the MicroSD card to continue.",
+        anchor="ls",
+    )


### PR DESCRIPTION
## Summary

- avoid passing paragraph separators to `FreeTypeFont.getbbox()` in text and button metric calculations
- add regression coverage for newline sanitization
- document the complete macOS screenshot-generator setup, including native libraries, Pillow RAQM support, translations, and Homebrew library discovery

## Why

libraqm 0.11 rejects input spanning multiple paragraphs. SeedSigner handles explicit line breaks during its own reflow/rendering, but previously passed the original multiline strings to RAQM during initial font measurement. Fresh macOS Homebrew installations therefore failed with `RuntimeError: raqm_layout() failed`.

## Verification

- `python -m pytest -q` — 189 passed
- `python -m pytest tests/screenshot_generator/generator.py` — 22 locales passed
- manually reproduced and verified on macOS with Python 3.12.13, Pillow 10.3.0, and libraqm 0.11.0