### PR TITLE
[enhancement] Image Entropy: Require a full pool of distinct preview frames before capture

### DIFF
--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -1,9 +1,10 @@
+import hashlib
 import time
 
 from dataclasses import dataclass
 from gettext import gettext as _
 from typing import Any
-from PIL.Image import Image
+from PIL import Image, ImageDraw
 from seedsigner.gui.renderer import Renderer
 from seedsigner.hardware.camera import Camera
 from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea
@@ -17,6 +18,10 @@ from seedsigner.gui.keyboard import Keyboard
 
 @dataclass
 class ToolsImageEntropyLivePreviewScreen(BaseScreen):
+    # Set how many distinct, non-blank preview frames must be collected into the preview
+    # pool before the final image can be taken.
+    PREVIEW_POOL_SIZE = 50
+
     def __post_init__(self):
         super().__post_init__()
 
@@ -32,13 +37,23 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
     def _run(self):
         # save preview image frames to use as additional entropy below
         preview_images = []
-        max_entropy_frames = 50
         instructions_font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_button_font_size())
 
+        # Pre-calculate how wide the frame counter display can be.
+        # TRANSLATOR_NOTE: Counts frames collected so far vs the total required (e.g. 12/50)
+        max_counter_text = _("{}/{}").format(self.PREVIEW_POOL_SIZE, self.PREVIEW_POOL_SIZE)
+        (left, top, right, bottom) = instructions_font.getbbox(max_counter_text)
+        counter_text_width = right - left
+
+        # The camera hands us its most recent frame on every loop pass, but the SAME frame
+        # can arrive more than once. Store each image's sha256 hash so we can recognize
+        # and skip the repeats. The set is intentionally never pruned. A frame identical
+        # to any previously admitted frame can never be added a second time.
+        preview_frame_hashes = set()
+
         # If the user continues holding the button that brought them into this flow, we
-        # have to ensure that it doesn't trigger the ANYCLICK check below, otherwise they
-        # will inadvertently skip all the preview frames and take the final image
-        # immediately.
+        # have to ensure that it doesn't trigger the ANYCLICK check below, otherwise the
+        # final image capture would fire on its own the instant the preview pool fills.
         is_maybe_still_holding = True
 
         while True:
@@ -49,7 +64,7 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
                 self.camera.stop_video_stream_mode()
                 return RET_CODE__BACK_BUTTON
 
-            frame: Image = self.camera.read_video_stream(as_image=True)
+            frame: Image.Image = self.camera.read_video_stream(as_image=True)
 
             if frame is None:
                 # Camera probably isn't ready yet
@@ -81,68 +96,160 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
 
                 self.renderer.canvas.paste(frame.crop(box=box))
 
-            # If the ANYCLICK buttons are detected as being all released (none of them
-            # cause check_for_low to return True), we can be sure that the user isn't
-            # still holding down the initial button press that brought them into this
-            # flow. It is then safe to arm the loop to trigger the final image capture for
-            # whenever the *next* ANYCLICK button is pressed.
-            if not self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
-                # Confirmed that all ANYCLICK buttons are released. The next click can now
-                # trigger the final image capture.
-                is_maybe_still_holding = False
+            # Decide whether this frame can be added to the preview pool.
+            # Rule 1: the frame must not be a single flat color (e.g. an all-black frame
+            # or an overexposed all-white one). getextrema() reports the lowest and
+            # highest value found in each color channel; if the lowest equals the highest
+            # in every channel, every pixel in the frame is identical and the frame is
+            # rejected.
+            frame_has_variation = False
+            for lowest_value, highest_value in frame.getextrema():
+                if lowest_value != highest_value:
+                    frame_has_variation = True
 
-            elif not is_maybe_still_holding:
-                # We passed the above check; this is a fresh, explicit click. We can now
-                # capture the final image and exit this loop.
+            if frame_has_variation:
+                # Rule 2: the frame must be one we have never counted before
+                frame_hash = hashlib.sha256(frame.tobytes()).digest()
+                if frame_hash not in preview_frame_hashes:
+                    preview_frame_hashes.add(frame_hash)
+                    if len(preview_images) == self.PREVIEW_POOL_SIZE:
+                        # The preview pool is full. Dump the oldest and add the current
+                        # frame.
+                        preview_images.pop(0)
+                    preview_images.append(frame)
 
