### PR TITLE
Use side button to confirm dice rolls

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1115,6 +1115,7 @@ class KeyboardScreen(BaseTopNavScreen):
         * key_height: Specify `None` to maximize key height to available space.
         * keys_charset: Specify the chars displayed on the keys of the keyboard.
         * keys_to_values: Optional mapping from key_charset to input value (e.g. dice icon to digit).
+        * key_confirm_inputs: Hardware inputs that lock in a highlighted keyboard key.
         * return_after_n_chars: exits and returns the user's input after n characters.
         * show_save_button: Render a KEY3 soft button for save & exit
         * initial_value: initialize the TextEntryDisplay with an existing string
@@ -1126,6 +1127,7 @@ class KeyboardScreen(BaseTopNavScreen):
     key_height: int = None
     keys_charset: str = None
     keys_to_values: dict = None
+    key_confirm_inputs: list = field(default_factory=lambda: [HardwareButtonsConstants.KEY_PRESS])
     return_after_n_chars: int = None
     show_save_button: bool = False
     initial_value: str = ""
@@ -1221,10 +1223,16 @@ class KeyboardScreen(BaseTopNavScreen):
     def _run(self):
         self.cursor_position = len(self.user_input)
 
+        click_inputs = list(dict.fromkeys(
+            [HardwareButtonsConstants.KEY_PRESS] + self.key_confirm_inputs
+        ))
+        if self.show_save_button and HardwareButtonsConstants.KEY3 not in click_inputs:
+            click_inputs.append(HardwareButtonsConstants.KEY3)
+
         # Start the interactive update loop
         while True:
             input = self.hw_inputs.wait_for(
-                HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN + [HardwareButtonsConstants.KEY_PRESS, HardwareButtonsConstants.KEY3]
+                HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN + click_inputs
             )
 
             with self.renderer.lock:
@@ -1233,6 +1241,10 @@ class KeyboardScreen(BaseTopNavScreen):
                 # Check possible exit conditions   
                 if self.top_nav.is_selected and input == HardwareButtonsConstants.KEY_PRESS:
                     return RET_CODE__BACK_BUTTON
+
+                elif self.top_nav.is_selected and input in self.key_confirm_inputs:
+                    # Side-button confirmation is only valid for a highlighted keyboard key.
+                    continue
 
                 elif self.show_save_button and input == HardwareButtonsConstants.KEY3:
                     # Save!
@@ -1277,8 +1289,10 @@ class KeyboardScreen(BaseTopNavScreen):
                             self.cursor_position -= 1
                             title_needs_update = True
                             
-                elif input == HardwareButtonsConstants.KEY_PRESS and ret_val not in Keyboard.ADDITIONAL_KEYS:
+                elif input in self.key_confirm_inputs and ret_val not in Keyboard.ADDITIONAL_KEYS:
                     # User has locked in the current letter
+                    self.render_key_confirmation_feedback()
+
                     if self.keys_to_values:
                         # Map the Key display char to its output value (e.g. dice icon to digit)
                         ret_val = self.keys_to_values[ret_val]
@@ -1302,13 +1316,18 @@ class KeyboardScreen(BaseTopNavScreen):
                 elif input in HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN:
                     # Live joystick movement; haven't locked this new letter in yet.
                     # Leave current spot blank for now. Only update the active keyboard keys
-                    # when a selection has been locked in (KEY_PRESS) or removed ("del").
+                    # when a selection has been locked in or removed ("del").
                     pass
 
                 # Render the text entry display and cursor block
                 self.text_entry_display.render(self.user_input)
 
                 self.renderer.show_image()
+
+
+    def render_key_confirmation_feedback(self):
+        """Optionally render feedback for a dedicated keyboard confirmation input."""
+        pass
 
 
     def update_title(self) -> bool:

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -6,7 +6,7 @@ from typing import Any
 from PIL.Image import Image
 from seedsigner.gui.renderer import Renderer
 from seedsigner.hardware.camera import Camera
-from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea
+from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconButton, IconTextLine, SeedSignerIconConstants, TextArea
 
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, ButtonListScreen, ButtonOption, KeyboardScreen
 from seedsigner.hardware.buttons import HardwareButtonsConstants
@@ -171,6 +171,7 @@ class ToolsDiceEntropyEntryScreen(KeyboardScreen):
         self.cols = 3
         self.keyboard_font_name = GUIConstants.ICON_FONT_NAME__FONT_AWESOME
         self.keyboard_font_size = 36
