### PR TITLE
[Bugfix] Back Navigation in Scan View

### DIFF
--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -151,6 +151,7 @@ class ScanView(View):
 
                 return Destination(
                     SeedSignMessageStartView,
+                    skip_current_view=True,
                     view_args=dict(
                         derivation_path=qr_data["derivation_path"],
                         message=qr_data["message"],

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -166,7 +166,7 @@ class ScanView(View):
             self.controller.resume_main_flow = None
             return Destination(ScanInvalidQRTypeView)
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -1,6 +1,7 @@
 from base import FlowTest, FlowStep
 
 from seedsigner.controller import Controller
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.views.view import MainMenuView
 from seedsigner.views import scan_views, seed_views, psbt_views
 from seedsigner.models.settings import SettingsConstants
@@ -68,6 +69,40 @@ class TestPSBTFlows(FlowTest):
 
         # Selecting the existing seed should have set it as the signing seed
         assert self.controller.psbt_seed is self.controller.storage.seeds[0]
+
+    def test_back_from_seed_scan_via_psbt_select_signer_flow(self):
+        """
+        Pressing BACK during seed selection for a PSBT should return to
+        PSBTSelectSeedView with the transaction flow intact. A second sequence
+        verifies that backing out to Main Menu clears the PSBT state.
+        """
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data("cHNidP8BAIkCAAAAAc9dCSh2RcRPfHaT5bNVBpbg0jAekRLqOK+bpN/QA0jeAAAAAAD9////AtAHAAAAAAAAIlEg24shYsV3IRCzlgmMKjAsR4Ad9tX896z7zDAi5q0TU9H3CgAAAAAAACIAIByGQg/VP2aRID62ty40E64HYZeRRsKRGLt8J/76R6stQ04FAE8BBDWHzwSLLGdzgAAAAq3q6nR20JnHR+vKrBQdWxN9C7xU8zNX942mVF7AQpl2ArrdLwVlkGxaatQJ4wwkvypNBKbwOq9hXGLNlKi7rZWAFDUxzXUwAACAAQAAgAAAAIACAACATwEENYfPBHOCZmWAAAACmH6KTXIny0vueRgQFBq4M6oMuG8f1QM0I/RzKQ03bCgCHrF0fyUtV0+FD2N34u/woqb8MAt/o+7Ed58RddhY8zYUCUjSaDAAAIABAACAAAAAgAIAAIAAAQEriBMAAAAAAAAiACBY4WsjDgJXLj3VW222jU1tkIIhT26ce/2efH73BWGGBiICAqyfkrdUO662QBrdvJcSOZMFxniD7M1awm9U0Kb5XCm5RzBEAiAPkQTY84YjFFkpD6MI2cc5rJySqws5fsTQA/8XEZFpbAIgTNVykbEH4Z7bqyzhhy6lty0K8rtCUDCaHNv+47NNIWgBAQMEAQAAAAEFR1IhApL4XO+VE1pPYn5wnRFyJQKVSc9TX2dO6KIBH6jwvgPaIQKsn5K3VDuutkAa3byXEjmTBcZ4g+zNWsJvVNCm+VwpuVKuIgYCkvhc75UTWk9ifnCdEXIlApVJz1NfZ07oogEfqPC+A9ocNTHNdTAAAIABAACAAAAAgAIAAIAAAAAAAAAAACIGAqyfkrdUO662QBrdvJcSOZMFxniD7M1awm9U0Kb5XCm5HAlI0mgwAACAAQAAgAAAAIACAACAAAAAAAAAAAAAAAEBR1IhApYXaczuYbBM/A+EH639Ir2yIB4PxL46dK/I1V1O9aHgIQLa02HCI/+EP+9gGpxHskjYWFN5hZzXY7RRvwV4UF42ylKuIgIClhdpzO5hsEz8D4Qfrf0ivbIgHg/Evjp0r8jVXU71oeAcNTHNdTAAAIABAACAAAAAgAIAAIABAAAAAAAAACICAtrTYcIj/4Q/72AanEeySNhYU3mFnNdjtFG/BXhQXjbKHAlI0mgwAACAAQAAgAAAAIACAACAAQAAAAAAAAAA")
+        
+        # Sequence 1: BACK from the seed scanner returns to Select Signer and preserves the PSBT flow so another signer can be selected.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanSeedQRView),
+            FlowStep(psbt_views.PSBTSelectSeedView),
+        ])
+
+        assert self.controller.psbt is not None
+        assert self.controller.resume_main_flow == Controller.FLOW__PSBT
+
+        # Sequence 2: BACK from Select Signer returns to Main Menu and clears the PSBT flow state.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanSeedQRView),
+            FlowStep(psbt_views.PSBTSelectSeedView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+
+        assert self.controller.psbt is None
+        assert self.controller.resume_main_flow is None
 
 
     def test_scan_psbt_first_then_load_electrum_seed(self):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -692,6 +692,26 @@ class TestMessageSigningFlows(FlowTest):
         self.controller.sign_message_data["paged_message"] = paged
 
 
+    def test_back_from_sign_message_review_returns_to_seed_options(self):
+        """
+        Pressing BACK from the message review after selecting Sign Message from
+        Seed Options should return to SeedOptionsView instead of reopening ScanView.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        # Scan the seed first, then start Sign Message from Seed Options.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+            FlowStep(scan_views.ScanView, before_run=self.load_short_message_into_decoder),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.SeedOptionsView)
+        ])
+
+
     def test_sign_message_flow(self):
         """
         Should scan a `signmessage` QR and complete the message review, address review,

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -6,6 +6,7 @@ import pytest
 from base import BaseTest, FlowTest, FlowStep
 from base import FlowTestInvalidButtonDataSelectionException
 
+from seedsigner.controller import Controller
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
@@ -117,6 +118,73 @@ class TestSeedFlows(FlowTest):
         ]
 
         self.run_sequence(sequence)
