### PR TITLE
[Bugfix] Back navigation when cancelling Address Verification

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1919,9 +1919,6 @@ class SeedAddressVerificationView(View):
                 if self.verified_index.cur_count is not None:
                     break
 
-                if selected_menu_num == RET_CODE__BACK_BUTTON:
-                    break
-
                 if selected_menu_num is None:
                     # Only happens in the test suite; the screen isn't actually executed so
                     # it returns before the brute force thread has completed.
@@ -1949,7 +1946,8 @@ class SeedAddressVerificationView(View):
             while self.addr_verification_thread.is_alive():
                 time.sleep(0.01)
 
-        return Destination(MainMenuView)
+        # Cancel should return to the view that started verification.
+        return Destination(BackStackView)
 
 
 

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -281,6 +281,31 @@ class TestToolsFlows(FlowTest):
             ])
 
 
+
+    def test_verify_address_cancel_from_verification_returns_to_previous_view(self):
+        """
+        Choosing Cancel from address verification should return to the previous view.
+        """
+        controller = Controller.get_instance()
+        controller.storage.set_pending_seed(Seed(mnemonic=["abandon " * 11 + "about"]))
+        controller.storage.finalize_pending_seed()
+        controller.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST)
+
+        def load_address_into_decoder(view: scan_views.ScanView):
+            # Native segwit regtest receive address at index 6 for the test seed.
+            view.decoder.add_data("bcrt1q4e9q5taxnsvc6m0uxv6h75mkzvnkxeqk6l90u2")
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate reading an address QR
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, screen_return_value=0),
+            FlowStep(seed_views.SeedAddressVerificationView, button_data_selection=seed_views.SeedAddressVerificationView.CANCEL),
+            FlowStep(seed_views.SeedSelectSeedView),
+        ])
+
+
 class TestToolsImageEntropyFlows(FlowTest):
 
     def test__image_entropy__incorrect_preview_frame_count_aborts(self):


### PR DESCRIPTION
## Description

This PR fixes a back navigation bug in the address verification flow where selecting Cancel from SeedAddressVerificationView returned directly to `MainMenuView` instead of returning to the view that started address verification.

### Problem or Issue being addressed

<!--
Describe the problem this PR solves.
Include background context, links to relevant issues, BIPs, discussions, etc.
-->

After loading a seed and starting address verification SeedAddressVerificationView returned `Destination(MainMenuView)` when the user selected Cancel. The user should be taken to the previous screen instead to retry the flow.

### Solution

SeedAddressVerificationView now returns `Destination(BackStackView)` when address verification is cancelled. This takes the user to the previous SeedSelectSeedView instead of routing directly to the main menu.

The unreachable `RET_CODE__BACK_BUTTON` branch was also removed because SeedAddressVerificationScreen disables the top-navigation BACK button. The ONLY available exit on this screen is the explicit Cancel button.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---