-                # Have to manually update last input time since we're not in a wait_for loop
-                self.hw_inputs.update_last_input_time()
-                self.camera.stop_video_stream_mode()
+            # Can only proceed to the final image when the preview pool is full
+            if len(preview_images) == self.PREVIEW_POOL_SIZE:
+                # If the ANYCLICK buttons are detected as being all released (none of
+                # them cause check_for_low to return True), we can be sure that the user
+                # isn't still holding down the initial button press that brought them
+                # into this flow. It is then safe to arm the loop to trigger the final
+                # image capture for whenever the *next* ANYCLICK button is pressed.
+                if not self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
+                    # Confirmed that all ANYCLICK buttons are released. The next click
+                    # can now trigger the final image capture.
+                    is_maybe_still_holding = False
 
-                with self.renderer.lock:
+                elif not is_maybe_still_holding:
+                    # We passed the above check; this is a fresh, explicit click. We can
+                    # now capture the final image and exit this loop.
+
+                    # Have to manually update last input time since we're not in a wait_for loop
+                    self.hw_inputs.update_last_input_time()
+                    self.camera.stop_video_stream_mode()
+
+                    with self.renderer.lock:
+                        self.renderer.draw.text(
+                            xy=(
+                                int(self.renderer.canvas_width/2),
+                                self.renderer.canvas_height - GUIConstants.EDGE_PADDING
+                            ),
+                            text=_("Capturing image..."),
+                            fill=GUIConstants.ACCENT_COLOR,
+                            font=instructions_font,
+                            stroke_width=4,
+                            stroke_fill=GUIConstants.BACKGROUND_COLOR,
+                            anchor="ms"
+                        )
+                        self.renderer.show_image()
+
+                    return preview_images
+
+            # If we're still here, it's just another preview frame loop
+            with self.renderer.lock:
+                if len(preview_images) == self.PREVIEW_POOL_SIZE and not is_maybe_still_holding:
                     self.renderer.draw.text(
                         xy=(
                             int(self.renderer.canvas_width/2),
                             self.renderer.canvas_height - GUIConstants.EDGE_PADDING
                         ),
-                        text=_("Capturing image..."),
-                        fill=GUIConstants.ACCENT_COLOR,
+                        text="< " + _("back") + "  |  " + _("click a button"),  # TODO: Render with UI elements instead of text
+                        fill=GUIConstants.BODY_FONT_COLOR,
                         font=instructions_font,
                         stroke_width=4,
                         stroke_fill=GUIConstants.BACKGROUND_COLOR,
                         anchor="ms"
                     )
-                    self.renderer.show_image()
 
-                return preview_images
+                else:
+                    # Still collecting (or is_maybe_still_holding); report current
+                    # progress on number of preview pool frames.
 
