### PR TITLE
[CI] Bugfix: Screenshot generator: crashes when the latest-release fetch fails

### DIFF
--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -7,6 +7,7 @@ import sys
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from PIL import ImageFont
 from unittest.mock import Mock, patch, MagicMock
 
@@ -116,10 +117,17 @@ seed_24_w_passphrase = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9"
 
 MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFfsBrmpj226ZYiRszYi2qK6iGvh2vkkghfGB2YiRUVY4rqqedHCFEgw12FwDkm7rUoVtq9wLTKc6BN2sxswvQeQgp7m8st4FP8WtP8go76/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*))#3jhtf6yx"""
 
-# Grab the most recent release version info
+# Grab the most recent release version info for the "release build" splash screenshots.
 (latest_release_version_name, latest_release_version_timestamp) = VersionUtils._fetch_latest_seedsigner_release_tag()
 if not latest_release_version_name or not latest_release_version_timestamp:
-    print("Could not fetch latest release version from GitHub")
+    # The fetch can fail (offline, or the unauthenticated GitHub API rate-limit that
+    # shared CI runners regularly hit). Substitute a placeholder so the "release build"
+    # screenshots still render, rather than feeding None into the Version mock (which
+    # would otherwise crash both the splash screen and the Version settings screen on
+    # None slicing / len()).
+    print("Could not fetch latest release version from GitHub; using a placeholder")
+    latest_release_version_name = latest_release_version_name or "version_not_available"
+    latest_release_version_timestamp = latest_release_version_timestamp or datetime(1970, 1, 1)
 
 
 # Wrap QRDisplayScreen's `render_brightness_tip` in a simple View + Screen so we


### PR DESCRIPTION
## Bug Description

The `Generate screenshots` CI job intermittently failed for **all locales** with:

    TypeError: 'NoneType' object is not subscriptable

at the OpeningSplash version render. The failure is random; the same commit can pass on one run and fail on another.

recent failure: https://github.com/SeedSigner/seedsigner/actions/runs/31336282379/job/93302565910

Root cause: the screenshot generator fetches the latest release tag at import time via an **unauthenticated** GitHub API call (`VersionUtils._fetch_latest_seedsigner_release_tag()`).

GitHub-hosted runners share outbound IPs and the unauthenticated api.github.com limit is 60 req/hr/IP, so the
call is periodically rate-limited (HTTP 403), returns `(None, None)`, and feeds `None` into the `mock_version_to_most_recent_release` Version mock. The mocked OpeningSplash screenshot (the first one rendered) then does `version[:20]` on `None` and every locale fails. The Version settings screen would fail the same way via `len(None)`.

## Fix

When the latest-release fetch can't resolve a name/timestamp, substitute a placeholder (`"version_not_available"` + a fixed timestamp) instead of passing `None` into the mock, so the "release build" screenshots still render. The real fetched values are used unchanged when the call succeeds.

This keeps the fix at the source of the `None` (the generator), so it also covers the Version settings screen without touching shipped view code.

## Testing

- Full screenshot generator run passes across all locales.
- Reproduced the failure locally by forcing the fetch to return `(None, None)` and confirmed the generator now renders end-to-end instead of crashing.

## Contributor Notes

Developed collaboratively with Claude, with human review.

---

This pull request is categorized as a:
- [x] Bug fix

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] N/A (we don't have any tests for the screenshot generator itself)

---

#### I tested this PR hands-on on the following platform(s):
- [ ] N/A

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.