+
+
+    def test_back_from_seedqr_scan_via_load_seed_flow(self):
+        """
+        Pressing BACK during SeedQR loading should return to LoadSeedView.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.SEED_QR),
+            FlowStep(scan_views.ScanSeedQRView),
+            FlowStep(seed_views.LoadSeedView),
+        ])
+
+
+    def test_back_from_psbt_scan_via_seed_options_flow(self):
+        """
+        Pressing BACK during a transaction scan should return to SeedOptionsView
+        with the selected seed intact. A second sequence verifies that backing out
+        from SeedOptionsView to Main Menu clears the pending PSBT seed.
+        """
+        seed = Seed(mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split())
+        self.controller.storage.set_pending_seed(seed)
+        self.controller.storage.finalize_pending_seed()
+
+        # Sequence 1: BACK from the transaction scanner returns to Seed Options.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, screen_return_value=0),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SCAN_PSBT),
+            FlowStep(scan_views.ScanPSBTView),
+            FlowStep(seed_views.SeedOptionsView),
+        ])
+        assert self.controller.psbt_seed is self.controller.storage.seeds[0]
+
+        # Sequence 2: BACK from Seed Options returns to Main Menu and clears state.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, screen_return_value=0),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SCAN_PSBT),
+            FlowStep(scan_views.ScanPSBTView),
+            FlowStep(seed_views.SeedOptionsView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+        assert self.controller.psbt_seed is None
+
+
+    def test_back_from_seed_scan_via_sign_message_flow(self):
+        """
+        Pressing BACK during seed selection for message signing should return to
+        SeedSelectSeedView with the captured message intact.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        def load_message(view):
+            view.decoder.add_data("signmessage m/84h/0h/0h/0/0 ascii:test message")
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_message),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanView),
+            FlowStep(seed_views.SeedSelectSeedView),
+        ])
+        assert self.controller.resume_main_flow == Controller.FLOW__SIGN_MESSAGE
+        assert "message" in self.controller.sign_message_data
 
 
     def test_electrum_mnemonic_entry_flow(self):
@@ -823,5 +891,3 @@ class TestMessageSigningFlows(FlowTest):
 
         self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
         expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
-
-

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -279,3 +279,137 @@ class TestToolsFlows(FlowTest):
                 FlowStep(seed_views.SeedAddressVerificationView),
                 FlowStep(seed_views.SeedAddressVerificationSuccessView),
             ])