-            # If we're still here, it's just another preview frame loop
-            with self.renderer.lock:
-                self.renderer.draw.text(
-                    xy=(
-                        int(self.renderer.canvas_width/2),
-                        self.renderer.canvas_height - GUIConstants.EDGE_PADDING
-                    ),
-                    text="< " + _("back") + "  |  " + _("click a button"),  # TODO: Render with UI elements instead of text
-                    fill=GUIConstants.BODY_FONT_COLOR,
-                    font=instructions_font,
-                    stroke_width=4,
-                    stroke_fill=GUIConstants.BACKGROUND_COLOR,
-                    anchor="ms"
-                )
+                    # TRANSLATOR_NOTE: Shown while the camera gathers the image frames a new seed requires
+                    collecting_text = _("Collecting entropy frames")
+                    self.renderer.draw.text(
+                        xy=(
+                            int(self.renderer.canvas_width/2),
+                            self.renderer.canvas_height - GUIConstants.EDGE_PADDING - GUIConstants.BUTTON_HEIGHT - GUIConstants.COMPONENT_PADDING
+                        ),
+                        text=collecting_text,
+                        fill=GUIConstants.BODY_FONT_COLOR,
+                        font=instructions_font,
+                        stroke_width=4,
+                        stroke_fill=GUIConstants.BACKGROUND_COLOR,
+                        anchor="ms"
+                    )
+
+                    # Render the frame counter progress bar; same visual design as the
+                    # animated QR scan progress bar.
+                    rectangle = Image.new('RGBA', (self.renderer.canvas_width - 2*GUIConstants.EDGE_PADDING, GUIConstants.BUTTON_HEIGHT), (0, 0, 0, 0))
+                    draw = ImageDraw.Draw(rectangle)
+
+                    # Start with a background rounded rectangle, same dims as the buttons
+                    overlay_color = (0, 0, 0, 191)  # opacity ranges from 0-255
+                    draw.rounded_rectangle(
+                        (
+                            (0, 0),
+                            (rectangle.width, rectangle.height)
+                        ),
+                        fill=overlay_color,
+                        radius=8,
+                        outline=overlay_color,
+                        width=2,
+                    )
+
+                    progress_bar_thickness = 4
+                    progress_bar_width = rectangle.width - 2*GUIConstants.EDGE_PADDING - counter_text_width - int(GUIConstants.EDGE_PADDING/2)
+                    progress_bar_xy = (
+                            (GUIConstants.EDGE_PADDING, int((rectangle.height - progress_bar_thickness) / 2)),
+                            (GUIConstants.EDGE_PADDING + progress_bar_width, int(rectangle.height + progress_bar_thickness) / 2)
+                        )
+                    draw.rounded_rectangle(
+                        progress_bar_xy,
+                        fill=GUIConstants.INACTIVE_COLOR,
+                        radius=8
+                    )
+
+                    if len(preview_images) > 0:
+                        draw.rounded_rectangle(
+                            (
+                                progress_bar_xy[0],
+                                (GUIConstants.EDGE_PADDING + int(len(preview_images) * progress_bar_width / self.PREVIEW_POOL_SIZE), progress_bar_xy[1][1])
+                            ),
+                            fill=GUIConstants.GREEN_INDICATOR_COLOR,
+                            radius=8
+                        )
+
+                    # TRANSLATOR_NOTE: Counts frames collected so far vs the total required (e.g. 12/50)
+                    counter_text = _("{}/{}").format(len(preview_images), self.PREVIEW_POOL_SIZE)
+
+                    draw.text(
+                        xy=(rectangle.width - GUIConstants.EDGE_PADDING, int(rectangle.height / 2)),
+                        text=counter_text,
+                        fill=GUIConstants.BODY_FONT_COLOR,
+                        font=instructions_font,
+                        anchor="rm",  # right-justified, middle
+                    )
+
+                    self.renderer.canvas.paste(rectangle, (GUIConstants.EDGE_PADDING, self.renderer.canvas_height - GUIConstants.EDGE_PADDING - rectangle.height), rectangle)
+
                 self.renderer.show_image()
-
-            if len(preview_images) == max_entropy_frames:
-                # Keep a moving window of the last n preview frames; pop the oldest
-                # before we add the currest frame.
-                preview_images.pop(0)
-            preview_images.append(frame)
 
 
 
 @dataclass
 class ToolsImageEntropyFinalImageScreen(BaseScreen):
-    final_image: Image = None
+    final_image: Image.Image = None
 
     def _run(self):
         instructions_font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_button_font_size())

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -35,6 +35,12 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
         max_entropy_frames = 50
         instructions_font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_button_font_size())
 
+        # If the user continues holding the button that brought them into this flow, we
+        # have to ensure that it doesn't trigger the ANYCLICK check below, otherwise they
+        # will inadvertently skip all the preview frames and take the final image
+        # immediately.
+        is_maybe_still_holding = True
+
         while True:
             if self.hw_inputs.check_for_low(HardwareButtonsConstants.KEY_LEFT):
                 # Have to manually update last input time since we're not in a wait_for loop
@@ -75,8 +81,20 @@ class ToolsImageEntropyLivePreviewScreen(BaseScreen):
 
                 self.renderer.canvas.paste(frame.crop(box=box))
 
-            # Check for ANYCLICK to take final entropy image
-            if self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
+            # If the ANYCLICK buttons are detected as being all released (none of them
+            # cause check_for_low to return True), we can be sure that the user isn't
+            # still holding down the initial button press that brought them into this
+            # flow. It is then safe to arm the loop to trigger the final image capture for
+            # whenever the *next* ANYCLICK button is pressed.
+            if not self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
+                # Confirmed that all ANYCLICK buttons are released. The next click can now
+                # trigger the final image capture.
+                is_maybe_still_holding = False
+
+            elif not is_maybe_still_holding:
+                # We passed the above check; this is a fresh, explicit click. We can now
+                # capture the final image and exit this loop.
+
                 # Have to manually update last input time since we're not in a wait_for loop
                 self.hw_inputs.update_last_input_time()
                 self.camera.stop_video_stream_mode()
