### PR TITLE
Warn users to use real physical dice before dice entropy entry

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants, resize_image_to_fill
 from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen
-from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.gui.screens.screen import ButtonOption, WarningScreen
 from seedsigner.helpers import mnemonic_generation
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
@@ -228,10 +228,40 @@ class ToolsDiceEntropyMnemonicLengthView(View):
             return Destination(BackStackView)
 
         elif button_data[selected_menu_num] == TWELVE:
-            return Destination(ToolsDiceEntropyEntryView, view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__12WORD))
+            return Destination(ToolsDiceEntropyWarningView, view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__12WORD))
 
         elif button_data[selected_menu_num] == TWENTY_FOUR:
-            return Destination(ToolsDiceEntropyEntryView, view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__24WORD))
+            return Destination(ToolsDiceEntropyWarningView, view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__24WORD))
+
+
+
+class ToolsDiceEntropyWarningView(View):
+    def __init__(self, total_rolls: int):
+        super().__init__()
+        self.total_rolls = total_rolls
+
+
+    def run(self):
+        destination = Destination(
+            ToolsDiceEntropyEntryView,
+            view_args=dict(total_rolls=self.total_rolls),
+            skip_current_view=True,  # Prevent going BACK to WarningViews
+        )
+
+        selected_menu_num = self.run_screen(
+            WarningScreen,
+            # TRANSLATOR_NOTE: Inform the user that dice rolls must come from real physical dice
+            status_headline=_("Use real dice"),
+            # TRANSLATOR_NOTE: Instruct the user not to invent or guess dice roll numbers on the device
+            text=_("Roll physical dice yourself. Do not invent or guess numbers on the device."),
+        )
+
+        if selected_menu_num == 0:
+            # User clicked "I Understand"
+            return destination
+
+        elif selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
 
 
 

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -455,6 +455,7 @@ def generate_screenshots(locale):
                 #ScreenshotConfig(ToolsImageEntropyFinalImageView),
                 ScreenshotConfig(tools_views.ToolsImageEntropyMnemonicLengthView),
                 ScreenshotConfig(tools_views.ToolsDiceEntropyMnemonicLengthView),
+                ScreenshotConfig(tools_views.ToolsDiceEntropyWarningView, dict(total_rolls=50)),
                 ScreenshotConfig(tools_views.ToolsDiceEntropyEntryView, dict(total_rolls=50)),
                 ScreenshotConfig(tools_views.ToolsCalcFinalWordNumWordsView),
                 ScreenshotConfig(tools_views.ToolsCalcFinalWordFinalizePromptView),

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -279,3 +279,30 @@ class TestToolsFlows(FlowTest):
                 FlowStep(seed_views.SeedAddressVerificationView),
                 FlowStep(seed_views.SeedAddressVerificationSuccessView),
             ])
+
+
+    def test__dice_entropy__warning__flow(self):
+        """
+            Selecting dice entropy should show a physical-dice warning after mnemonic
+            length selection, before roll entry.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.DICE),
+            FlowStep(tools_views.ToolsDiceEntropyMnemonicLengthView, screen_return_value=0),  # 12 words
+            FlowStep(tools_views.ToolsDiceEntropyWarningView, screen_return_value=0),  # I understand
+            FlowStep(tools_views.ToolsDiceEntropyEntryView),
+        ])
+
+
+    def test__dice_entropy__warning__back__flow(self):
+        """
+            BACK from the dice warning should return to mnemonic length selection.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.DICE),
+            FlowStep(tools_views.ToolsDiceEntropyMnemonicLengthView, screen_return_value=0),  # 12 words
+            FlowStep(tools_views.ToolsDiceEntropyWarningView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(tools_views.ToolsDiceEntropyMnemonicLengthView),
+        ])


### PR DESCRIPTION
## Description

### Problem or Issue being addressed
Users can enter invented dice roll numbers on-device with no guidance that rolls must come from real physical dice, which undermines entropy.

### Solution
Add `ToolsDiceEntropyWarningView` after mnemonic length selection and before dice entry. Uses `WarningScreen` (not dire warnings / not settings-gated) to instruct users to roll physical dice themselves.

### Additional Information
- BACK from the warning returns to length selection
- Continue uses `skip_current_view=True` so BACK from entry does not re-show the warning

### Screenshots
N/A for emulator screenshot capture in this PR; caution screen uses standard `WarningScreen`.
Attached Screenshot
<img width="240" height="240" alt="ToolsDiceEntropyWarningView" src="https://github.com/user-attachments/assets/496e7dd9-42d0-492b-a094-d4a80c243a06" />


---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens
- [x] Yes
- [] No
- [ ] N/A

---

#### I added or updated tests
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS Manual Build
- [ ] SeedSigner OS on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
- [x] I understand