+
+    def test_back_from_address_scan_via_verify_address_flow(self):
+        """
+        Pressing BACK during Verify Address should return to ToolsMenuView.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView),
+            FlowStep(tools_views.ToolsMenuView),
+        ])
+
+
+    def test_back_from_seed_scan_via_address_explorer_flow(self):
+        """
+        Pressing BACK during the Address Explorer seed scan should return to
+        source selection with the flow preserved. Backing out to Main Menu should
+        clear the flow state.
+        """
+        # Sequence 1: BACK from the seed scan returns to source selection.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_SEED),
+            FlowStep(scan_views.ScanSeedQRView),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView),
+        ])
+        assert self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER
+
+        # Sequence 2: BACK to Main Menu.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_SEED),
+            FlowStep(scan_views.ScanSeedQRView),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+        assert self.controller.resume_main_flow is None
+
+
+    def test_back_from_descriptor_scan_via_address_explorer_flow(self):
+        """
+        Pressing BACK during the Address Explorer descriptor scan should return
+        to source selection with the flow preserved, while backing out to Main Menu
+        should clear the flow state.
+        """
+        # Sequence 1: BACK from the descriptor scanner returns to source selection.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
+            FlowStep(scan_views.ScanWalletDescriptorView),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView),
+        ])
+        assert self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER
+
+        # Sequence 2: BACK to Main Menu.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
+            FlowStep(scan_views.ScanWalletDescriptorView),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+        assert self.controller.resume_main_flow is None
+
+    
+    def test_back_from_seed_scan_via_singlesig_address_verification_flow(self):
+        """
+        Pressing BACK during seed selection for singlesig address verification
+        should return to Select Seed with verification state preserved. Backing
+        out to Main Menu should clear that state.
+        """
+        
+        def load_singlesig_address_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data("bcrt1q4e9q5taxnsvc6m0uxv6h75mkzvnkxeqk6l90u2")
+
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST)
+
+        # Sequence 1: BACK from the seed scanner returns to Select Seed.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_singlesig_address_into_decoder),
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanView),
+            FlowStep(seed_views.SeedSelectSeedView),
+        ])
+        assert self.controller.unverified_address is not None
+        assert self.controller.resume_main_flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR
+
+        # Sequence 2: BACK from Select Seed and Tools returns to Main Menu.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_singlesig_address_into_decoder),
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanView),
+            FlowStep(seed_views.SeedSelectSeedView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+        assert self.controller.unverified_address is None
+        assert self.controller.resume_main_flow is None
+
+
+    def test_back_from_descriptor_scan_via_multisig_address_verification_flow(self):
+        """
+        Pressing BACK during multisig descriptor loading should return to the
+        descriptor prompt with address verification state preserved.
+        """
+
+        def load_multisig_address_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data("2N5eN5vUpgsLHAGzKm2VfmYyvNwXmCug5dH")
+        
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST)
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_multisig_address_into_decoder),
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.AddressVerificationSigTypeView, button_data_selection=seed_views.AddressVerificationSigTypeView.MULTISIG),
+            FlowStep(seed_views.LoadMultisigWalletDescriptorView, button_data_selection=seed_views.LoadMultisigWalletDescriptorView.SCAN),
+            FlowStep(scan_views.ScanWalletDescriptorView),
+            FlowStep(seed_views.LoadMultisigWalletDescriptorView),
+        ])
+        assert self.controller.unverified_address is not None
+        assert self.controller.resume_main_flow == Controller.FLOW__VERIFY_MULTISIG_ADDR

--- a/tests/test_flows_view.py
+++ b/tests/test_flows_view.py
@@ -14,6 +14,17 @@ from seedsigner.views.view import CameraConnectionErrorView, MainMenuView, NotYe
 
 class TestViewFlows(FlowTest):
 
+    def test_back_from_scan_via_main_menu(self):
+        """
+        Opening the generic scanner from Main Menu and pressing BACK should
+        return to MainMenuView through the back stack.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(ScanView),
+            FlowStep(MainMenuView),
+        ])
+
     def test_restart_flow(self):
         """
         Basic flow from MainMenuView to RestartView


### PR DESCRIPTION
## Description
Resolves #775 

This PR fixes a back-navigation bug in `ScanView` where pressing BACK without completing a QR scan routed the user directly to `MainMenuView` instead of returning to the view that opened the scanner. It also adds FlowTests for every scan-view BACK exit scenario.

### Problem or Issue being addressed

When a user entered a scan screen from another flow and pressed the hardware BACK button without scanning a QR code, `ScanView.run()` fell through to `return Destination(MainMenuView)`

Routing to `MainMenuView` clears the controller back stack and all pending flow state. This caused the user to lose their current context and, in some flows, lose data that was still needed to continue.
The expected behavior is to return to the view that opened the scanner while preserving the pending flow state.

<!--
Describe the problem this PR solves.
Include background context, links to relevant issues, BIPs, discussions, etc.
-->

### Solution

Changed the final fallback in ScanView.run() from `Destination(MainMenuView)` to `Destination(BackStackView)`. When the BACK button is pressed, scan view now returns through the controller back stack. This restores the previous view and preserves any pending flow state.

The sign-message QR route now uses `skip_current_view=True`. After message is successfully scanned, the scanner is removed from the back stack so pressing BACK from message review returns to the originating Seed Options flow instead of reopening the scanner.

```text
Seed Options -> Sign Message -> Scan message -> Review message -> BACK -> Seed Options
```
### Additional Information

Invalid QR behavior remains unchanged and is outside the scope of this PR, as that behavior is covered by PR #983

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---