### PR TITLE
Add SECURITY.md with vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security policy
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Please report any vulnerability or any bug that could potentially affect the security of users' funds by mail to:
+
+- [`kdmukai.vision749@passmail.net`](mailto:kdmukai.vision749@passmail.net)
+- [`nick@klockenga.net`](mailto:nick@klockenga.net)
+
+In the subject type `[SeedSigner] Security Report: <short description>`
+and in the body a long description describing the issue. We aim to respond
+within one week and patch within 90 days.
+
+### What to include
+
+To help triage the report quickly, please include as much of the following as you can:
+
+- The SeedSigner version
+- A description of the vulnerability and its impact
+- Steps to reproduce, ideally with a proof of concept
+
+## Scope
+
+This policy covers SeedSigner and related build repos (ie seedsigner-os).


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

The repo has no documented way to report security vulnerabilities privately. Without a `SECURITY.md`, GitHub shows no "Report a vulnerability" guidance, and researchers who find a bug affecting users' funds have no obvious channel other than opening a public issue.

### Solution

Add a simple `SECURITY.md` at the repo root.

Kept intentionally minimal as a starting point that can be expanded.

### Additional Information

Documentation only; no code changes. The response/patch timelines are a stated aim, not a guarantee — worth confirming the maintainers are comfortable with those numbers.

---

This pull request is categorized as a:

- [x] Documentation

---

## Checklist

#### I ran `pytest` locally
- [x] N/A

---

#### I included screenshots of any new or modified screens
- [x] N/A

---

#### I added or updated tests
- [x] N/A

---