@@ -150,6 +168,13 @@ class ToolsImageEntropyFinalImageScreen(BaseScreen):
                 anchor="ms"
             )
             self.renderer.show_image()
+
+        # The button click that triggered the final image might still be held down as this
+        # screen appears. We can't let that held button auto-dismiss the final image
+        # review here. Wait until every button has been released before listening for the
+        # accept/reshoot decision.
+        while self.hw_inputs.check_for_low(keys=[HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT] + HardwareButtonsConstants.KEYS__ANYCLICK):
+            time.sleep(0.01)
 
         # LEFT = reshoot, RIGHT / ANYCLICK = accept
         input = self.hw_inputs.wait_for([HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT] + HardwareButtonsConstants.KEYS__ANYCLICK)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -60,6 +60,26 @@ class ToolsMenuView(View):
     Image entropy Views
 ****************************************************************************"""
 class ToolsImageEntropyLivePreviewView(View):
+    """
+    A fixed number of live preview frames are collected into a frame pool to provide an
+    additional source of entropy. These frames provide VOLUME for the final seed but are
+    not themselves individually assessed for entropy QUALITY. The quality heuristics are
+    only applied to the final image capture.
+
+    The preview pool enforces two rules:
+    1.) A frame that is a single flat color is rejected (e.g. completely black, completely
+    white, all just one shade of green).
+
+    2.) A frame identical to any previously admitted frame is rejected (de-duplicated via
+    sha256).
+
+    The final image cannot be taken until the full pool has arrived.
+
+    This mirrors the role that NIST SP 800-90B (sec. 4.2) assigns to continuous health
+    tests: detect gross noise-source failure -- a sensor stuck on one value, a stalled
+    or repeating camera -- without attempting to measure entropy.
+    """
+
     def run(self):
         from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
         self.controller.image_entropy_preview_frames = None
@@ -67,7 +87,14 @@ class ToolsImageEntropyLivePreviewView(View):
 
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        
+
+        # The live preview screen must return the required number of preview pool frames.
+        # Do not proceed if there is any mismatch.
+        if ret is None or len(ret) != ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE:
+            num_frames = 0 if ret is None else len(ret)
+            # TRANSLATOR_NOTE: Shown when the camera fails to collect enough frames for a new seed. "expected" and "actual" are the number of frames.
+            raise Exception(_("Entropy collection failed. Expected {expected} preview frames, got {actual}").format(expected=ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE, actual=num_frames))
+
         self.controller.image_entropy_preview_frames = ret
         return Destination(ToolsImageEntropyFinalImageView)
 

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -279,3 +279,64 @@ class TestToolsFlows(FlowTest):
                 FlowStep(seed_views.SeedAddressVerificationView),
                 FlowStep(seed_views.SeedAddressVerificationSuccessView),
             ])
+
+
+class TestToolsImageEntropyFlows(FlowTest):
+
+    def test__image_entropy__incorrect_preview_frame_count_aborts(self):
+        """
+        If the live preview screen returns anything other than the required number of
+        entropy frames, the View must raise rather than continue on to seed creation.
+        """
+        from unittest.mock import Mock
+        from seedsigner.views.view import UnhandledExceptionView
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+
+        # Empty list (no frames)
+        self.run_sequence([
+            FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[]),
+            FlowStep(UnhandledExceptionView),
+        ])
+
+        # Too few
+        self.run_sequence([
+            FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Mock()] * 10),
+            FlowStep(UnhandledExceptionView),
+        ])
+
+        # Too many
+        self.run_sequence([
+            FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Mock()] * (ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE + 5)),
+            FlowStep(UnhandledExceptionView),
+        ])
+
+        # Degenerate None
+        self.run_sequence([
+            FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=None),
+            FlowStep(UnhandledExceptionView),
+        ])
+
+
+
+    def test__image_entropy__screen_exception_does_not_advance(self):
+        """
+        There is no explicit handling for the live preview screen raising, but the flow
+        must never continue on to seed creation when it does.
+        """
+        from seedsigner.views.view import UnhandledExceptionView
+
+        self.run_sequence([
+            FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=Exception("Test exception")),
+            FlowStep(UnhandledExceptionView),
+        ])
+
+
+    def test__image_entropy__full_preview_frames_advances(self):
+        """ A full set of preview frames advances to the final image capture. """
+        from unittest.mock import Mock
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+
+        self.run_sequence([
+            FlowStep(tools_views.ToolsImageEntropyLivePreviewView, screen_return_value=[Mock()] * ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE),
+            FlowStep(tools_views.ToolsImageEntropyFinalImageView),
+        ])

--- a/tests/test_tools_screens.py
+++ b/tests/test_tools_screens.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 
 from unittest.mock import MagicMock, patch
@@ -28,6 +29,24 @@ def make_noise_frame(width: int = 240, height: int = 240) -> Image.Image:
     # Random bytes are fine here: tests only need frames that are non-blank and
     # distinct from one another; nothing here feeds real entropy.
     return Image.frombytes("RGBA", (width, height), os.urandom(width * height * 4))
+
+
+def make_blank_frame(color: tuple = (0, 0, 0, 255), width: int = 240, height: int = 240) -> Image.Image:
+    """ A frame of a single flat color: every pixel identical, as from a covered camera. """
+    return Image.new("RGBA", (width, height), color)
+
+
+# A blank frame is any frame of one uniform color: a covered lens reads full black, an
+# overexposed one reads full white, and a color cast reads as some other single color.
+BLANK_FRAME_COLORS = [
+    (0, 0, 0, 255),        # full black
+    (255, 255, 255, 255),  # full white
+    (128, 128, 128, 255),  # a flat mid grey
+    (255, 0, 0, 255),      # one saturated channel is still a single flat color
+    (0, 255, 0, 255),
+    (0, 0, 255, 255),
+    # ...and so is any color whose three channels each hold their own unchanging value
+] + [(value, (value * 7) % 256, (value * 13) % 256, 255) for value in range(1, 55)]
 
 
 def make_mock_camera(frames: list) -> MagicMock:
@@ -70,6 +89,14 @@ def make_mock_hw_inputs(left_script: list = None, anyclick_script: list = None) 
     return hw_inputs
 
 
+def count_anyclick_checks(mock_hw_inputs: MagicMock) -> int:
+    """
+    How many times the screen polled the ANYCLICK group.
+    """
+    from seedsigner.hardware.buttons import HardwareButtonsConstants
+    return sum(1 for c in mock_hw_inputs.check_for_low.call_args_list if c.kwargs.get("keys") == HardwareButtonsConstants.KEYS__ANYCLICK)
+
+
 
 class ImageEntropyScreenTestBase(BaseTest):
 
@@ -102,40 +129,100 @@ class TestToolsImageEntropyLivePreviewScreen(ImageEntropyScreenTestBase):
         return screen
 
 
-    def test_button_held_from_start_never_captures_until_released(self):
+    def test_screen_returns_exactly_50_unique_frames(self):
         """