+        self.key_confirm_inputs = [HardwareButtonsConstants.KEY1]
         self.keys_charset = "".join([
             FontAwesomeIconConstants.DICE_ONE,
             FontAwesomeIconConstants.DICE_TWO,
@@ -192,6 +193,35 @@ class ToolsDiceEntropyEntryScreen(KeyboardScreen):
 
         # Now initialize the parent class
         super().__post_init__()
+
+        # Keep the full-width dice grid while making room for a visible KEY1
+        # confirmation button beside the roll history field.
+        right_panel_buttons_width = 60
+        self.text_entry_display.rect = (
+            GUIConstants.EDGE_PADDING,
+            self.top_nav.height,
+            self.canvas_width - right_panel_buttons_width,
+            self.top_nav.height + 30,
+        )
+
+        self.confirm_button = IconButton(
+            icon_name=SeedSignerIconConstants.CHECK,
+            icon_color=GUIConstants.SUCCESS_COLOR,
+            width=right_panel_buttons_width,
+            screen_x=self.canvas_width - right_panel_buttons_width + GUIConstants.COMPONENT_PADDING,
+            screen_y=self.top_nav.height,
+        )
+        self.components.append(self.confirm_button)
+
+
+    def render_key_confirmation_feedback(self):
+        self.confirm_button.is_selected = True
+        self.confirm_button.render()
+        self.renderer.show_image()
+
+        # Leave the deselected state on the canvas for the normal end-of-loop render.
+        self.confirm_button.is_selected = False
+        self.confirm_button.render()
     
 
     def update_title(self) -> bool:

--- a/tests/test_keyboard_screen.py
+++ b/tests/test_keyboard_screen.py
@@ -1,0 +1,161 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Keep this test runnable on non-Raspberry Pi hardware, including in isolation.
+sys.modules.setdefault("RPi", MagicMock())
+sys.modules.setdefault("RPi.GPIO", MagicMock())
+sys.modules.setdefault("seedsigner.hardware.ST7789", MagicMock())
+sys.modules.setdefault("picamera", MagicMock())
+sys.modules.setdefault("picamera.array", MagicMock())
+
+
+from seedsigner.gui.keyboard import Keyboard
+from seedsigner.gui.screens import screen as screen_module
+from seedsigner.gui.screens import tools_screens
+from seedsigner.gui.screens.screen import KeyboardScreen, RET_CODE__BACK_BUTTON
+from seedsigner.gui.screens.tools_screens import ToolsDiceEntropyEntryScreen
+
+
+class HardwareInputs:
+    KEY_LEFT = 1
+    KEY_RIGHT = 2
+    KEY_UP = 3
+    KEY_DOWN = 4
+    KEY_PRESS = 5
+    KEY1 = 6
+    KEY2 = 7
+    KEY3 = 8
+
+    KEYS__LEFT_RIGHT_UP_DOWN = [KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN]
+
+
+def make_keyboard_screen(monkeypatch, inputs, *, user_input="", confirm_inputs=None,
+                         return_after_n_chars=1, show_save_button=False):
+    monkeypatch.setattr(screen_module, "HardwareButtonsConstants", HardwareInputs)
+
+    screen = object.__new__(KeyboardScreen)
+    screen.user_input = user_input
+    screen.key_confirm_inputs = confirm_inputs or [HardwareInputs.KEY_PRESS]
+    screen.return_after_n_chars = return_after_n_chars
+    screen.show_save_button = show_save_button
+    screen.keys_to_values = {"die": "1"}
+
+    screen.hw_inputs = MagicMock()
+    screen.hw_inputs.wait_for.side_effect = inputs
+
+    screen.top_nav = MagicMock()
+    screen.top_nav.is_selected = False
+
+    screen.keyboard = MagicMock()
+    screen.text_entry_display = MagicMock()
+    screen.renderer = MagicMock()
+    screen.render_key_confirmation_feedback = MagicMock()
+    screen.update_title = MagicMock(return_value=False)
+
+    if show_save_button:
+        screen.save_button = MagicMock()
+
+    return screen
+
+
+def test_dedicated_key1_confirms_die_and_joystick_press_does_not(monkeypatch):
+    screen = make_keyboard_screen(
+        monkeypatch,
+        inputs=[HardwareInputs.KEY_PRESS, HardwareInputs.KEY1],
+        confirm_inputs=[HardwareInputs.KEY1],
+    )
+    screen.keyboard.update_from_input.side_effect = ["die", "die"]
+
+    assert screen._run() == "1"
+    screen.render_key_confirmation_feedback.assert_called_once_with()
+
+    waited_for_keys = screen.hw_inputs.wait_for.call_args_list[0].args[0]
+    assert HardwareInputs.KEY1 in waited_for_keys
+    assert HardwareInputs.KEY2 not in waited_for_keys
+    assert HardwareInputs.KEY3 not in waited_for_keys
+
+
+def test_dice_screen_renders_key1_confirm_without_narrowing_grid(monkeypatch):
+    monkeypatch.setattr(screen_module, "HardwareButtonsConstants", HardwareInputs)
+    monkeypatch.setattr(tools_screens, "HardwareButtonsConstants", HardwareInputs)
+
+    def fake_keyboard_post_init(screen):
+        screen.canvas_width = 240
+        screen.top_nav = SimpleNamespace(height=48)
+        screen.text_entry_display = SimpleNamespace(rect=(8, 48, 232, 78))
+        screen.keyboard = SimpleNamespace(rect=(8, 86, 232, 231))
+        screen.components = []
+        screen.renderer = MagicMock()
+
+    def fake_icon_button(**kwargs):
+        return SimpleNamespace(height=32, **kwargs)
+
+    monkeypatch.setattr(KeyboardScreen, "__post_init__", fake_keyboard_post_init)
+    monkeypatch.setattr(tools_screens, "IconButton", fake_icon_button)
+
+    screen = ToolsDiceEntropyEntryScreen(return_after_n_chars=50)
+
+    assert screen.key_confirm_inputs == [HardwareInputs.KEY1]
+    assert screen.text_entry_display.rect == (8, 48, 180, 78)
+    assert screen.keyboard.rect == (8, 86, 232, 231)
+    assert (
+        screen.confirm_button.screen_x,
+        screen.confirm_button.screen_y,
+        screen.confirm_button.width,
+        screen.confirm_button.height,
+    ) == (188, 48, 60, 32)
+
+
+def test_key1_is_ignored_for_delete_but_joystick_press_deletes(monkeypatch):
+    screen = make_keyboard_screen(
+        monkeypatch,
+        inputs=[HardwareInputs.KEY1, HardwareInputs.KEY_PRESS, HardwareInputs.KEY1],
+        user_input="12",
+        confirm_inputs=[HardwareInputs.KEY1],
+        return_after_n_chars=2,
+    )
+    screen.keyboard.update_from_input.side_effect = [
+        Keyboard.KEY_BACKSPACE["code"],
+        Keyboard.KEY_BACKSPACE["code"],
+        "die",
+    ]
+
+    assert screen._run() == "11"
+    screen.render_key_confirmation_feedback.assert_called_once_with()
+
+
+def test_key1_is_ignored_for_back_but_joystick_press_goes_back(monkeypatch):
+    screen = make_keyboard_screen(
+        monkeypatch,
+        inputs=[HardwareInputs.KEY1, HardwareInputs.KEY_PRESS],
+        confirm_inputs=[HardwareInputs.KEY1],
+    )
+    screen.top_nav.is_selected = True
+
+    assert screen._run() == RET_CODE__BACK_BUTTON
+    screen.keyboard.update_from_input.assert_not_called()
+
+
+def test_default_keyboard_still_confirms_with_joystick_press(monkeypatch):
+    screen = make_keyboard_screen(
+        monkeypatch,
+        inputs=[HardwareInputs.KEY_PRESS],
+    )
+    screen.keyboard.update_from_input.return_value = "die"
+
+    assert screen._run() == "1"
+
+
+def test_show_save_button_still_uses_key3(monkeypatch):
+    screen = make_keyboard_screen(
+        monkeypatch,
+        inputs=[HardwareInputs.KEY3],
+        user_input="42",
+        return_after_n_chars=10,
+        show_save_button=True,
+    )
+
+    assert screen._run() == "42"
+    assert screen.save_button.is_selected is True
+    screen.save_button.render.assert_called_once_with()


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

The dice-entry screen uses the joystick for both navigation and confirmation. During a long entry sequence, an unintended joystick-center press while moving between dice is accepted immediately as another roll. The resulting extra or duplicated digit is easy to miss in the compact roll history.

I encountered this while entering the same 99-roll public test sequence on multiple devices for [this dice-only seed investigation](https://schjonhaug.dev/articles/why-dice-only-coldcard-seeds-were-unaffected-by-the-rng-bug/). On SeedSigner I accidentally clicked the joystick several times while navigating, did not notice the incorrect entries until the end, and had to restart the entire 99-roll sequence.

### Solution

- Make `KeyboardScreen` confirmation inputs configurable while preserving joystick-center confirmation as the default for every existing keyboard screen.
- Configure only `ToolsDiceEntropyEntryScreen` to confirm the highlighted die with `KEY1`.
- Display a green check button aligned with `KEY1` and briefly show its selected state when a roll is recorded.
- Keep joystick-center available for existing back-navigation and backspace behavior, but prevent it from recording a die.
- Leave `KEY2` and `KEY3` inactive on the dice-entry screen.

This separates navigation from confirmation on the one screen where many repetitive entries make accidental joystick clicks especially costly, without changing interaction behavior elsewhere.

### Additional Information

The interaction was first implemented in an OS image and tested hands-on on a Raspberry Pi Zero. Entering dice rolls with the joystick for movement and the adjacent check button for confirmation was substantially less error-prone. This PR ports that tested interaction onto the latest upstream `dev` branch.

Six focused regression tests cover dedicated `KEY1` confirmation, ignored joystick presses on dice values, retained joystick back/backspace behavior, the visible confirmation control, and unchanged defaults for other keyboard screens.

The focused tests pass locally. I could not complete the full local flow suite because this Mac does not have the native `zbar` shared library; the repository's Linux CI installs that dependency before running the complete suite.

### Screenshots

No screenshot is attached. The primary change is the physical input interaction; the visible change is a green check control aligned with the top side button, following the existing hardware-button UI pattern.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [ ] All tests passed before submitting the PR
- [x] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [x] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.
