### PR TITLE
[Bugfix] Guard sign-message resume flow against missing message

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -557,8 +557,17 @@ class SeedOptionsView(View):
             return Destination(SeedExportXpubScriptTypeView, view_args=dict(seed=self.seed, sig_type=SettingsConstants.SINGLE_SIG), skip_current_view=True)
 
         elif self.controller.resume_main_flow == Controller.FLOW__SIGN_MESSAGE:
-            self.controller.sign_message_data["seed"] = self.seed
-            return Destination(SeedSignMessageConfirmMessageView, skip_current_view=True)
+            # Only resume message review when a message was actually captured.
+            # A recognized non-message QR can route through seed import and return
+            # here with the sign-message flow armed but without any message data.
+            if self.controller.sign_message_data and "message" in self.controller.sign_message_data:
+                self.controller.sign_message_data["seed"] = self.seed
+                return Destination(SeedSignMessageConfirmMessageView, skip_current_view=True)
+
+            # Treat an incomplete sign-message flow as an abort and return to the
+            # normal Seed Options menu instead of opening review with missing data.
+            self.controller.resume_main_flow = None
+            self.controller.sign_message_data = None
 
         if self.controller.psbt:
             from seedsigner.models.psbt_parser import PSBTParser

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -624,6 +624,32 @@ class TestMessageSigningFlows(FlowTest):
         self.controller.sign_message_data["paged_message"] = paged
 
 
+    def test_sign_message_missing_message_aborts_cleanly(self):
+        """
+        If Sign Message is armed before a message is captured, scanning a
+        non-message QR should return to the normal Seed Options menu instead of
+        opening message review with missing data.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        # Load a seed to sign with, then scan another SeedQR where the message QR
+        # is expected. The second seed import returns to Seed Options with the
+        # sign-message flow still armed but without a captured message.
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.SIGN_MESSAGE),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BACKUP),
+            FlowStep(seed_views.SeedBackupView),
+        ])
+
+        assert self.controller.resume_main_flow is None
+        assert self.controller.sign_message_data is None
+
+
     def test_sign_message_flow(self):
         """
         Should scan a `signmessage` QR and complete the message review, address review,


### PR DESCRIPTION
## Description

This PR fixes the sign-message resume-flow issue which was identified by Keith.

### Problem or Issue being addressed

#### Incomplete sign-message flow caused a crash

SeedOptionsView arms the sign-message flow before a message has been captured:

```python
self.controller.sign_message_data = dict(seed=self.seed)
self.controller.resume_main_flow = Controller.FLOW__SIGN_MESSAGE
```

Because the generic ScanView accepts multiple QR formats, a user can scan a SeedQR while the app is expecting a message:
```text
Seed Options -> Sign Message -> Scan SeedQR instead of a message QR -> Seed Finalize -> Seed Options -> Resume message review -> KeyError on missing message
```

### Solution

#### Guard the sign-message resume path

SeedOptionsView now resumes message review only when a message was actually captured. If the flow is armed without message data:
- `resume_main_flow` & `sign_message_data` is cleared.
- The normal Seed Options menu is shown.
- Message review is not opened.
- The missing-message crash is avoided.


### Additional Information

<!--
Tradeoffs, follow-ups, limitations, or anything reviewers should be aware of.
-->

### Screenshots

<!--
Include screenshots for any new or modified screens.
If omitted, explain why.
-->

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---