-        A button already held down when the screen starts must not trigger the final
-        image capture; only a fresh press after all buttons have been seen released
-        may capture.
+        The screen should return 50 unique frames from its preview pool.
         """
-        frames = [make_noise_frame() for i in range(5)]
-        mock_camera = make_mock_camera(frames)
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+        num_required = ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE
 
-        # Button is held for the first two loop passes, released on the third, then
-        # pressed again on the fourth.
-        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[True, True, False, True])
-        screen = self.build_screen(mock_camera, mock_hw_inputs)
+        frames = [make_noise_frame() for i in range(num_required)]
 
-        # The screen returns the live preview frames
-        result = screen._run()
-
-        # The held presses were ignored; the fresh press on the fourth pass captured.
-        # Three frames were collected before the capture pass.
-        assert result == frames[:3]
-        mock_camera.stop_video_stream_mode.assert_called_once()
-
-
-    def test_click_after_release_captures(self):
-        """ Normal use: no buttons pressed at first, then a click captures. """
-        frames = [make_noise_frame() for i in range(2)]
-        mock_camera = make_mock_camera(frames)
+        # One extra read happens on the capture pass; feed it a duplicate of the last
+        # frame, which the dedupe check rejects (so the returned pool is untouched).
+        duplicate = frames[-1].copy()
+        mock_camera = make_mock_camera(frames + [duplicate])
         mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[False, True])
         screen = self.build_screen(mock_camera, mock_hw_inputs)
 
         result = screen._run()
 
-        assert result == frames[:1]
+        assert result == frames
         mock_camera.stop_video_stream_mode.assert_called_once()
+
+
+    def test_button_held_from_start_never_captures_until_released(self):
+        """
+        A button already held down when the screen starts must not trigger the final
+        image capture -- not even after the entropy pool has filled. Only a fresh
+        press after all buttons have been seen released may capture.
+        """
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+        num_required = ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE
+
+        # The pool fills at frame 50; the held button registers as still held for the next
+        # two loop iterations, released on the third (that's the go-ahead to arm the watch
+        # for the final click), then finally pressed on the fourth.
+        frames = [make_noise_frame() for i in range(num_required + 3)]
+        mock_camera = make_mock_camera(frames)
+        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[True, True, False, True])
+        screen = self.build_screen(mock_camera, mock_hw_inputs)
+
+        result = screen._run()
+
+        # The pool is a moving window of the LAST 50 admitted frames.
+        assert result == frames[3:]
+        assert len(result) == num_required
+
+        # The ANYCLICK checks should only start after the preview pool is filled so we
+        # should only see the four checks scripted above.
+        assert count_anyclick_checks(mock_hw_inputs) == 4
+        mock_camera.stop_video_stream_mode.assert_called_once()
+
+
+    def test_blank_frames_are_never_admitted(self):
+        """
+        Flat single-color frames (e.g. covered camera, all white, all turquoise, etc) are
+        never counted, the final capture click is never armed, and the back button still
+        exits.
+        """
+        # One frame per flat color, more of them than the pool needs, and all distinct.
+        blanks = [make_blank_frame(color) for color in BLANK_FRAME_COLORS]
+        mock_camera = make_mock_camera(blanks)
+        mock_hw_inputs = make_mock_hw_inputs(left_script=[False] * (len(blanks) - 1) + [True])
+        screen = self.build_screen(mock_camera, mock_hw_inputs)
+
+        result = screen._run()
+
+        assert result == RET_CODE__BACK_BUTTON
+
+        # The pool never filled, so the final capture click (ANYCLICK) was never checked.
+        assert count_anyclick_checks(mock_hw_inputs) == 0
+        mock_camera.stop_video_stream_mode.assert_called_once()
+
+
+    def test_duplicate_frames_are_only_counted_once(self):
+        """
+        A frame whose bytes exactly match an already-admitted frame cannot be included in
+        the preview pool again.
+        """
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+        num_required = ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE
+
+        test_frame = make_noise_frame()
+        fillers = [make_noise_frame() for i in range(num_required)]
+
+        feed = fillers[:10] + [test_frame] + fillers[10:20] + [test_frame] + fillers[20:]
+        mock_camera = make_mock_camera(feed)
+        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[False, True])
+        screen = self.build_screen(mock_camera, mock_hw_inputs)
+
+        result = screen._run()
+
+        assert test_frame in result
+        # PIL Images are unhashable, so uniqueness is checked on their bytes
+        assert len(set(frame.tobytes() for frame in result)) == num_required  # all unique
+
 
 
     def test_back_button_exits_immediately(self):

--- a/tests/test_tools_screens.py
+++ b/tests/test_tools_screens.py
@@ -1,0 +1,199 @@
+import os
+
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+# Must import test base before the Controller
+from base import BaseTest
+
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+from seedsigner.hardware.camera import Camera
+
+
+"""
+    We don't test other Screens; they mostly have simple UI nav, text entry, or button
+    select behavior. But the image entropy screens have critical user interaction review
+    checks that could impact the security of the generated seed. So explicit tests of
+    those interactions are warranted.
+
+    These tests have to simulate user button press sequences AND duration at various
+    stages of the image entropy live review loop and final image review.
+
+    These tests are not concerned with actual image content, entropy, etc.
+"""
+
+
+def make_noise_frame(width: int = 240, height: int = 240) -> Image.Image:
+    # Random bytes are fine here: tests only need frames that are non-blank and
+    # distinct from one another; nothing here feeds real entropy.
+    return Image.frombytes("RGBA", (width, height), os.urandom(width * height * 4))
+
+
+def make_mock_camera(frames: list) -> MagicMock:
+    """
+    Returns a mocked Camera whose read_video_stream() plays back the given frames in
+    order.
+    """
+    camera = MagicMock()
+    frame_feed = list(frames)
+
+    def read_video_stream(as_image: bool = False):
+        if not frame_feed:
+            raise AssertionError("Camera frame script exhausted; the screen loop should have exited by now")
+        return frame_feed.pop(0)
+
+    camera.read_video_stream.side_effect = read_video_stream
+    return camera
+
+
+def make_mock_hw_inputs(left_script: list = None, anyclick_script: list = None) -> MagicMock:
+    """
+    Returns a mocked HardwareButtons whose check_for_low() plays back scripted
+    responses.
+
+    There are two types of input checks:
+    * check_for_low(specific_key_constant). e.g. was KEY_LEFT (back) pressed?
+
+    * check_for_low(keys=list_of_keys). e.g. was ANYCLICK pressed? (any of the click buttons)
+    """
+    left_feed = list(left_script or [])
+    anyclick_feed = list(anyclick_script or [])
+    hw_inputs = MagicMock()
+
+    def check_for_low(key=None, keys=None):
+        if keys is None:
+            return left_feed.pop(0) if left_feed else False
+        return anyclick_feed.pop(0) if anyclick_feed else False
+
+    hw_inputs.check_for_low.side_effect = check_for_low
+    return hw_inputs
+
+
+
+class ImageEntropyScreenTestBase(BaseTest):
+
+    def setup_method(self):
+        super().setup_method()
+
+        from seedsigner.gui.renderer import Renderer
+
+        # tests/base.py mocks the whole renderer module; give each test a fresh renderer
+        # whose canvas dims are real ints (the screens do math on them). Exposed as a
+        # patch so screen construction restores the original when its `with` exits.
+        self.mock_renderer = MagicMock()
+        self.mock_renderer.canvas_width = 240
+        self.mock_renderer.canvas_height = 240
+        self.renderer_patch = patch.object(Renderer, "get_instance", return_value=self.mock_renderer)
+
+
+
+class TestToolsImageEntropyLivePreviewScreen(ImageEntropyScreenTestBase):
+
+    def build_screen(self, mock_camera: MagicMock, mock_hw_inputs: MagicMock):
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+
+        # Run within our mocked Renderer context
+        with self.renderer_patch:
+            with patch.object(Camera, "get_instance", return_value=mock_camera):
+                screen = ToolsImageEntropyLivePreviewScreen()
+
+        screen.hw_inputs = mock_hw_inputs
+        return screen
+
+
+    def test_button_held_from_start_never_captures_until_released(self):
+        """
+        A button already held down when the screen starts must not trigger the final
+        image capture; only a fresh press after all buttons have been seen released
+        may capture.
+        """
+        frames = [make_noise_frame() for i in range(5)]
+        mock_camera = make_mock_camera(frames)
+
+        # Button is held for the first two loop passes, released on the third, then
+        # pressed again on the fourth.
+        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[True, True, False, True])
+        screen = self.build_screen(mock_camera, mock_hw_inputs)
+
+        # The screen returns the live preview frames
+        result = screen._run()
+
+        # The held presses were ignored; the fresh press on the fourth pass captured.
+        # Three frames were collected before the capture pass.
+        assert result == frames[:3]
+        mock_camera.stop_video_stream_mode.assert_called_once()
+
+
+    def test_click_after_release_captures(self):
+        """ Normal use: no buttons pressed at first, then a click captures. """
+        frames = [make_noise_frame() for i in range(2)]
+        mock_camera = make_mock_camera(frames)
+        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[False, True])
+        screen = self.build_screen(mock_camera, mock_hw_inputs)
+
+        result = screen._run()
+
+        assert result == frames[:1]
+        mock_camera.stop_video_stream_mode.assert_called_once()
+
+
+    def test_back_button_exits_immediately(self):
+        """ KEY_LEFT backs out at any time, even before any frame is read. """
+        mock_camera = make_mock_camera([])
+        mock_hw_inputs = make_mock_hw_inputs(left_script=[True])
+        screen = self.build_screen(mock_camera, mock_hw_inputs)
+
+        result = screen._run()
+
+        assert result == RET_CODE__BACK_BUTTON
+        mock_camera.stop_video_stream_mode.assert_called_once()
+        mock_camera.read_video_stream.assert_not_called()
+
+
+class TestToolsImageEntropyFinalImageScreen(ImageEntropyScreenTestBase):
+
+    def build_screen(self, mock_hw_inputs: MagicMock):
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyFinalImageScreen
+
+        # Run within our mocked Renderer context
+        with self.renderer_patch:
+            screen = ToolsImageEntropyFinalImageScreen(final_image=MagicMock())
+        screen.hw_inputs = mock_hw_inputs
+        return screen
+
+
+    def test_held_button_must_be_released_before_review_input(self):
+        """
+        The click that captured the photo can still be held down when the review
+        screen appears; it must be released before accept/reshoot input is read, so
+        one long press can never accept the photo sight unseen.
+        """
+        from seedsigner.hardware.buttons import HardwareButtonsConstants
+
+        # Button held for two polls, released on the third; only then is the real
+        # accept/reshoot decision awaited.
+        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[True, True, False])
+        mock_hw_inputs.wait_for.return_value = HardwareButtonsConstants.KEY_LEFT
+        screen = self.build_screen(mock_hw_inputs)
+
+        # Screen returns the back button code when the user chooses to reshoot (KEY_LEFT).
+        result = screen._run()
+
+        assert mock_hw_inputs.check_for_low.call_count == 3
+        mock_hw_inputs.wait_for.assert_called_once()
+        assert result == RET_CODE__BACK_BUTTON
+
+
+    def test_accept_returns_none_to_advance(self):
+        """ A (fresh) accept click falls through: the screen returns None. """
+        from seedsigner.hardware.buttons import HardwareButtonsConstants
+
+        mock_hw_inputs = make_mock_hw_inputs(anyclick_script=[False])
+        mock_hw_inputs.wait_for.return_value = HardwareButtonsConstants.KEY_RIGHT
+        screen = self.build_screen(mock_hw_inputs)
+
+        result = screen._run()
+
+        assert result is None
+        mock_hw_inputs.wait_for.assert_called_once()


### PR DESCRIPTION
Depends on #990. This PR is based on that branch and should be reviewed after #990 is merged (until it's merged, the diff here will include both PRs' changes and will be harder to sort through).

## Motivation

The live preview frames in the image entropy flow are temporarily stored (up to the most recent 50) and provided as additional entropy. But currently the user can click straight past the live preview to the final image capture.

The 50 preview frames are meant to be extra assurance that sufficient entropy is being collected, even if the final image happens to be weak (e.g. a fully blocked camera lens).

The typical user who has not reviewed the code would not know that they would ideally wait for the full 50 preview frames to accumulate before moving on to the final image capture. But even if they were aware, there is no feedback to indicate how many have been collected, nor are there any checks for if the frames are duplicates or devoid of data (e.g. all black).

_Note that seeds created via image entropy in current and previous releases will have sufficient entropy, regardless, as long as the user can visually recognize the scene on the live display. In other words, the only failure scenario is if the lens is completely blocked (in which case they'll only see black on the screen) or if you intentionally shine a bright light into the camera (they'll only see white). If you see a normal enough live preview and final image, there is likely hundreds of thousands of bits of entropy. See full analysis: https://kdmukai-bot.github.io/seedsigner-ai-analysis/image-entropy_

## Changes

Improve the image entropy guarantees by ensuring that reasonably valid live preview frames are always fully collected before allowing the user to proceed to the final image capture.

<img width="315" height="300" alt="Screenshot_20260809-160105" src="https://github.com/user-attachments/assets/6a1932b9-85cc-47ca-a94c-89cd453eaa08" />


- **Require a full preview pool before capture.** The live preview must now collect `PREVIEW_POOL_SIZE` (50) before the final image can be taken.
- **Only count genuinely new frames.** Duplicate frames the camera re-hands us are skipped by comparing a sha256 of the frame bytes.
- Do not count flat single-color frames (e.g. all-black / overexposed all-white). These are rejected via `Image.getextrema()` which returns the max/min value of each R, G, B channel. If `max == min` for each channel, the entire image is just one single color.
- **Show collection progress.** A "Collecting entropy frames" progress bar and an `N/50` counter give the user live feedback until the pool fills.
- Even after the full 50 preview frames are collected, subsequent live preview frames will still be added (kicking out the oldest) provided they meet the same criteria above.
- **Harden the held-button guard for the new gating.** Reworked so a still-held button can't auto-capture the instant the pool becomes full (`is_maybe_still_holding`), preserving the intent of #990 under the new flow.

Users can still exit the live preview entirely with joystick LEFT.

## Tests

- Extended `tests/test_tools_screens.py` to cover the pool-fill gating, duplicate/blank frame rejection, and held-button behavior at capture time.
- Extended `tests/test_flows_tools.py` for the updated end-to-end flow.

## Contributor Notes

Developed collaboratively with Claude, with full human review, rewriting, and iteration.

---

This pull request is categorized as a:
- [x] New feature

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes

---

#### I tested this PR hands-on on the following platform(s):
(https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.