### PR TITLE
docs: add AGENTS.md and a SeedSigner OS context doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,181 @@
+# AGENTS.md
+
+## What this repo is
+
+SeedSigner is an air-gapped, stateless Bitcoin signing device built from inexpensive
+Raspberry Pi hardware. It generates and stores seeds only in memory, and communicates with
+the outside world exclusively by scanning QR codes with its camera and displaying QR codes
+on its screen.
+
+**This repo contains only the Python application.** Two sibling repositories complete the
+product:
+
+| Repo | Contents |
+| --- | --- |
+| `SeedSigner/seedsigner` (here) | The app: Views/Screens/Controller, seed handling, PSBT + QR, tests. |
+| [`SeedSigner/seedsigner-os`](https://github.com/SeedSigner/seedsigner-os) | Buildroot-based OS: kernel config, board defconfigs, rootfs overlay, image build. |
+| [`SeedSigner/seedsigner-translations`](https://github.com/SeedSigner/seedsigner-translations) | `.po`/`.mo` catalogs + non-Latin fonts. Vendored here as a git submodule. |
+
+## Repo map
+
+| Path | Contents |
+| --- | --- |
+| `src/main.py` | Entry point. Parses `--loglevel`, starts `Controller`. |
+| `src/seedsigner/controller.py` | `Controller` singleton, `BackStack`, main loop. |
+| `src/seedsigner/views/` | Business logic per screen. Returns `Destination`s. |
+| `src/seedsigner/gui/` | `Renderer`, `screens/` (reusable UI), `components.py` (primitives). |
+| `src/seedsigner/models/` | `Settings`, `SettingsDefinition`, `Seed`, `SeedStorage`, PSBT parser, QR encode/decode. |
+| `src/seedsigner/hardware/` | Buttons, camera, microSD, display drivers. |
+| `src/seedsigner/helpers/` | embit utils, mnemonic generation, l10n, version, vendored `ur2/`. |
+| `src/seedsigner/resources/` | Fonts, icons, images, and the translations submodule. |
+| `tests/` | pytest suite, `base.py`, `screenshot_generator/`. |
+| `l10n/` | `messages.pot` and the localization guide. |
+| `docs/` | Project documentation. |
+| `tools/` | Standalone CLI scripts (mnemonic verification, version file writer). |
+| `enclosures/`, `docker/` | 3D print files; a test-only container. |
+
+## Architecture
+
+Roughly MVC, deliberately shaped like a Flask app (see `docs/code_structure.md`).
+Canonical files: `src/seedsigner/controller.py`, `src/seedsigner/views/view.py`,
+`src/seedsigner/gui/screens/screen.py`.
+
+- A `View` holds business logic and returns a `Destination` — analogous to a web app
+  returning `response.redirect(URL)`. A `Screen` renders. `gui/components` are primitives.
+  Views must not know about pixel-level rendering.
+- `Destination(View_cls, view_args, skip_current_view, clear_history)`. `BackStackView` is
+  an empty marker class meaning "pop the back stack".
+- `Controller` and `Settings` are singletons (`models/singleton.py`). The `Controller`
+  holds all cross-view state; `MainMenuView` is special-cased to wipe both the back stack
+  and any in-progress flow.
+- Multi-step journeys that can be interrupted (scan a QR mid-flow, then resume) are tracked
+  by `Controller.resume_main_flow` against the `FLOW__*` constants in `controller.py`.
+
+Two things that trip people up:
+
+- **Redirect pattern:** call `self.set_redirect(destination)` from `__init__` /
+  `__post_init__`, then return immediately. A View that fails to call
+  `super().__init__()` raises on `has_redirect`. This is the most common footgun here.
+- **Import `Controller`, Screens, and follow-on Views inside methods, not at module top.**
+  Circular imports are structural in this design; `controller.py` documents this in-code.
+
+## Core domain
+
+- **Seeds** (`models/seed.py`) are BIP-39 mnemonics, optionally with a passphrase, plus an
+  `ElectrumSeed` subclass with deliberately reduced functionality (`docs/electrum.md`).
+  They live in `SeedStorage` on the `Controller` — in memory only, for as long as the
+  device is powered.
+- **Seed creation** supports BIP-39 word entry, dice rolls, and camera image entropy
+  (`helpers/mnemonic_generation.py`, which doubles as a verification CLI — see
+  `docs/dice_verification.md`).
+- **QR is the only I/O channel.** `models/decode_qr.py`, `models/encode_qr.py`, and
+  `models/qr_type.py` handle every supported format: animated UR2 PSBTs, Specter base64,
+  SeedQR and CompactSeedQR, plain mnemonics, and SettingsQR. Formats are specified in
+  `docs/qr_formats.md`; the SeedQR spec and its test vectors are in `docs/seed_qr/`.
+- **PSBT signing** parses with `models/psbt_parser.py` and walks the user through a review
+  flow in `views/psbt_views.py` (overview → math → address details → change verification →
+  finalize) before anything is signed.
+- **Settings** are declared, not hardcoded: every option is a `SettingsEntry` in
+  `models/settings_definition.py`, which drives the settings UI, SettingsQR parsing, and
+  on-disk persistence automatically. Add options there, not in the views.
+- Views are grouped by domain: `psbt_views`, `scan_views`, `seed_views`, `settings_views`,
+  `tools_views`.
+
+## Runtime environment
+
+In production the app runs on SeedSigner OS, not a general-purpose Linux host, and the
+differences matter when writing code:
+
+- **No network stack exists.** `CONFIG_NET` is not enabled in any release kernel, and
+  BusyBox ships without networking applets. Nothing in this codebase may assume sockets,
+  DNS, HTTP, or NTP are available.
+- **The root filesystem is an initramfs in RAM** and is discarded on power-off. The only
+  writable location is `/mnt/microsd`, the FAT boot partition, and only while a card is
+  inserted — that is where `settings.json` goes if the user enables persistent settings.
+- **The app runs as root** from `/opt/src`, launched by a BusyBox init script. There is no
+  other user account; the root account has no password and cannot be logged into.
+- **The shipped tree is stripped**: no `tests/`, `tools/`, `docs/`, `.git`, or packaging
+  metadata reach the device. Don't rely on them at runtime.
+- **Behavior is keyed off the hostname.** `Settings.HOSTNAME` is compared against the
+  literal `"seedsigner-os"` to gate the settings path, microSD detection, and version
+  lookups. Development images use a different hostname and take the fallback paths.
+- `-dev` OS images add networking and SSH for on-device development and are explicitly not
+  security-hardened. They are not representative of production.
+
+[`docs/seedsigner_os.md`](docs/seedsigner_os.md) covers the OS in depth — boot chain, how
+this repo's code gets into an image, per-board hardware differences, and reproducible
+builds. Read it before changing anything that touches boot, packaging, persistence, or
+process privileges, and before drawing conclusions about the device's security properties.
+
+## Commands
+
+```bash
+pip3 install -r requirements.txt -r tests/requirements.txt -r l10n/requirements-l10n.txt
+pip3 install -e .                      # required: `seedsigner` must be importable
+                                       # system dep: libzbar0 (or zbar-tools)
+python setup.py compile_catalog        # .po -> .mo; needed before running the app or l10n tests
+pytest
+pytest tests/test_seed.py::test_name
+pytest tests/screenshot_generator/generator.py --locale es
+./tests/run_full_coverage.sh
+```
+
+Python >= 3.10; CI runs 3.10 and 3.12. Clone with `--recurse-submodules`.
+**No linter or formatter is configured** — match the style of surrounding code and do not
+reformat untouched lines.
+
+## Testing
+
+- Read `tests/base.py` first. It stubs the hardware modules into `sys.modules` with
+  `MagicMock` **before** any `seedsigner` import — that ordering is load-bearing, and it is
+  the only way this code runs off-device. There is no emulator in the production tree.
+  `BaseTest` resets the `Controller` and `Settings` singletons between tests.
+- `FlowTest` / `FlowStep` / `run_sequence()` is the framework for asserting navigation
+  sequences. New or changed **flows require FlowTests**; new or changed functionality
+  requires unit tests. This is the PR template's wording, not a suggestion.
+- Modules with hardware dependencies are `omit`-ed from coverage in `pyproject.toml` —
+  don't chase coverage there.
+- New or modified screens need screenshots in the PR; generate them with the screenshot
+  generator. It hard-fails if libraqm is unavailable, since device-parity rendering
+  depends on it.
+
+## Localization
+
+Catalogs live in the **`seedsigner-translations` submodule** at
+`src/seedsigner/resources/seedsigner-translations` (tracks `dev`), together with the
+CJK/Arabic/Devanagari fonts. `*.po` and `*.mo` are gitignored in *this* repo. 21 locales
+currently ship. `SettingsConstants.get_detected_languages()` autodiscovers languages by
+walking for `.mo` files, so shipping a catalog is what enables a language.
+
+Translation happens on **Transifex**, not in pull requests. Pull with `tx pull -f --all`
+from the submodule directory, then `python setup.py compile_catalog`.
+
+Three marking techniques — full rationale in [`l10n/README.md`](l10n/README.md):
+
+- **`ButtonOption("...")`** for `button_data` entries. Marks the string for translation but
+  **never returns a translated value**, because class attributes are evaluated once at
+  import time and the English literal must stay the lookup key.
+- **`_mft("...")`** (`mark_for_translation`, a no-op in `helpers/l10n.py`) for other
+  class-level attributes. Used sparingly; prefer to avoid it.
+- **`from gettext import gettext as _`** for dynamically evaluated code. Marks *and*
+  retrieves.
+
+Rule of thumb, from `l10n/README.md`: *"Mark for translation in the `View`. Retrieve
+translated values in the `Screen`. Pass final display text into the basic gui
+`Component`s."*
+
+A `# TRANSLATOR_NOTE:` comment must sit on the line immediately preceding the executable
+line it annotates. `.format()` goes **outside** the `_()` wrapper. Use `ngettext` for
+plurals. Extraction keywords are configured in `setup.cfg`.
+
+## Conventions
+
+- The default branch is **`dev`**, not `main`. Both submodules track `dev`.
+- PR expectations come from `.github/pull_request_template.md`: keep changes limited in
+  scope, split unrelated findings into separate PRs, include screenshots for UI changes,
+  and state which platform you tested on hands-on.
+- Navigation wording (`views/view.py`): "Next" continues, "Done" ends a flow
+  non-destructively, "OK"/"Close" exits a screen non-destructively, "Cancel" ends a task
+  destructively.
+- **Documentation in `docs/` can lag the code.** Treat the source tree as authoritative
+  and verify any command, path, or filename from a doc against the tree before acting on it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+

--- a/README.md
+++ b/README.md
@@ -356,5 +356,7 @@ Letter templates(8.5in * 11in):
 # Build from Source
 See the [SeedSigner OS repo](https://github.com/SeedSigner/seedsigner-os/) for instructions.
 
+For an overview of how SeedSigner OS works and how this application runs on it, see [docs/seedsigner_os.md](docs/seedsigner_os.md).
+
 # Developer Local Build Instructions
 Raspberry Pi OS is commonly used for development. See the [Raspberry Pi OS Build Instructions](docs/raspberry_pi_os_build_instructions.md)

--- a/docs/seedsigner_os.md
+++ b/docs/seedsigner_os.md
@@ -1,0 +1,311 @@
+# SeedSigner OS: cross-repo context
+
+The SeedSigner application in this repo does not ship on its own. In production it runs on
+**SeedSigner OS**, a purpose-built Linux system maintained in a separate repository:
+[github.com/SeedSigner/seedsigner-os](https://github.com/SeedSigner/seedsigner-os).
+
+The application is written against that system, not a general-purpose Linux host. This
+document describes what the device actually is, so that assumptions about networking,
+persistence, filesystems, and privileges start from the real environment.
+
+**If your task touches boot behavior, kernel configuration, packaging, image building, or
+the runtime environment, clone the OS repo alongside this one and read it before proposing
+changes:**
+
+```bash
+git clone --recursive https://github.com/SeedSigner/seedsigner-os.git
+```
+
+---
+
+## 1. What seedsigner-os is
+
+A [Buildroot](https://www.buildroot.org) external tree that cross-compiles a complete
+Linux system — kernel and userspace — from source for Raspberry Pi hardware.
+
+Buildroot itself is a git submodule at `opt/buildroot`, pinned to commit `bf2a2858aa` of
+`github.com/seedsigner/buildroot`. That fork is **upstream Buildroot 2024.11.4 plus
+exactly one commit**, which touches only `package/python3/python3.mk`: it adds
+`-f --invalidation-mode=checked-hash` to `.pyc` generation and disables Buildroot's
+`PYTHON3_REMOVE_PY_FILES` finalize hook so the boards' own `post-build.sh` can handle it
+instead. Both changes serve reproducible builds; the fork carries no other delta from
+upstream.
+
+Docker is the supported build path (`Dockerfile`, `docker-compose.yml`); there is a
+Debian-only non-Docker path in `docs/without_docker.md`.
+
+## 2. Layout
+
+```
+opt/build.sh                      the only build entrypoint
+opt/buildroot/                    submodule, pinned commit
+opt/{pi0,pi02w,pi2,pi4}/          release board configs
+opt/{pi0,pi02w,pi2,pi4}-dev/      developer board configs
+opt/rootfs-overlay/               release userspace overlay
+opt/rootfs-overlay-dev/           dev overlay, applied second
+opt/external-packages/            custom Buildroot packages
+opt/patches/                      BR2_GLOBAL_PATCH_DIR
+```
+
+Each release board directory contains `configs/<board>_defconfig` and a `board/` holding
+`kernel.config`, `busybox.config`, `boot_config.txt`, `boot_cmdline.txt`, `post-build.sh`,
+and `post-image-seedsigner.sh`.
+
+**The entire release userspace overlay is eight files** — this is the whole delta on top of
+the Buildroot skeleton:
+
+```
+opt/rootfs-overlay/start.sh
+opt/rootfs-overlay/etc/fstab
+opt/rootfs-overlay/etc/shadow
+opt/rootfs-overlay/etc/mdev.conf
+opt/rootfs-overlay/etc/mdev/mdev.sh
+opt/rootfs-overlay/etc/init.d/S02seedsigner
+opt/rootfs-overlay/etc/init.d/S10mdev
+opt/rootfs-overlay/.gitignore
+```
+
+There is no `/etc/inittab`, no network configuration, and no SSH in the release overlay.
+
+`opt/external-packages/` holds Buildroot packages for this project's Python dependencies:
+`python-embit`, `python-pyzbar` (SeedSigner's pyzbar fork), `python-urtypes`,
+`python-picamera`, `python-pillow-ep`, `python-mock`, `libraqm`, plus `gh` (dev images
+only). Each carries a `.hash` file with checksums for its source tarball.
+
+`opt/patches/` contains two patches applied to upstream sources: a FAT `nodirty` mount
+option for the kernel (so a flashed card can be byte-compared against the published image
+without the driver setting the volume dirty flag), and a numpy patch that blanks
+build-machine info for cross-architecture reproducibility.
+
+## 3. Boot chain
+
+1. The Pi's GPU bootloader reads the microSD card and loads `bootcode.bin`.
+2. `start_x.elf` reads `config.txt` and `cmdline.txt`, then loads the kernel.
+3. The CPU boots `zImage` — which contains the kernel **and** the entire root filesystem.
+4. BusyBox init runs `/etc/init.d/S02seedsigner`, which runs `/start.sh`.
+5. `/start.sh` is three lines: `cd /opt/src/` then `/usr/bin/python3 main.py &`.
+
+The app therefore runs as root, from `/opt/src`, in RAM.
+
+## 4. How this repo's code gets into the image
+
+**There is no Buildroot package for the application.** `opt/build.sh` clones this
+repository directly into the rootfs overlay:
+
+```sh
+seedsigner_app_repo="https://github.com/SeedSigner/seedsigner.git"
+seedsigner_app_repo_branch="dev"
+git clone --recurse-submodules --depth 1 -b "${branch}" "${repo}" "${rootfs_overlay}/opt/"
+```
+
+`--app-repo`, `--app-branch`, and `--app-commit-id` override the defaults;
+`--app-commit-id` does a full clone plus `git reset --hard`. Because
+`BR2_ROOTFS_OVERLAY="../rootfs-overlay/"`, the checkout lands at `/opt` on the device, so
+`src/main.py` becomes `/opt/src/main.py`.
+
+The build then processes the checkout:
+
+- **`compile_translations_and_fonts()`** creates a virtualenv, installs Babel and
+  fonttools, runs `python3 setup.py compile_catalog`, then uses `pyftsubset` to subset the
+  bundled fonts down to only the glyphs the compiled translations actually use, deleting
+  the originals. Font size is a real constraint on a 50 MB image.
+- **`write_version_json()`** runs `tools/write_versionfile.py` with
+  `SEEDSIGNER_OS_BUILDER=1` to produce `src/seedsigner/version.json`. This file is
+  load-bearing: a missing file or a null field makes the app raise at the splash screen,
+  which presents as an unrecoverable boot hang. This repo's `.github/workflows/build.yml`
+  asserts on it explicitly for that reason.
+- **`delete_unnecessary_files()`** strips `.github`, `docker`, `docs`, `enclosures`,
+  `l10n`, `seedsigner-screenshots`, `tests`, `tools`, all `.git*`, `requirements*.txt`,
+  `setup.*`, `pyproject.toml`, `seedsigner_pubkey.gpg`, and every `.po` file.
+
+**A release device therefore has no tests, no tools, no `.git`, and no packaging
+metadata.** The board's `post-build.sh` then byte-compiles `/opt/src` deterministically
+(`SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 --invalidation-mode=checked-hash`).
+
+## 5. Security posture
+
+Effective kernel values, after Kconfig defaults and `select` statements are resolved. Note
+that the `kernel.config` files in the OS repo are build inputs, so a symbol's value there is
+not always its final one.
+
+| | pi0 | pi02w | pi2 | pi4 |
+| --- | --- | --- | --- | --- |
+| `CONFIG_NET` | `n` | `n` | `n` | `n` |
+| `CONFIG_MODULES` | `n` | `n` | `n` | `n` |
+| `CONFIG_USB` | `n` | `y` | `y` | `y` |
+| `CONFIG_SERIAL_8250_CONSOLE` / `AMBA_PL011_CONSOLE` | `n` | `y` | `y` | `y` |
+| `CONFIG_EXT4_FS` | `n` | `n` | `n` | `n` |
+| `CONFIG_SUSPEND` | `n` | `n` | `n` | `n` |
+| `CONFIG_I2C` | `y` | `y` | `y` | `y` |
+| `CONFIG_SWAP` | `y` | `y` | `y` | `y` |
+| `dtoverlay=disable-wifi` / `-bt` | no | yes | yes | yes |
+
+**No networking, on any board.** `CONFIG_NET` is `n` on all four boards, so there is no
+socket layer at all: no
+`NETDEVICES`, no `CFG80211`/`MAC80211`, no `BRCMFMAC`, no Bluetooth. No wifi firmware
+package is enabled in the release defconfigs. BusyBox is built without `ifconfig`,
+`iproute`, `ping`, `route`, `netcat`, `nslookup`, `httpd`, `arp`, `wget`, or `udhcpc`, and
+`post-build.sh` deletes Buildroot's `S40network` init script. On `pi02w`/`pi2`/`pi4` the
+radios are *additionally* disabled at the device-tree level in `boot_config.txt` — defense
+in depth on top of a kernel that cannot use them.
+
+**Nothing loadable at runtime.** `CONFIG_MODULES=n` on all four boards, so every `=m` line
+in those config files is dead and no `.ko` files ship.
+
+**Root is locked.** `opt/rootfs-overlay/etc/shadow` ships `root:*:::::::` (and `*` for
+every other account). Note the release defconfigs contain
+`BR2_TARGET_GENERIC_ROOT_PASSWD="passworDT"` — this is **inert**. Buildroot's password hook
+runs before overlays are copied onto the target tree, so the overlay's locked shadow file
+always overwrites it. The dev board configs have to explicitly re-apply a password in their
+`post-build.sh` to undo this, and say so in comments.
+
+**A getty does run, and cannot be logged into.** The release overlay ships no
+`/etc/inittab`, so Buildroot installs its own (`package/busybox/inittab`) and rewrites it
+at build time. `BR2_TARGET_GENERIC_GETTY` defaults to `y` and `BR2_TARGET_GENERIC_GETTY_PORT`
+defaults to `"console"`; no release defconfig overrides either, so `busybox.mk` substitutes
+the template's commented-out getty line for a live one:
+
+```
+console::respawn:/sbin/getty -L  console  vt100
+```
+
+So a login prompt *is* respawned on `/dev/console`. It cannot be satisfied: the only
+account is `root`, and `root` has no valid password hash. No login is possible; a getty
+does nonetheless exist. Which physical interface `/dev/console` reaches is determined by
+the board's device tree at boot.
+
+**USB and serial, precisely.** `CONFIG_USB` and the 8250/PL011 console drivers *are* built
+on `pi02w`, `pi2`, and `pi4` (not on `pi0`). However, **no release board passes a
+`console=` argument**: `boot_cmdline.txt` is empty on `pi02w`/`pi2`/`pi4` and contains only
+`spidev.bufsiz=131072` on `pi0`. `CONFIG_I2C` is `y` on all four boards, though
+its bus drivers are `=m` and therefore dead under `CONFIG_MODULES=n`.
+
+**Filesystem.** Only `CONFIG_MSDOS_FS` and `CONFIG_VFAT_FS` — the release kernel cannot
+mount ext4 at all. `CONFIG_SUSPEND` is `n`.
+
+**Swap is compiled in but never used.** `CONFIG_SWAP` is `y` on all four boards — the board
+configs comment out `CONFIG_ZSWAP`/`CONFIG_FRONTSWAP`/`CONFIG_NFS_SWAP` but never disable
+`CONFIG_SWAP` itself, which defaults on — and BusyBox's inittab runs `swapon -a` at sysinit.
+Nothing is ever swapped: `/etc/fstab` declares no swap entry and the image contains no swap
+partition or file.
+
+**Slimming.** `post-build.sh` deletes the `syslogd`, `klogd`, `sysctl`, `mdev`, `seedrng`,
+`network`, and `pigpio` init scripts; the rpi-userland demo binaries (`raspistill`,
+`raspivid`, `vcgencmd`, `dtoverlay`, `zbarcam`, …); and Python stdlib subsystems with no
+importer — `asyncio`, `email`, `xml`, `http`, `multiprocessing`, `wsgiref`, `venv`,
+`zoneinfo`, `unittest`, `ensurepip`, plus the matching C extensions. Only `.pyc` files ship
+for the stdlib.
+
+## 6. The one persistent write path
+
+The root filesystem is RAM-only and discarded on every power cycle. `opt/rootfs-overlay/etc/fstab`
+mounts only `proc`, `devpts`, and `sysfs`; its `/dev/root` line is `rw,noauto` and is never
+actually mounted.
+
+The exception is the FAT boot partition. `etc/mdev.conf` routes `mmcblk0p1` hotplug events
+to `etc/mdev/mdev.sh`, which does:
+
+```sh
+mount -o sync,nodirty $DEVNAME /mnt/microsd || mount -o sync $DEVNAME /mnt/microsd
+echo -n "add" > /tmp/mdev_fifo
+```
+
+So `/mnt/microsd` is the card, mounted read-write with `sync`, and `/tmp/mdev_fifo` is the
+insert/remove signal. This is what `src/seedsigner/hardware/microsd.py` reads
+(`MOUNT_POINT = "/mnt/microsd"`, `FIFO_PATH = "/tmp/mdev_fifo"`) and where
+`Settings.SETTINGS_FILENAME` points when persistent settings are enabled. Seeds are never
+written there.
+
+## 7. The hostname coupling
+
+The single most important behavioral link between the two repos. `src/seedsigner/models/settings.py`:
+
+```python
+HOSTNAME = platform.uname()[1]
+SEEDSIGNER_OS = "seedsigner-os"
+SETTINGS_FILENAME = "/mnt/microsd/settings.json" if HOSTNAME == SEEDSIGNER_OS else "settings.json"
+```
+
+The hostname is set by `BR2_TARGET_GENERIC_HOSTNAME` in the board defconfigs:
+`"seedsigner-os"` on release images, `"seedsigner-dev"` on dev images. Three subsystems in
+this repo branch on it:
+
+- the settings file path falls back to a relative `settings.json` off SeedSigner OS,
+- the microSD insert/remove polling thread in `hardware/microsd.py` only runs on
+  SeedSigner OS (elsewhere `is_inserted` is hardcoded `True`),
+- `helpers/version.py` gates its git-based lookups behind a `NotAllowedInSeedSignerOS`
+  guard.
+
+If you change any of these, changing the hostname string in either repo alone will silently
+break the coupling.
+
+## 8. Dev images versus release images
+
+> *"They are not security-hardened: networking and SSH are enabled. Never use a dev image
+> with real funds."* — seedsigner-os `docs/dev_images.md`
+
+Built with `./build.sh --<board> --dev`. The dev board config deliberately *references* the
+release kernel and busybox configs and layers a fragment on top, and sets
+`BR2_ROOTFS_OVERLAY="../rootfs-overlay/ ../rootfs-overlay-dev/"` so the dev overlay is
+applied second and wins.
+
+| | Release | Dev |
+| --- | --- | --- |
+| Networking | absent from kernel and userspace | `CONFIG_NET`/`INET`/`CFG80211`/`BRCMFMAC` on; wifi firmware, `wpa_supplicant`, `iw` |
+| SSH | none | dropbear, root password `seedsigner`, or `authorized_keys` on the boot partition |
+| Discovery | none | mDNS, reachable at `seedsigner.local` |
+| USB gadget | none | `dtoverlay=dwc2` + `g_ether`, static `10.55.0.1`, `udhcpd` |
+| Console | no `console=` argument, root locked | passwordless root shell on `tty1` and serial |
+| Partitions | one 50 MB FAT32 | 256 MB FAT (`SEEDSIGNDEV`) + persistent ext4 (`seedsigner-data`), grown on first boot |
+| App source | baked-in `/opt/src` | prefers `/mnt/data/seedsigner/src/main.py` if present |
+| Extras | none | pip, git, gh, rsync, bash, tmux, gdb, strace, htop, jq, gnupg2, nano, parted |
+| Slimming | full | skipped — complete Python stdlib and `.py` sources kept |
+
+Dev-image behavior is not evidence about production behavior in either direction.
+
+## 9. Boards and hardware
+
+| Image | Boards | Flag |
+| --- | --- | --- |
+| `seedsigner_os.<tag>.pi0.img` | Pi Zero, Pi Zero W | `--pi0` |
+| `seedsigner_os.<tag>.pi02w.img` | Pi Zero 2 W, Pi 3 Model B | `--pi02w` |
+| `seedsigner_os.<tag>.pi2.img` | Pi 2 Model B | `--pi2` |
+| `seedsigner_os.<tag>.pi4.img` | Pi 4 Model B | `--pi4` |
+
+All boards build the same pinned `raspberrypi/linux` kernel tarball (commit
+`14b35093ca68`, rpi-5.15.y) as 32-bit ARM against a glibc toolchain with Python 3.12. They
+differ in CPU target (`arm1176jzf_s` / `cortex_a53` / `cortex_a7` / `cortex_a72`), device
+tree names, and firmware variant (`PI_X` versus `PI4_X` for the Pi 4).
+
+- **Display** is driven from Python over `spidev` (`dtparam=spi=on`, `CONFIG_SPI_SPIDEV`,
+  `CONFIG_SPI_BCM2835`). There is **no in-kernel panel driver** — the ST7789/ILI9341
+  drivers in `src/seedsigner/hardware/displays/` do the work.
+- **Camera** uses the legacy MMAL stack: `start_x=1` in `boot_config.txt`, plus
+  `rpi-userland` and `python-picamera`.
+- **Buttons** use `RPi.GPIO` over `CONFIG_GPIO_SYSFS`; all button logic lives in this repo.
+- **QR** decoding uses `zbar` and SeedSigner's `pyzbar` fork.
+
+## 10. Building and reproducibility
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64   # required for a reproducible result
+export BOARD_TYPE=pi0
+export RELEASE_TAG=x.y.z
+git checkout $RELEASE_TAG
+git submodule init && git submodule update
+SS_ARGS="--$BOARD_TYPE --app-branch=$RELEASE_TAG" docker compose up --force-recreate --build
+```
+
+Other `build.sh` flags: `--all`, `--dev`, `--no-clean`, `--skip-repo`, `--app-repo`,
+`--app-commit-id`, `--no-op`. Output lands in `images/seedsigner_os.<branch>.<board>.img`.
+Expect 25 minutes to 2.5+ hours and 20–30 GB of disk.
+
+`BR2_REPRODUCIBLE=y` is set on every board, and the image build is deliberately
+deterministic: a fixed disk timestamp, a fixed FAT volume ID and label, `mkfs.vfat
+--invariant`, `chmod`/`touch` normalization of every boot file, sorted globbing instead of
+directory copies, and the `nodirty` FAT kernel patch so a card can be byte-compared to the
+flashed image. A build that reproduces should match the published release hash.
+
+**On signing:** the OS build prints a `sha256sum` of the finished image and does no signing
+of any kind. Release images are published and PGP-signed on *this* repo's releases page;
+verification instructions are in this repo's `README.md`.


### PR DESCRIPTION
> [!NOTE]
> Based on the order of merging PRs, if this is merged after the PRs that migrate to uv, I would like to change the commands, etc that are listed in the doc.

## Description

### Problem or Issue being addressed

SeedSigner's production software spans three repos, but this one is the only one most people ever read. Because the OS lives in [seedsigner-os](https://github.com/SeedSigner/seedsigner-os), contributors and AI coding agents working here have no visibility into the environment this code actually runs in, and end up reasoning about it as if it were a general-purpose Linux host.

That leads to wasted effort in both directions: patches that assume capabilities the device doesn't have, and reports about network exposure, persistence, or process privileges that don't apply to a release image — a release kernel has no network stack compiled in at all, and the root filesystem is a RAM-only initramfs.

### Solution

- **`AGENTS.md`** at the repo root, following the [agents.md](https://agents.md) convention (a format read automatically by Claude Code, Codex, Cursor, etc). It covers what the project is and how the three repos relate, the repo map, the View/Screen/Controller model plus its two recurring footguns (the redirect pattern and the structural need for in-method imports), the core domain (seeds, QR as the only I/O channel, the PSBT review flow, the declarative settings model), the runtime environment, exact commands, testing expectations, and the l10n marking rules.

- **`docs/seedsigner_os.md`** as the deeper cross-repo reference: what seedsigner-os is, its layout, the boot chain, how this repo's code is injected into an image, the per-board runtime environment, the `/mnt/microsd` write path, the hostname coupling between the two repos, dev-vs-release image differences, and reproducible builds.

- Plus a one-line link to the new doc from `README.md`'s "Build from Source" section.

Kernel-level statements are effective values rather than what the `kernel.config` inputs literally contain, since Kconfig defaults and `select` statements can change a symbol from what the input file suggests. Two of them may be worth a second look from someone who knows the OS better than the docs describe it: a getty does respawn on `/dev/console` on release images (it can't be logged into — `root` is the only account and has no valid password hash), and `CONFIG_SWAP` is `y` on all four boards, though no swap partition or file exists and `/etc/fstab` declares no swap entry.

---

This pull request is categorized as a:

- [x] Documentation

---

## Checklist

#### I ran `pytest` locally
- [x] N/A

---

#### I included screenshots of any new or modified screens

- [x] N/A

---

#### I added or updated tests

- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):

- [x] N/A

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand
