### PR TITLE
BIP46 support (timelocked fidelity bonds)

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.7\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-05 22:02+0000\n"
+"POT-Creation-Date: 2026-09-04 07:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -427,6 +427,10 @@ msgstr ""
 msgid "derivation path"
 msgstr ""
 
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Bond {year}-{month:02d}"
+msgstr ""
+
 #: src/seedsigner/gui/screens/settings_screens.py
 #: src/seedsigner/views/settings_views.py src/seedsigner/views/view.py
 msgid "Settings"
@@ -471,6 +475,11 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/settings_screens.py
 #: src/seedsigner/views/settings_views.py
+msgid "Version"
+msgstr ""
+
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
 msgid "Settings QR"
 msgstr ""
 
@@ -482,8 +491,18 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#. Counts frames collected so far vs the total required (e.g. 12/50)
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "{}/{}"
+msgstr ""
+
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "click a button"
+msgstr ""
+
+#. Shown while the camera gathers the image frames a new seed requires
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Collecting entropy frames"
 msgstr ""
 
 #. A prompt to the user to either accept or reshoot the image
@@ -650,6 +669,10 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Testnet"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Signet"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
@@ -913,6 +936,44 @@ msgstr ""
 msgid "Verifying Self-Transfer..."
 msgstr ""
 
+#: src/seedsigner/views/psbt_views.py
+msgid "Select a different seed"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Seed Can't Sign"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "None of the inputs in this transaction are controlled by this seed."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Discard transaction"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious Transaction"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Likely an Attack!"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid ""
+"The transaction's change/self-transfer outputs are not going back to your"
+" wallet."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction Problem"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "This transaction incorrectly claims that its input(s) belong to this seed."
+msgstr ""
+
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
 msgid "Transaction's {} address could not be verified from wallet descriptor."
@@ -924,15 +985,7 @@ msgid "Transaction's {} address could not be generated from your seed."
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Suspicious Transaction"
-msgstr ""
-
-#: src/seedsigner/views/psbt_views.py
 msgid "Address Verification Failed"
-msgstr ""
-
-#: src/seedsigner/views/psbt_views.py
-msgid "Discard transaction"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
@@ -1007,7 +1060,8 @@ msgstr ""
 msgid "QRCode is invalid or is a data format not yet supported."
 msgstr ""
 
-#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/view.py
 msgid "Back to Main Menu"
 msgstr ""
 
@@ -1139,6 +1193,10 @@ msgid "Address explorer"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+msgid "Fidelity bond"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
 msgid "Backup seed"
 msgstr ""
 
@@ -1148,6 +1206,53 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Discard seed"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Choose locktime"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Fidelity Bond"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Funds will be locked"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Register with JoinMarket NG, complete certificate setup, perform an "
+"unfunded signing/redemption test, only then fund JoinMarket's "
+"independently reconstructed address."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "No Future Locktimes"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "BIP 46 locktimes are only available through 2099."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Back to Seed Options"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Bond Year"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Bond Month"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Show QR"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Export registration QR"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1346,6 +1451,14 @@ msgid "{threshold} of {n}"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+msgid "Invalid certificate"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "The fidelity bond signing request is not a canonical BIP 46 certificate."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
 msgid "Signing messages for custom derivation paths not supported"
 msgstr ""
 
@@ -1405,6 +1518,14 @@ msgstr ""
 
 #: src/seedsigner/views/tools_views.py src/seedsigner/views/view.py
 msgid "Tools"
+msgstr ""
+
+#. Shown when the camera fails to collect enough frames for a new seed.
+#. "expected" and "actual" are the number of frames.
+#: src/seedsigner/views/tools_views.py
+msgid ""
+"Entropy collection failed. Expected {expected} preview frames, got "
+"{actual}"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -1885,9 +1885,34 @@ def reflow_text_for_width(text: str,
                 # Candidate line is possibly shorter than necessary.
                 return _binary_len_search(min_index=index, max_index=max_index, word_spacer=word_spacer)
 
-        if len(text.split()) == 1 and not treat_chars_as_words:
-            # No whitespace chars to split on! Warn but proceed anyway.
-            logger.warning("Text cannot fit in target rect with this font+size")
+        def _fit_word_prefix(word: str) -> tuple[int, int, int]:
+            """Return the longest nonempty prefix that renders within the width."""
+            min_index = 1
+            max_index = len(word)
+            best = 1
+            best_width = 0
+            best_px_below_baseline = 0
+
+            while min_index <= max_index:
+                index = (min_index + max_index) // 2
+                left, top, right, px_below_baseline = font.getbbox(
+                    word[:index], anchor="ls"
+                )
+                line_width = right - left
+                if line_width < width:
+                    best = index
+                    best_width = line_width
+                    best_px_below_baseline = px_below_baseline
+                    min_index = index + 1
+                else:
+                    max_index = index - 1
+
+            if best_width == 0:
+                left, top, right, best_px_below_baseline = font.getbbox(
+                    word[:1], anchor="ls"
+                )
+                best_width = right - left
+            return best, best_width, best_px_below_baseline
 
         # Now we're ready to go line-by-line into our line break binary search!
         for line in text.split("\n"):
@@ -1914,6 +1939,18 @@ def reflow_text_for_width(text: str,
                 _add_text_line("", 0, 0)
             else:
                 while words:
+                    if not treat_chars_as_words:
+                        left, top, right, px_below_baseline = font.getbbox(
+                            words[0], anchor="ls"
+                        )
+                        if right - left >= width:
+                            index, tw, px_below_baseline = _fit_word_prefix(words[0])
+                            _add_text_line(words[0][:index], tw, px_below_baseline)
+                            words[0] = words[0][index:]
+                            if not words[0]:
+                                words = words[1:]
+                            continue
+
                     (index, tw, px_below_baseline) = _binary_len_search(0, len(words), word_spacer=word_spacer)
                     _add_text_line(word_spacer.join(words[0:index]), tw, px_below_baseline)
                     words = words[index:]

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -1113,7 +1113,7 @@ class BtcAmount(BaseComponent):
             sats_unit = _("sats")
             btc_color = GUIConstants.ACCENT_COLOR
 
-        elif network == SettingsConstants.TESTNET:
+        elif network in (SettingsConstants.TESTNET, SettingsConstants.SIGNET):
             btc_color = GUIConstants.TESTNET_COLOR
         
         elif network == SettingsConstants.REGTEST:

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1675,3 +1675,32 @@ class SeedSignMessageConfirmAddressScreen(ButtonListScreen):
             screen_y=derivation_path_display.screen_y + derivation_path_display.height + 2*GUIConstants.COMPONENT_PADDING,
         )
         self.components.append(address_display)
+
+
+@dataclass
+class SeedFidelityBondAddressScreen(ButtonListScreen):
+    year: int = None
+    month: int = None
+    derivation_path: str = None
+    address: str = None
+
+    def __post_init__(self):
+        self.title = _("Bond {year}-{month:02d}").format(year=self.year, month=self.month)
+        self.is_bottom_list = True
+        self.is_button_text_centered = True
+        super().__post_init__()
+
+        derivation_path_display = IconTextLine(
+            icon_name=SeedSignerIconConstants.DERIVATION,
+            icon_color=GUIConstants.INFO_COLOR,
+            label_text=_("derivation path"),
+            value_text=self.derivation_path,
+            is_text_centered=True,
+            screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
+        )
+        self.components.append(derivation_path_display)
+        self.components.append(FormattedAddress(
+            address=self.address,
+            max_lines=3,
+            screen_y=derivation_path_display.screen_y + derivation_path_display.height + 2*GUIConstants.COMPONENT_PADDING,
+        ))

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1693,8 +1693,8 @@ class SeedFidelityBondAddressScreen(ButtonListScreen):
         derivation_path_display = IconTextLine(
             icon_name=SeedSignerIconConstants.DERIVATION,
             icon_color=GUIConstants.INFO_COLOR,
-            label_text=_("derivation path"),
             value_text=self.derivation_path,
+            font_size=GUIConstants.get_body_font_size() - 2,
             is_text_centered=True,
             screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
         )
@@ -1702,5 +1702,8 @@ class SeedFidelityBondAddressScreen(ButtonListScreen):
         self.components.append(FormattedAddress(
             address=self.address,
             max_lines=3,
-            screen_y=derivation_path_display.screen_y + derivation_path_display.height + 2*GUIConstants.COMPONENT_PADDING,
+            font_size=14,
+            width=self.canvas_width - 2*GUIConstants.EDGE_PADDING,
+            screen_x=GUIConstants.EDGE_PADDING,
+            screen_y=derivation_path_display.screen_y + derivation_path_display.height + GUIConstants.COMPONENT_PADDING,
         ))

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -23,9 +23,11 @@ from seedsigner.models.settings_definition import SettingsConstants
 def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, wallet_type: str = SettingsConstants.SINGLE_SIG, script_type: str = SettingsConstants.NATIVE_SEGWIT) -> str:
     if network == SettingsConstants.MAINNET:
         network_path = "0'"
-    elif network == SettingsConstants.TESTNET:
-        network_path = "1'"
-    elif network == SettingsConstants.REGTEST:
+    elif network in (
+        SettingsConstants.TESTNET,
+        SettingsConstants.SIGNET,
+        SettingsConstants.REGTEST,
+    ):
         network_path = "1'"
     else:
         raise Exception("Unexpected network")
@@ -117,6 +119,7 @@ def get_embit_network_name(settings_name):
     lookup = {
         SettingsConstants.MAINNET: "main",
         SettingsConstants.TESTNET: "test",
+        SettingsConstants.SIGNET: "test",
         SettingsConstants.REGTEST: "regtest",
     }
     return lookup.get(settings_name)
@@ -142,7 +145,11 @@ def parse_derivation_path(derivation_path: str) -> dict:
         bond_path = fidelity_bonds.parse_derivation_path(derivation_path)
         network = SettingsConstants.MAINNET
         if bond_path.coin_type == 1:
-            network = [SettingsConstants.TESTNET, SettingsConstants.REGTEST]
+            network = [
+                SettingsConstants.TESTNET,
+                SettingsConstants.SIGNET,
+                SettingsConstants.REGTEST,
+            ]
         return {
             "script_type": SettingsConstants.NATIVE_SEGWIT,
             "network": network,
@@ -168,7 +175,11 @@ def parse_derivation_path(derivation_path: str) -> dict:
         },
         "networks": {
             "0h": SettingsConstants.MAINNET,
-            "1h": [SettingsConstants.TESTNET, SettingsConstants.REGTEST],
+            "1h": [
+                SettingsConstants.TESTNET,
+                SettingsConstants.SIGNET,
+                SettingsConstants.REGTEST,
+            ],
         }
     }
 

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -136,6 +136,25 @@ def parse_derivation_path(derivation_path: str) -> dict:
 
     sections = derivation_path.split("/")
 
+    # BIP 46 uses the otherwise nonstandard branch 2 for fidelity bonds.
+    from seedsigner.helpers import fidelity_bonds
+    try:
+        bond_path = fidelity_bonds.parse_derivation_path(derivation_path)
+        network = SettingsConstants.MAINNET
+        if bond_path.coin_type == 1:
+            network = [SettingsConstants.TESTNET, SettingsConstants.REGTEST]
+        return {
+            "script_type": SettingsConstants.NATIVE_SEGWIT,
+            "network": network,
+            "is_change": False,
+            "index": bond_path.index,
+            "wallet_derivation_path": "/".join(sections[:-2]),
+            "is_fidelity_bond": True,
+            "clean_match": True,
+        }
+    except ValueError:
+        pass
+
     if sections[1] == "48h":
         # So far this helper is only meant for single sig message signing
         raise Exception("Not implemented")
@@ -154,6 +173,7 @@ def parse_derivation_path(derivation_path: str) -> dict:
     }
 
     details = dict()
+    details["is_fidelity_bond"] = False
     details["script_type"] = lookups["script_types"].get(sections[1])
     if not details["script_type"]:
         details["script_type"] = SettingsConstants.CUSTOM_DERIVATION

--- a/src/seedsigner/helpers/fidelity_bonds.py
+++ b/src/seedsigner/helpers/fidelity_bonds.py
@@ -1,5 +1,6 @@
 """BIP 46 timelocked fidelity bond helpers."""
 
+import json
 import re
 from dataclasses import dataclass
 
@@ -53,7 +54,11 @@ def _require_index(index: int) -> None:
 def _coin_type(network: str) -> int:
     if network == SettingsConstants.MAINNET:
         return 0
-    if network in (SettingsConstants.TESTNET, SettingsConstants.REGTEST):
+    if network in (
+        SettingsConstants.TESTNET,
+        SettingsConstants.SIGNET,
+        SettingsConstants.REGTEST,
+    ):
         return 1
     raise ValueError("unsupported network")
 
@@ -226,6 +231,34 @@ def derive_address(
     return script.p2wsh(derive_witness_script(seed_bytes, index, network)).address(
         NETWORKS[embit_network]
     )
+
+
+def registration_payload(seed_bytes: bytes, index: int, network: str) -> str:
+    """Return the canonical single-QR BIP 46 registration payload."""
+    if not isinstance(seed_bytes, bytes):
+        raise ValueError("seed_bytes must be bytes")
+    embit_network = SettingsConstants.map_network_to_embit(network)
+    network_name = SettingsConstants.map_network_to_name(network)
+    if embit_network is None or network_name is None:
+        raise ValueError("unsupported network")
+
+    origin_path = f"m/84'/{_coin_type(network)}'/0'/2"
+    root = bip32.HDKey.from_seed(seed_bytes, version=NETWORKS[embit_network]["xprv"])
+    xpub = root.derive(origin_path).to_public().to_string(
+        version=NETWORKS[embit_network]["xpub"]
+    )
+    year, month = index_to_year_month(index)
+    payload = {
+        "type": "seedsigner-bip46",
+        "version": 1,
+        "network": network_name,
+        "master_fingerprint": root.my_fingerprint.hex(),
+        "origin_path": origin_path,
+        "xpub": xpub,
+        "locktime_date": f"{year:04d}-{month:02d}",
+        "address": derive_address(seed_bytes, index, network),
+    }
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
 
 
 def parse_certificate(certificate: str) -> FidelityBondCertificate:

--- a/src/seedsigner/helpers/fidelity_bonds.py
+++ b/src/seedsigner/helpers/fidelity_bonds.py
@@ -3,6 +3,7 @@
 import json
 import re
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from embit import bip32, ec, script
 from embit.networks import NETWORKS
@@ -76,6 +77,20 @@ def year_month_to_index(year: int, month: int) -> int:
     if type(month) is not int or not 1 <= month <= 12:
         raise ValueError("month must be between 1 and 12")
     return (year - MIN_YEAR) * 12 + month - 1
+
+
+def future_year_months(now: datetime | None = None) -> list[tuple[int, int]]:
+    """Return BIP 46 months strictly after the current UTC month."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
+    return [
+        (year, month)
+        for year in range(MIN_YEAR, MAX_YEAR + 1)
+        for month in range(1, 13)
+        if (year, month) > (now.year, now.month)
+    ]
 
 
 def index_to_locktime(index: int) -> int:
@@ -242,20 +257,21 @@ def registration_payload(seed_bytes: bytes, index: int, network: str) -> str:
     if embit_network is None or network_name is None:
         raise ValueError("unsupported network")
 
-    origin_path = f"m/84'/{_coin_type(network)}'/0'/2"
     root = bip32.HDKey.from_seed(seed_bytes, version=NETWORKS[embit_network]["xprv"])
-    xpub = root.derive(origin_path).to_public().to_string(
-        version=NETWORKS[embit_network]["xpub"]
-    )
     year, month = index_to_year_month(index)
+    locktime = index_to_locktime(index)
+    path = derivation_path(index, network)
+    pubkey = derive_pubkey(seed_bytes, index, network).sec().hex()
     payload = {
         "type": "seedsigner-bip46",
         "version": 1,
         "network": network_name,
         "master_fingerprint": root.my_fingerprint.hex(),
-        "origin_path": origin_path,
-        "xpub": xpub,
+        "derivation_path": path,
+        "index": index,
+        "locktime": locktime,
         "locktime_date": f"{year:04d}-{month:02d}",
+        "pubkey": pubkey,
         "address": derive_address(seed_bytes, index, network),
     }
     return json.dumps(payload, separators=(",", ":"), ensure_ascii=True)

--- a/src/seedsigner/helpers/fidelity_bonds.py
+++ b/src/seedsigner/helpers/fidelity_bonds.py
@@ -1,0 +1,256 @@
+"""BIP 46 timelocked fidelity bond helpers."""
+
+import re
+from dataclasses import dataclass
+
+from embit import bip32, ec, script
+from embit.networks import NETWORKS
+
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+MIN_INDEX = 0
+MAX_INDEX = 959
+MIN_YEAR = 2020
+MAX_YEAR = 2099
+_MONTH_DAYS = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+
+
+@dataclass(frozen=True)
+class FidelityBondPath:
+    coin_type: int
+    index: int
+
+
+@dataclass(frozen=True)
+class ParsedWitnessScript:
+    locktime: int
+    index: int
+    pubkey: ec.PublicKey
+
+
+@dataclass(frozen=True)
+class FidelityBondCertificate:
+    pubkey: ec.PublicKey
+    pubkey_hex: str
+    expiry: int
+
+
+def _is_leap_year(year: int) -> bool:
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def _leap_years_before(year: int) -> int:
+    year -= 1
+    return year // 4 - year // 100 + year // 400
+
+
+def _require_index(index: int) -> None:
+    if type(index) is not int or not MIN_INDEX <= index <= MAX_INDEX:
+        raise ValueError("BIP 46 index must be between 0 and 959")
+
+
+def _coin_type(network: str) -> int:
+    if network == SettingsConstants.MAINNET:
+        return 0
+    if network in (SettingsConstants.TESTNET, SettingsConstants.REGTEST):
+        return 1
+    raise ValueError("unsupported network")
+
+
+def index_to_year_month(index: int) -> tuple[int, int]:
+    """Return the BIP 46 year and month for an address index."""
+    _require_index(index)
+    return MIN_YEAR + index // 12, 1 + index % 12
+
+
+def year_month_to_index(year: int, month: int) -> int:
+    """Return the BIP 46 index for a year and month."""
+    if type(year) is not int or not MIN_YEAR <= year <= MAX_YEAR:
+        raise ValueError("BIP 46 year must be between 2020 and 2099")
+    if type(month) is not int or not 1 <= month <= 12:
+        raise ValueError("month must be between 1 and 12")
+    return (year - MIN_YEAR) * 12 + month - 1
+
+
+def index_to_locktime(index: int) -> int:
+    """Return the first-second UTC Unix locktime for a BIP 46 index."""
+    year, month = index_to_year_month(index)
+    days = (year - 1970) * 365
+    days += _leap_years_before(year) - _leap_years_before(1970)
+    days += sum(_MONTH_DAYS[: month - 1])
+    if month > 2 and _is_leap_year(year):
+        days += 1
+    return days * 24 * 60 * 60
+
+
+def derivation_path(index: int, network: str = SettingsConstants.MAINNET) -> str:
+    """Return the canonical BIP 46 derivation path for an index and network."""
+    _require_index(index)
+    return f"m/84'/{_coin_type(network)}'/0'/2/{index}"
+
+
+def parse_derivation_path(path: str, network: str | None = None) -> FidelityBondPath:
+    """Parse an exact BIP 46 path, accepting either apostrophes or h markers."""
+    if not isinstance(path, str):
+        raise ValueError("derivation path must be a string")
+    match = re.fullmatch(r"m/84(['h])/([01])\1/0\1/2/([0-9]+)", path)
+    if match is None:
+        raise ValueError("not a canonical BIP 46 derivation path")
+    coin_type, index_text = int(match.group(2)), match.group(3)
+    index = int(index_text)
+    _require_index(index)
+    if index_text != str(index):
+        raise ValueError("BIP 46 index must be canonical decimal")
+    if network is not None and coin_type != _coin_type(network):
+        raise ValueError("derivation path does not match network")
+    return FidelityBondPath(coin_type=coin_type, index=index)
+
+
+def _script_num(value: int) -> bytes:
+    if type(value) is not int or not 0 <= value <= 0xFFFFFFFF:
+        raise ValueError("locktime must be an unsigned 32-bit integer")
+    if value == 0:
+        return b""
+    result = bytearray()
+    while value:
+        result.append(value & 0xFF)
+        value >>= 8
+    if result[-1] & 0x80:
+        result.append(0)
+    return bytes(result)
+
+
+def _compressed_pubkey(pubkey: ec.PublicKey | bytes) -> tuple[ec.PublicKey, bytes]:
+    if isinstance(pubkey, ec.PublicKey):
+        encoded = pubkey.sec()
+    elif isinstance(pubkey, bytes):
+        encoded = pubkey
+    else:
+        raise ValueError("pubkey must be a compressed public key")
+    if len(encoded) != 33 or encoded[0] not in (2, 3):
+        raise ValueError("pubkey must be a compressed public key")
+    try:
+        parsed = ec.PublicKey.parse(encoded)
+    except Exception as error:
+        raise ValueError("invalid compressed public key") from error
+    if parsed.sec() != encoded:
+        raise ValueError("pubkey must use canonical compressed encoding")
+    return parsed, encoded
+
+
+def witness_script(locktime: int, pubkey: ec.PublicKey | bytes) -> script.Script:
+    """Construct the canonical BIP 46 witness script."""
+    _, encoded_pubkey = _compressed_pubkey(pubkey)
+    encoded_locktime = _script_num(locktime)
+    return script.Script(
+        bytes((len(encoded_locktime),))
+        + encoded_locktime
+        + b"\xb1\x75\x21"
+        + encoded_pubkey
+        + b"\xac"
+    )
+
+
+def _parse_script_num(encoded: bytes) -> int:
+    if not encoded:
+        return 0
+    value = sum(byte << (8 * position) for position, byte in enumerate(encoded))
+    if encoded[-1] & 0x80:
+        value &= ~(0x80 << (8 * (len(encoded) - 1)))
+        value = -value
+    return value
+
+
+def _index_from_locktime(locktime: int) -> int:
+    for index in range(MIN_INDEX, MAX_INDEX + 1):
+        if index_to_locktime(index) == locktime:
+            return index
+    raise ValueError("locktime is not a BIP 46 monthly locktime")
+
+
+def parse_witness_script(witness: script.Script | bytes) -> ParsedWitnessScript:
+    """Parse only the canonical BIP 46 witness script template."""
+    if isinstance(witness, script.Script):
+        data = witness.data
+    elif isinstance(witness, bytes):
+        data = witness
+    else:
+        raise ValueError("witness script must be Script or bytes")
+    if not data or data[0] not in (4, 5) or len(data) != data[0] + 38:
+        raise ValueError("not a canonical BIP 46 witness script")
+    locktime_length = data[0]
+    locktime_bytes = data[1 : 1 + locktime_length]
+    if data[1 + locktime_length : 3 + locktime_length] != b"\xb1\x75":
+        raise ValueError("not a canonical BIP 46 witness script")
+    if data[3 + locktime_length] != 0x21 or data[-1] != 0xAC:
+        raise ValueError("not a canonical BIP 46 witness script")
+    locktime = _parse_script_num(locktime_bytes)
+    if locktime < 0 or _script_num(locktime) != locktime_bytes:
+        raise ValueError("locktime is not minimally encoded")
+    pubkey, _ = _compressed_pubkey(data[4 + locktime_length : -1])
+    return ParsedWitnessScript(
+        locktime=locktime, index=_index_from_locktime(locktime), pubkey=pubkey
+    )
+
+
+def derive_pubkey(
+    seed_bytes: bytes, index: int, network: str = SettingsConstants.MAINNET
+) -> ec.PublicKey:
+    """Derive a BIP 46 compressed public key from seed bytes."""
+    if not isinstance(seed_bytes, bytes):
+        raise ValueError("seed_bytes must be bytes")
+    embit_network = SettingsConstants.map_network_to_embit(network)
+    if embit_network is None:
+        raise ValueError("unsupported network")
+    key = bip32.HDKey.from_seed(seed_bytes, version=NETWORKS[embit_network]["xprv"])
+    return key.derive(derivation_path(index, network)).to_public().key
+
+
+def derive_witness_script(
+    seed_bytes: bytes, index: int, network: str = SettingsConstants.MAINNET
+) -> script.Script:
+    """Derive a BIP 46 witness script from seed bytes."""
+    return witness_script(
+        index_to_locktime(index), derive_pubkey(seed_bytes, index, network)
+    )
+
+
+def derive_address(
+    seed_bytes: bytes, index: int, network: str = SettingsConstants.MAINNET
+) -> str:
+    """Derive a BIP 46 P2WSH address from seed bytes."""
+    embit_network = SettingsConstants.map_network_to_embit(network)
+    if embit_network is None:
+        raise ValueError("unsupported network")
+    return script.p2wsh(derive_witness_script(seed_bytes, index, network)).address(
+        NETWORKS[embit_network]
+    )
+
+
+def parse_certificate(certificate: str) -> FidelityBondCertificate:
+    """Parse a strict ASCII BIP 46 fidelity bond certificate message."""
+    if not isinstance(certificate, str) or not certificate.isascii():
+        raise ValueError("certificate must be an ASCII string")
+    parts = certificate.split("|")
+    if len(parts) != 3 or parts[0] != "fidelity-bond-cert":
+        raise ValueError("invalid fidelity bond certificate")
+    pubkey_hex, expiry_text = parts[1], parts[2]
+    if re.fullmatch(r"0|[1-9][0-9]*", expiry_text) is None:
+        raise ValueError("certificate expiry must be canonical decimal")
+    expiry = int(expiry_text)
+    if expiry > 0xFFFF:
+        raise ValueError("certificate expiry must be a uint16")
+    if re.fullmatch(r"0[23][0-9a-f]{64}", pubkey_hex) is None:
+        raise ValueError("certificate pubkey must be lowercase compressed hex")
+    pubkey, _ = _compressed_pubkey(bytes.fromhex(pubkey_hex))
+    return FidelityBondCertificate(pubkey=pubkey, pubkey_hex=pubkey_hex, expiry=expiry)
+
+
+def is_valid_certificate(certificate: str) -> bool:
+    """Return whether a certificate has the strict BIP 46 message form."""
+    try:
+        parse_certificate(certificate)
+    except ValueError:
+        return False
+    return True

--- a/src/seedsigner/helpers/qr.py
+++ b/src/seedsigner/helpers/qr.py
@@ -1,8 +1,10 @@
+from io import BytesIO
+import subprocess
+
 import qrcode
 from qrcode.image.styledpil import StyledPilImage
 from qrcode.image.styles.moduledrawers import CircleModuleDrawer, GappedSquareModuleDrawer
 from PIL import Image, ImageDraw
-import subprocess
 
 class QR:
     STYLE__DEFAULT = 1
@@ -109,17 +111,18 @@ class QR:
             "-t",
             "PNG",
             "-o",
-            "/tmp/qrcode.png",
+            "-",
             str(data),
         ]
         try:
-            rv = subprocess.call(cmd)
+            result = subprocess.run(cmd, capture_output=True, check=False)
         except OSError:
-            rv = -1
+            result = None
 
         # if qrencode fails, fall back to only encoder
-        if rv != 0:
+        if result is None or result.returncode != 0:
             return self.qrimage(data,width,height,border)
-        img = Image.open("/tmp/qrcode.png").resize((width,height), Image.Resampling.NEAREST).convert("RGBA")
+        with Image.open(BytesIO(result.stdout)) as encoded_image:
+            img = encoded_image.resize((width,height), Image.Resampling.NEAREST).convert("RGBA")
 
         return img

--- a/src/seedsigner/helpers/qr.py
+++ b/src/seedsigner/helpers/qr.py
@@ -96,8 +96,26 @@ class QR:
         else:
             border_str = "3"
 
-        cmd = f"""qrencode -m {border_str} -s 3 -l L --foreground=000000 --background={background_color} -t PNG -o "/tmp/qrcode.png" "{str(data)}" """
-        rv = subprocess.call(cmd, shell=True)
+        cmd = [
+            "qrencode",
+            "-m",
+            border_str,
+            "-s",
+            "3",
+            "-l",
+            "L",
+            "--foreground=000000",
+            f"--background={background_color}",
+            "-t",
+            "PNG",
+            "-o",
+            "/tmp/qrcode.png",
+            str(data),
+        ]
+        try:
+            rv = subprocess.call(cmd)
+        except OSError:
+            rv = -1
 
         # if qrencode fails, fall back to only encoder
         if rv != 0:

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -69,6 +69,11 @@ class BaseQrEncoder:
 **************************************************************************************"""
 @dataclass
 class BaseStaticQrEncoder(BaseQrEncoder):
+    def __post_init__(self):
+        super().__post_init__()
+        self._cached_image = None
+        self._cached_image_params = None
+
     def seq_len(self):
         return 1
     
@@ -80,6 +85,21 @@ class BaseStaticQrEncoder(BaseQrEncoder):
     @property
     def is_complete(self):
         return True
+
+    def part_to_image(self, part, width, height, border: int = 3, background_color: str = "ffffff"):
+        image_params = (part, width, height, border, background_color)
+        if self._cached_image_params != image_params:
+            self._cached_image = super().part_to_image(
+                part,
+                width,
+                height,
+                border,
+                background_color=background_color,
+            )
+            self._cached_image_params = image_params
+
+        # Brightness tips are drawn directly onto the returned image.
+        return self._cached_image.copy()
 
 
 

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -2,7 +2,7 @@ import math
 
 from embit import bip32
 from embit.networks import NETWORKS
-from binascii import hexlify
+from binascii import b2a_base64, hexlify
 from dataclasses import dataclass
 from typing import List
 from embit import bip32
@@ -142,6 +142,33 @@ class GenericStaticQrEncoder(BaseStaticQrEncoder):
 
     def next_part(self):
         return self.data
+
+
+@dataclass
+class Base64PsbtQrEncoder(GenericStaticQrEncoder):
+    psbt: PSBT = None
+
+    MAX_QR_MODULES = 65
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.data = b2a_base64(self.psbt.serialize()).rstrip(b"\n").decode("ascii")
+
+    @property
+    def fits_in_qr(self) -> bool:
+        import qrcode
+
+        qr = qrcode.QRCode(
+            version=1,
+            error_correction=qrcode.constants.ERROR_CORRECT_L,
+            border=2,
+        )
+        qr.add_data(self.data)
+        try:
+            qr.make(fit=True)
+        except qrcode.exceptions.DataOverflowError:
+            return False
+        return len(qr.get_matrix()) - 4 <= self.MAX_QR_MODULES
 
 
 

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -186,7 +186,7 @@ class Base64PsbtQrEncoder(GenericStaticQrEncoder):
         qr.add_data(self.data)
         try:
             qr.make(fit=True)
-        except qrcode.exceptions.DataOverflowError:
+        except (qrcode.exceptions.DataOverflowError, ValueError):
             return False
         return len(qr.get_matrix()) - 4 <= self.MAX_QR_MODULES
 

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -5,6 +5,7 @@ from embit.descriptor import Descriptor
 from embit.networks import NETWORKS
 from embit.psbt import PSBT, DerivationPath, InputScope, OutputScope
 from embit.ec import PublicKey
+from embit.transaction import SIGHASH
 from io import BytesIO
 from typing import List
 
@@ -259,15 +260,21 @@ class PSBTParser():
     def _parse_inputs(self, child_key_derivation_cache: dict):
         self.input_amount = 0
         self.num_inputs = len(self.psbt.inputs)
-        for inp in self.psbt.inputs:
+        for input_index, inp in enumerate(self.psbt.inputs):
             if inp.witness_utxo:
                 self.input_amount += inp.witness_utxo.value
                 script_pubkey = inp.witness_utxo.script_pubkey
             elif inp.non_witness_utxo:
                 self.input_amount += inp.utxo.value
                 script_pubkey = inp.script_pubkey
+            else:
+                if PSBTParser._is_fidelity_bond_scope(inp):
+                    raise ValueError("Fidelity bond input requires a witness UTXO")
+                raise ValueError("PSBT input is missing UTXO data")
 
             inp_policy = PSBTParser._get_policy(inp, script_pubkey, self.psbt.xpubs, child_key_derivation_cache)
+            if inp_policy.get("fidelity_bond"):
+                self._validate_fidelity_bond_input(input_index, inp, script_pubkey)
             if self.policy == None:
                 self.policy = inp_policy
             else:
@@ -396,6 +403,12 @@ class PSBTParser():
                 trimmed_psbt.inputs[i].final_scriptwitness = inp.final_scriptwitness
             else:
                 trimmed_psbt.inputs[i].partial_sigs = inp.partial_sigs
+                if PSBTParser._is_fidelity_bond_scope(inp):
+                    # JoinMarket's finalizer needs these fields to verify and build the
+                    # final P2WSH witness from the returned partial signature.
+                    trimmed_psbt.inputs[i].witness_utxo = inp.witness_utxo
+                    trimmed_psbt.inputs[i].witness_script = inp.witness_script
+                    trimmed_psbt.inputs[i].sighash_type = inp.sighash_type
 
         return trimmed_psbt
 
@@ -440,6 +453,19 @@ class PSBTParser():
                 script = scope.redeem_script
 
             if script is not None:
+                if script_type == "p2wsh":
+                    from seedsigner.helpers import fidelity_bonds
+                    try:
+                        bond = fidelity_bonds.parse_witness_script(script)
+                        policy.update({
+                            "fidelity_bond": True,
+                            "locktime": bond.locktime,
+                            "pubkey": bond.pubkey.sec().hex(),
+                        })
+                        return policy
+                    except ValueError:
+                        pass
+
                 m, n, pubkeys = PSBTParser._parse_multisig(script)
             
                 # check pubkeys are derived from cosigners
@@ -456,6 +482,49 @@ class PSBTParser():
                     policy.update({"m": m, "n": n})
         
         return policy
+
+
+    @staticmethod
+    def _is_fidelity_bond_scope(scope) -> bool:
+        if scope.witness_script is None:
+            return False
+        from seedsigner.helpers import fidelity_bonds
+        try:
+            fidelity_bonds.parse_witness_script(scope.witness_script)
+        except ValueError:
+            return False
+        return True
+
+
+    def _validate_fidelity_bond_input(self, input_index, inp, script_pubkey):
+        from seedsigner.helpers import fidelity_bonds
+
+        if len(self.psbt.inputs) != 1 or len(self.psbt.outputs) != 1:
+            raise ValueError("Fidelity bond redemption requires one input and one output")
+        if inp.witness_utxo is None:
+            raise ValueError("Fidelity bond input requires a witness UTXO")
+        if script.p2wsh(inp.witness_script) != script_pubkey:
+            raise ValueError("Fidelity bond witness script does not match the UTXO")
+        if inp.sighash_type != SIGHASH.ALL:
+            raise ValueError("Fidelity bond input requires SIGHASH_ALL")
+
+        bond = fidelity_bonds.parse_witness_script(inp.witness_script)
+        if self.psbt.tx.locktime < bond.locktime:
+            raise ValueError("Fidelity bond transaction locktime is too early")
+        if self.psbt.tx.vin[input_index].sequence == 0xFFFFFFFF:
+            raise ValueError("Fidelity bond input sequence is final")
+
+        derivation = inp.bip32_derivations.get(bond.pubkey)
+        if derivation is None or len(inp.bip32_derivations) != 1:
+            raise ValueError("Fidelity bond input requires its BIP32 derivation")
+        path = bip32.path_to_str(derivation.derivation)
+        parsed_path = fidelity_bonds.parse_derivation_path(path, self.network)
+        if parsed_path.index != bond.index:
+            raise ValueError("Fidelity bond path does not match its locktime")
+        if derivation.fingerprint != self.root.my_fingerprint:
+            raise ValueError("Fidelity bond fingerprint does not match the seed")
+        if self.root.derive(derivation.derivation).to_public().key != bond.pubkey:
+            raise ValueError("Fidelity bond pubkey does not match the seed")
 
 
     @staticmethod

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -256,10 +256,12 @@ class SettingsConstants:
     # Seed-related constants
     MAINNET = "M"
     TESTNET = "T"
+    SIGNET = "S"
     REGTEST = "R"
     ALL_NETWORKS = [
         (MAINNET, _mft("Mainnet")),
         (TESTNET, _mft("Testnet")),
+        (SIGNET, _mft("Signet")),
         (REGTEST, _mft("Regtest"))
     ]
 
@@ -268,10 +270,20 @@ class SettingsConstants:
         # Note these are `embit` constants; do not wrap for translation
         if network == SettingsConstants.MAINNET:
             return "main"
-        elif network == SettingsConstants.TESTNET:
+        elif network in (SettingsConstants.TESTNET, SettingsConstants.SIGNET):
             return "test"
         if network == SettingsConstants.REGTEST:
             return "regtest"
+
+    @classmethod
+    def map_network_to_name(cls, network) -> str:
+        names = {
+            cls.MAINNET: "mainnet",
+            cls.TESTNET: "testnet",
+            cls.SIGNET: "signet",
+            cls.REGTEST: "regtest",
+        }
+        return names.get(network)
     
     PERSISTENT_SETTINGS__SD_INSERTED__HELP_TEXT = _mft("Store Settings on SD card")
     PERSISTENT_SETTINGS__SD_REMOVED__HELP_TEXT = _mft("Insert SD card to enable")

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -653,12 +653,24 @@ class PSBTFinalizeView(View):
 
 class PSBTSignedQRDisplayView(View):
     def run(self):
-        from seedsigner.models.encode_qr import UrPsbtQrEncoder
+        from seedsigner.models.encode_qr import Base64PsbtQrEncoder, UrPsbtQrEncoder
 
-        qr_encoder = UrPsbtQrEncoder(
-            psbt=self.controller.psbt,
-            qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
-        )
+        if (
+            self.controller.psbt_parser
+            and self.controller.psbt_parser.policy
+            and self.controller.psbt_parser.policy.get("fidelity_bond")
+        ):
+            qr_encoder = Base64PsbtQrEncoder(psbt=self.controller.psbt)
+            if not qr_encoder.fits_in_qr:
+                qr_encoder = UrPsbtQrEncoder(
+                    psbt=self.controller.psbt,
+                    qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+                )
+        else:
+            qr_encoder = UrPsbtQrEncoder(
+                psbt=self.controller.psbt,
+                qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+            )
         self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
 
         # We're done with this PSBT. Route back to MainMenuView which always

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -135,6 +135,15 @@ class ScanView(View):
                 address = self.decoder.get_address()
                 (script_type, network) = self.decoder.get_address_type()
 
+                # Testnet and Signet share address encoding. Preserve the active
+                # Signet context when the scanned address cannot distinguish them.
+                if (
+                    network == SettingsConstants.TESTNET
+                    and self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+                    == SettingsConstants.SIGNET
+                ):
+                    network = SettingsConstants.SIGNET
+
                 return Destination(
                     AddressVerificationStartView,
                     skip_current_view=True,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -643,7 +643,7 @@ class SeedFidelityBondWarningView(View):
             DireWarningScreen,
             title=_("Fidelity Bond"),
             status_headline=_("Funds will be locked"),
-            text=_("Funds cannot be spent before the selected month. Past dates are already spendable. Use one deposit and verify the address before funding."),
+            text=_("Funds stay locked until the selected month. Verify the address, then send one deposit."),
             button_data=[self.CONTINUE],
         )
         if selected_menu_num == RET_CODE__BACK_BUTTON:
@@ -734,7 +734,11 @@ class SeedFidelityBondAddressView(View):
             address=self.address,
         )
         if selected_menu_num == RET_CODE__BACK_BUTTON:
-            return Destination(BackStackView)
+            return Destination(
+                SeedOptionsView,
+                view_args=dict(seed=self.seed),
+                clear_history=True,
+            )
         if selected_menu_num == 0:
             return Destination(SeedFidelityBondAddressQRView, view_args=dict(address=self.address))
         return Destination(

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -643,7 +643,11 @@ class SeedFidelityBondWarningView(View):
             DireWarningScreen,
             title=_("Fidelity Bond"),
             status_headline=_("Funds will be locked"),
-            text=_("Funds stay locked until the selected month. Verify the address, then send one deposit."),
+            text=_(
+                "Register with JoinMarket NG, complete certificate setup, perform an "
+                "unfunded signing/redemption test, only then fund JoinMarket's "
+                "independently reconstructed address."
+            ),
             button_data=[self.CONTINUE],
         )
         if selected_menu_num == RET_CODE__BACK_BUTTON:
@@ -657,18 +661,32 @@ class SeedFidelityBondYearView(View):
         self.seed = seed
 
     def run(self):
-        from datetime import datetime, timezone
         from seedsigner.helpers import fidelity_bonds
 
-        years = list(range(fidelity_bonds.MIN_YEAR, fidelity_bonds.MAX_YEAR + 1))
-        button_data = [ButtonOptionWithoutTranslation(str(year), return_data=year) for year in years]
-        current_year = datetime.now(timezone.utc).year
-        selected_button = min(max(current_year, fidelity_bonds.MIN_YEAR), fidelity_bonds.MAX_YEAR) - fidelity_bonds.MIN_YEAR
+        dates = fidelity_bonds.future_year_months()
+        if not dates:
+            return Destination(
+                ErrorView,
+                view_args=dict(
+                    title=_("No Future Locktimes"),
+                    text=_("BIP 46 locktimes are only available through 2099."),
+                    button_text=_("Back to Seed Options"),
+                    next_destination=Destination(
+                        SeedOptionsView,
+                        view_args=dict(seed=self.seed),
+                        clear_history=True,
+                    ),
+                ),
+            )
+        years = list(dict.fromkeys(year for year, _ in dates))
+        button_data = [
+            ButtonOptionWithoutTranslation(str(year), return_data=year) for year in years
+        ]
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title=_("Bond Year"),
             button_data=button_data,
-            selected_button=selected_button,
+            selected_button=0,
         )
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
@@ -690,7 +708,18 @@ class SeedFidelityBondMonthView(View):
         self.year = year
 
     def run(self):
-        button_data = [ButtonOption(month, return_data=index + 1) for index, month in enumerate(self.MONTHS)]
+        from seedsigner.helpers import fidelity_bonds
+
+        months = [
+            month
+            for year, month in fidelity_bonds.future_year_months()
+            if year == self.year
+        ]
+        if not months:
+            return Destination(BackStackView)
+        button_data = [
+            ButtonOption(self.MONTHS[month - 1], return_data=month) for month in months
+        ]
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title=_("Bond Month"),
@@ -742,7 +771,7 @@ class SeedFidelityBondAddressView(View):
         if selected_menu_num == 0:
             return Destination(SeedFidelityBondAddressQRView, view_args=dict(address=self.address))
         return Destination(
-            SeedFidelityBondRegistrationWarningView,
+            SeedFidelityBondRegistrationQRView,
             view_args=dict(
                 seed=self.seed,
                 index=self.index,
@@ -760,33 +789,6 @@ class SeedFidelityBondAddressQRView(View):
         from seedsigner.gui.screens.screen import QRDisplayScreen
 
         self.run_screen(QRDisplayScreen, qr_encoder=GenericStaticQrEncoder(data=self.address))
-        return Destination(BackStackView)
-
-
-class SeedFidelityBondRegistrationWarningView(View):
-    def __init__(self, seed: Seed, index: int, network: str):
-        super().__init__()
-        self.seed = seed
-        self.index = index
-        self.network = network
-
-    def run(self):
-        destination = Destination(
-            SeedFidelityBondRegistrationQRView,
-            view_args=dict(seed=self.seed, index=self.index, network=self.network),
-            skip_current_view=True,
-        )
-        if self.settings.get_value(SettingsConstants.SETTING__PRIVACY_WARNINGS) == SettingsConstants.OPTION__DISABLED:
-            return destination
-
-        selected_menu_num = self.run_screen(
-            WarningScreen,
-            title=_("Privacy Leak!"),
-            status_headline=None,
-            text=_("This branch xpub reveals every BIP-46 bond from this dedicated seed."),
-        )
-        if selected_menu_num == 0:
-            return destination
         return Destination(BackStackView)
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -710,6 +710,7 @@ class SeedFidelityBondMonthView(View):
 
 class SeedFidelityBondAddressView(View):
     SHOW_QR = ButtonOption("Show QR")
+    EXPORT_REGISTRATION = ButtonOption("Export registration QR")
 
     def __init__(self, seed: Seed, year: int, month: int):
         from seedsigner.helpers import fidelity_bonds
@@ -726,7 +727,7 @@ class SeedFidelityBondAddressView(View):
     def run(self):
         selected_menu_num = self.run_screen(
             seed_screens.SeedFidelityBondAddressScreen,
-            button_data=[self.SHOW_QR],
+            button_data=[self.SHOW_QR, self.EXPORT_REGISTRATION],
             year=self.year,
             month=self.month,
             derivation_path=self.derivation_path,
@@ -734,7 +735,16 @@ class SeedFidelityBondAddressView(View):
         )
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        return Destination(SeedFidelityBondAddressQRView, view_args=dict(address=self.address))
+        if selected_menu_num == 0:
+            return Destination(SeedFidelityBondAddressQRView, view_args=dict(address=self.address))
+        return Destination(
+            SeedFidelityBondRegistrationWarningView,
+            view_args=dict(
+                seed=self.seed,
+                index=self.index,
+                network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
+            ),
+        )
 
 
 class SeedFidelityBondAddressQRView(View):
@@ -746,6 +756,47 @@ class SeedFidelityBondAddressQRView(View):
         from seedsigner.gui.screens.screen import QRDisplayScreen
 
         self.run_screen(QRDisplayScreen, qr_encoder=GenericStaticQrEncoder(data=self.address))
+        return Destination(BackStackView)
+
+
+class SeedFidelityBondRegistrationWarningView(View):
+    def __init__(self, seed: Seed, index: int, network: str):
+        super().__init__()
+        self.seed = seed
+        self.index = index
+        self.network = network
+
+    def run(self):
+        destination = Destination(
+            SeedFidelityBondRegistrationQRView,
+            view_args=dict(seed=self.seed, index=self.index, network=self.network),
+            skip_current_view=True,
+        )
+        if self.settings.get_value(SettingsConstants.SETTING__PRIVACY_WARNINGS) == SettingsConstants.OPTION__DISABLED:
+            return destination
+
+        selected_menu_num = self.run_screen(
+            WarningScreen,
+            title=_("Privacy Leak!"),
+            status_headline=None,
+            text=_("This branch xpub reveals every BIP-46 bond from this dedicated seed."),
+        )
+        if selected_menu_num == 0:
+            return destination
+        return Destination(BackStackView)
+
+
+class SeedFidelityBondRegistrationQRView(View):
+    def __init__(self, seed: Seed, index: int, network: str):
+        from seedsigner.helpers import fidelity_bonds
+
+        super().__init__()
+        self.payload = fidelity_bonds.registration_payload(seed.seed_bytes, index, network)
+
+    def run(self):
+        from seedsigner.gui.screens.screen import QRDisplayScreen
+
+        self.run_screen(QRDisplayScreen, qr_encoder=GenericStaticQrEncoder(data=self.payload))
         return Destination(BackStackView)
 
 
@@ -2341,8 +2392,12 @@ class SeedSignMessageConfirmAddressView(View):
             raise Exception(_("Signing messages for custom derivation paths not supported"))
 
         if addr_format["network"] != SettingsConstants.MAINNET:
-            # We're in either Testnet or Regtest or...?
-            if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in [SettingsConstants.TESTNET, SettingsConstants.REGTEST]:
+            # A coin-type-1 path can be Testnet, Signet, or Regtest.
+            if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in [
+                SettingsConstants.TESTNET,
+                SettingsConstants.SIGNET,
+                SettingsConstants.REGTEST,
+            ]:
                 addr_format["network"] = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             else:
                 from seedsigner.views.view import NetworkMismatchErrorView
@@ -2396,7 +2451,14 @@ class SeedSignMessageSignedMessageQRView(View):
         derivation_path = data["derivation_path"]
         message: str = data["message"]
 
-        self.signed_message = embit_utils.sign_message(seed_bytes=self.seed.seed_bytes, derivation=derivation_path, msg=message.encode())
+        self.signed_message = embit_utils.sign_message(
+            seed_bytes=self.seed.seed_bytes,
+            derivation=derivation_path,
+            msg=message.encode(),
+            embit_network=SettingsConstants.map_network_to_embit(
+                self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            ),
+        )
 
 
     def run(self):

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -17,7 +17,7 @@ from seedsigner.models.seed import Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
-from seedsigner.views.view import NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView
+from seedsigner.views.view import ErrorView, NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView
 
 logger = logging.getLogger(__name__)
 
@@ -530,6 +530,7 @@ class SeedOptionsView(View):
     EXPORT_XPUB = ButtonOption("Export xpub")
     EXPLORER = ButtonOption("Address explorer")
     SIGN_MESSAGE = ButtonOption("Sign message")
+    FIDELITY_BOND = ButtonOption("Fidelity bond")
     BACKUP = ButtonOption("Backup seed", right_icon_name=SeedSignerIconConstants.CHEVRON_RIGHT)
     BIP85_CHILD_SEED = ButtonOption("BIP-85 child seed")
     DISCARD = ButtonOption("Discard seed", button_label_color="red")
@@ -576,6 +577,7 @@ class SeedOptionsView(View):
         button_data.append(self.EXPORT_XPUB)
 
         button_data.append(self.EXPLORER)
+        button_data.append(self.FIDELITY_BOND)
         button_data.append(self.BACKUP)
 
         if self.settings.get_value(SettingsConstants.SETTING__MESSAGE_SIGNING) == SettingsConstants.OPTION__ENABLED:
@@ -608,6 +610,9 @@ class SeedOptionsView(View):
             self.controller.resume_main_flow = Controller.FLOW__ADDRESS_EXPLORER
             return Destination(SeedExportXpubScriptTypeView, view_args=dict(seed=self.seed, sig_type=SettingsConstants.SINGLE_SIG))
 
+        elif button_data[selected_menu_num] == self.FIDELITY_BOND:
+            return Destination(SeedFidelityBondWarningView, view_args=dict(seed=self.seed))
+
         elif button_data[selected_menu_num] == self.SIGN_MESSAGE:
             from seedsigner.views.scan_views import ScanView
             self.controller.sign_message_data = dict(seed=self.seed)
@@ -623,6 +628,125 @@ class SeedOptionsView(View):
         elif button_data[selected_menu_num] == self.DISCARD:
             return Destination(SeedDiscardView, view_args=dict(seed=self.seed))
 
+
+
+
+class SeedFidelityBondWarningView(View):
+    CONTINUE = ButtonOption("Choose locktime")
+
+    def __init__(self, seed: Seed):
+        super().__init__()
+        self.seed = seed
+
+    def run(self):
+        selected_menu_num = self.run_screen(
+            DireWarningScreen,
+            title=_("Fidelity Bond"),
+            status_headline=_("Funds will be locked"),
+            text=_("Funds cannot be spent before the selected month. Past dates are already spendable. Use one deposit and verify the address before funding."),
+            button_data=[self.CONTINUE],
+        )
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        return Destination(SeedFidelityBondYearView, view_args=dict(seed=self.seed))
+
+
+class SeedFidelityBondYearView(View):
+    def __init__(self, seed: Seed):
+        super().__init__()
+        self.seed = seed
+
+    def run(self):
+        from datetime import datetime, timezone
+        from seedsigner.helpers import fidelity_bonds
+
+        years = list(range(fidelity_bonds.MIN_YEAR, fidelity_bonds.MAX_YEAR + 1))
+        button_data = [ButtonOptionWithoutTranslation(str(year), return_data=year) for year in years]
+        current_year = datetime.now(timezone.utc).year
+        selected_button = min(max(current_year, fidelity_bonds.MIN_YEAR), fidelity_bonds.MAX_YEAR) - fidelity_bonds.MIN_YEAR
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Bond Year"),
+            button_data=button_data,
+            selected_button=selected_button,
+        )
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        return Destination(
+            SeedFidelityBondMonthView,
+            view_args=dict(seed=self.seed, year=button_data[selected_menu_num].return_data),
+        )
+
+
+class SeedFidelityBondMonthView(View):
+    MONTHS = (
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    )
+
+    def __init__(self, seed: Seed, year: int):
+        super().__init__()
+        self.seed = seed
+        self.year = year
+
+    def run(self):
+        button_data = [ButtonOption(month, return_data=index + 1) for index, month in enumerate(self.MONTHS)]
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Bond Month"),
+            button_data=button_data,
+        )
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        return Destination(
+            SeedFidelityBondAddressView,
+            view_args=dict(
+                seed=self.seed,
+                year=self.year,
+                month=button_data[selected_menu_num].return_data,
+            ),
+        )
+
+
+class SeedFidelityBondAddressView(View):
+    SHOW_QR = ButtonOption("Show QR")
+
+    def __init__(self, seed: Seed, year: int, month: int):
+        from seedsigner.helpers import fidelity_bonds
+
+        super().__init__()
+        self.seed = seed
+        self.year = year
+        self.month = month
+        self.index = fidelity_bonds.year_month_to_index(year, month)
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        self.derivation_path = fidelity_bonds.derivation_path(self.index, network)
+        self.address = fidelity_bonds.derive_address(seed.seed_bytes, self.index, network)
+
+    def run(self):
+        selected_menu_num = self.run_screen(
+            seed_screens.SeedFidelityBondAddressScreen,
+            button_data=[self.SHOW_QR],
+            year=self.year,
+            month=self.month,
+            derivation_path=self.derivation_path,
+            address=self.address,
+        )
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        return Destination(SeedFidelityBondAddressQRView, view_args=dict(address=self.address))
+
+
+class SeedFidelityBondAddressQRView(View):
+    def __init__(self, address: str):
+        super().__init__()
+        self.address = address
+
+    def run(self):
+        from seedsigner.gui.screens.screen import QRDisplayScreen
+
+        self.run_screen(QRDisplayScreen, qr_encoder=GenericStaticQrEncoder(data=self.address))
+        return Destination(BackStackView)
 
 
 class SeedBackupView(View):
@@ -2130,6 +2254,20 @@ class SeedSignMessageStartView(View):
             self.controller.resume_main_flow = None
             return
 
+        if addr_format["is_fidelity_bond"]:
+            from seedsigner.helpers import fidelity_bonds
+            if not fidelity_bonds.is_valid_certificate(message):
+                self.set_redirect(Destination(
+                    ErrorView,
+                    view_args=dict(
+                        status_headline=_("Invalid certificate"),
+                        text=_("The fidelity bond signing request is not a canonical BIP 46 certificate."),
+                        button_text=_("Back to Main Menu"),
+                    ),
+                ))
+                self.controller.resume_main_flow = None
+                return
+
         # Note: addr_format["network"] can be MAINNET or [TESTNET, REGTEST]
         if self.settings.get_value(SettingsConstants.SETTING__NETWORK) not in addr_format["network"]:
             from seedsigner.views.view import NetworkMismatchErrorView
@@ -2216,9 +2354,17 @@ class SeedSignMessageConfirmAddressView(View):
                 self.controller.sign_message_data = None
                 return
 
-        xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=addr_format["network"])
-        embit_network = embit_utils.get_embit_network_name(addr_format["network"])
-        self.address = embit_utils.get_single_sig_address(xpub=xpub, script_type=addr_format["script_type"], index=addr_format["index"], is_change=addr_format["is_change"], embit_network=embit_network)
+        if addr_format["is_fidelity_bond"]:
+            from seedsigner.helpers import fidelity_bonds
+            self.address = fidelity_bonds.derive_address(
+                seed.seed_bytes,
+                addr_format["index"],
+                addr_format["network"],
+            )
+        else:
+            xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=addr_format["network"])
+            embit_network = embit_utils.get_embit_network_name(addr_format["network"])
+            self.address = embit_utils.get_single_sig_address(xpub=xpub, script_type=addr_format["script_type"], index=addr_format["index"], is_change=addr_format["is_change"], embit_network=embit_network)
 
 
     def run(self):

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,53 @@
+from base import BaseTest
+
+from seedsigner.gui.components import (
+    Fonts,
+    GUIConstants,
+    reflow_text_for_width,
+    reflow_text_into_pages,
+)
+
+
+FIDELITY_BOND_CERTIFICATE = (
+    "fidelity-bond-cert|"
+    "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375"
+)
+
+
+class TestTextReflow(BaseTest):
+    def test_preserves_normal_word_wrapping(self):
+        lines = reflow_text_for_width("one two three", width=75)
+
+        assert [line["text"] for line in lines] == ["one two", "three"]
+
+    def test_hard_wraps_long_unbroken_message_without_losing_content(self):
+        width = 224
+        lines = reflow_text_for_width(FIDELITY_BOND_CERTIFICATE, width=width)
+
+        assert len(lines) > 1
+        assert all(line["text_width"] < width for line in lines)
+        assert "".join(line["text"] for line in lines) == FIDELITY_BOND_CERTIFICATE
+
+    def test_exact_width_token_uses_existing_strict_width_limit(self):
+        token = "fidelity"
+        font = Fonts.get_font(
+            font_name=GUIConstants.get_body_font_name(),
+            size=GUIConstants.get_body_font_size(),
+        )
+        left, top, right, bottom = font.getbbox(token, anchor="ls")
+
+        lines = reflow_text_for_width(token, width=right - left)
+
+        assert len(lines) == 2
+        assert "".join(line["text"] for line in lines) == token
+
+    def test_pages_preserve_long_unbroken_message(self):
+        pages = reflow_text_into_pages(
+            FIDELITY_BOND_CERTIFICATE,
+            width=224,
+            height=134,
+        )
+
+        assert len(pages) == 1
+        assert pages[0].count("\n") == 3
+        assert "".join(pages).replace("\n", "") == FIDELITY_BOND_CERTIFICATE

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -386,6 +386,12 @@ def test_parse_derivation_path():
     assert result["script_type"] == SC.NATIVE_SEGWIT
     assert result["network"] == SC.MAINNET
 
+    bond_result = embit_utils.parse_derivation_path("m/84'/0'/0'/2/240")
+    assert bond_result["clean_match"] is True
+    assert bond_result["is_fidelity_bond"] is True
+    assert bond_result["index"] == 240
+    assert bond_result["network"] == SC.MAINNET
+
     # Now exhaustively test supported permutations
     vectors_args = {
         (SC.MAINNET, SC.NATIVE_SEGWIT, False): "m/84'/0'/0'/0/5",

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -17,28 +17,34 @@ def test_get_standard_derivation_path():
 
         (SC.MAINNET, SC.SINGLE_SIG, SC.NATIVE_SEGWIT): "m/84'/0'/0'",
         (SC.TESTNET, SC.SINGLE_SIG, SC.NATIVE_SEGWIT): "m/84'/1'/0'",
+        (SC.SIGNET, SC.SINGLE_SIG, SC.NATIVE_SEGWIT): "m/84'/1'/0'",
         (SC.REGTEST, SC.SINGLE_SIG, SC.NATIVE_SEGWIT): "m/84'/1'/0'",
 
         (SC.MAINNET, SC.SINGLE_SIG, SC.NESTED_SEGWIT): "m/49'/0'/0'",
         (SC.TESTNET, SC.SINGLE_SIG, SC.NESTED_SEGWIT): "m/49'/1'/0'",
+        (SC.SIGNET, SC.SINGLE_SIG, SC.NESTED_SEGWIT): "m/49'/1'/0'",
         (SC.REGTEST, SC.SINGLE_SIG, SC.NESTED_SEGWIT): "m/49'/1'/0'",
 
         (SC.MAINNET, SC.SINGLE_SIG, SC.TAPROOT): "m/86'/0'/0'",
         (SC.TESTNET, SC.SINGLE_SIG, SC.TAPROOT): "m/86'/1'/0'",
+        (SC.SIGNET, SC.SINGLE_SIG, SC.TAPROOT): "m/86'/1'/0'",
         (SC.REGTEST, SC.SINGLE_SIG, SC.TAPROOT): "m/86'/1'/0'",
 
         (SC.MAINNET, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/0'/0'",
         (SC.TESTNET, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/1'/0'",
+        (SC.SIGNET, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/1'/0'",
         (SC.REGTEST, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/1'/0'",
 
 
         # multi sig
         (SC.MAINNET, SC.MULTISIG, SC.NATIVE_SEGWIT): "m/48'/0'/0'/2'",
         (SC.TESTNET, SC.MULTISIG, SC.NATIVE_SEGWIT): "m/48'/1'/0'/2'",
+        (SC.SIGNET, SC.MULTISIG, SC.NATIVE_SEGWIT): "m/48'/1'/0'/2'",
         (SC.REGTEST, SC.MULTISIG, SC.NATIVE_SEGWIT): "m/48'/1'/0'/2'",
 
         (SC.MAINNET, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/0'/0'/1'",
         (SC.TESTNET, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
+        (SC.SIGNET, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
         (SC.REGTEST, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
 
         (SC.MAINNET, SC.MULTISIG, SC.TAPROOT): Exception,
@@ -391,6 +397,9 @@ def test_parse_derivation_path():
     assert bond_result["is_fidelity_bond"] is True
     assert bond_result["index"] == 240
     assert bond_result["network"] == SC.MAINNET
+
+    signet_result = embit_utils.parse_derivation_path("m/84'/1'/0'/0/0")
+    assert SC.SIGNET in signet_result["network"]
 
     # Now exhaustively test supported permutations
     vectors_args = {

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -1,4 +1,4 @@
-from seedsigner.models.encode_qr import CompactSeedQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrPsbtQrEncoder, UrXpubQrEncoder
+from seedsigner.models.encode_qr import Base64PsbtQrEncoder, CompactSeedQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrPsbtQrEncoder, UrXpubQrEncoder
 from embit import psbt
 from binascii import a2b_base64
 
@@ -12,6 +12,10 @@ def test_ur_psbt_qr_encode():
 
     tx = psbt.PSBT.parse(a2b_base64(base64_psbt))
 
+    static_encoder = Base64PsbtQrEncoder(psbt=tx)
+    assert static_encoder.next_part() == base64_psbt
+    assert not static_encoder.fits_in_qr
+
     e = UrPsbtQrEncoder(psbt=tx, qr_density=SettingsConstants.DENSITY__MEDIUM)
 
     cnt = 0
@@ -19,6 +23,15 @@ def test_ur_psbt_qr_encode():
         fragment = e.next_part()
         e.part_to_image(fragment, 240, 240)
         cnt += 1
+
+
+def test_base64_fidelity_bond_psbt_qr_fits():
+    base64_psbt = "cHNidP8BAFICAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD+////AbiCAQAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIA4QteAAEBK6CGAQAAAAAAIgAgve6VFTWfyd+RIxhSO0zSLxwLVBAjLclDvnP59PB+Oa0BAwQBAAAAAQUqBADhC16xdSECobCfkwc8Y/IFCGRAiYFBwMPG0k9poY22CCJLzxQ/oBGsIgYCobCfkwc8Y/IFCGRAiYFBwMPG0k9poY22CCJLzxQ/oBEYc8XaClQAAIAAAACAAAAAgAIAAAAAAAAAAAA="
+    tx = psbt.PSBT.parse(a2b_base64(base64_psbt))
+
+    static_encoder = Base64PsbtQrEncoder(psbt=tx)
+    assert static_encoder.next_part() == base64_psbt
+    assert static_encoder.fits_in_qr
 
 
 

--- a/tests/test_fidelity_bond_psbt.py
+++ b/tests/test_fidelity_bond_psbt.py
@@ -1,0 +1,132 @@
+import pytest
+from embit import bip32, ec, psbt, script, transaction
+from embit.networks import NETWORKS
+from embit.transaction import SIGHASH
+
+from seedsigner.helpers import fidelity_bonds
+from seedsigner.models.psbt_parser import PSBTParser
+from seedsigner.models.seed import Seed
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+def make_bond_psbt(index=0):
+    seed = Seed(MNEMONIC.split())
+    root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
+    path = bip32.parse_path(fidelity_bonds.derivation_path(index))
+    pubkey = root.derive(path).to_public().key
+    witness_script = fidelity_bonds.witness_script(
+        fidelity_bonds.index_to_locktime(index),
+        pubkey,
+    )
+    destination = script.p2wpkh(root.derive("m/84'/0'/0'/0/0").key)
+    tx = transaction.Transaction(
+        vin=[transaction.TransactionInput(b"\x11" * 32, 0, sequence=0xFFFFFFFE)],
+        vout=[transaction.TransactionOutput(99_000, destination)],
+        locktime=fidelity_bonds.index_to_locktime(index),
+    )
+    bond_psbt = psbt.PSBT(tx)
+    bond_input = bond_psbt.inputs[0]
+    bond_input.witness_utxo = transaction.TransactionOutput(
+        100_000, script.p2wsh(witness_script)
+    )
+    bond_input.witness_script = witness_script
+    bond_input.sighash_type = SIGHASH.ALL
+    bond_input.bip32_derivations[pubkey] = psbt.DerivationPath(
+        root.my_fingerprint, path
+    )
+    return seed, bond_psbt, pubkey
+
+
+def test_parse_sign_and_trim_fidelity_bond_psbt():
+    seed, bond_psbt, pubkey = make_bond_psbt()
+    parser = PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+    assert parser.policy["fidelity_bond"] is True
+    assert parser.policy["locktime"] == 1577836800
+    assert parser.input_amount == 100_000
+    assert parser.spend_amount == 99_000
+    assert parser.fee_amount == 1_000
+    assert PSBTParser.has_matching_input_fingerprint(bond_psbt, seed)
+
+    assert bond_psbt.sign_with(parser.root) == 1
+    signature = bond_psbt.inputs[0].partial_sigs[pubkey]
+    sighash = bond_psbt.sighash(0, sighash=SIGHASH.ALL)
+    assert signature[-1] == SIGHASH.ALL
+    assert pubkey.verify(ec.Signature.parse(signature[:-1]), sighash)
+
+    trimmed = PSBTParser.trim(bond_psbt)
+    serialized = psbt.PSBT.parse(trimmed.serialize())
+    trimmed_input = serialized.inputs[0]
+    assert trimmed_input.witness_utxo == bond_psbt.inputs[0].witness_utxo
+    assert trimmed_input.witness_script == bond_psbt.inputs[0].witness_script
+    assert trimmed_input.sighash_type == SIGHASH.ALL
+    assert trimmed_input.partial_sigs[pubkey] == signature
+
+
+def test_rejects_missing_witness_utxo():
+    seed, bond_psbt, _ = make_bond_psbt()
+    bond_psbt.inputs[0].witness_utxo = None
+    with pytest.raises(ValueError, match="witness UTXO"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_wrong_witness_script_commitment():
+    seed, bond_psbt, _ = make_bond_psbt()
+    bond_psbt.inputs[0].witness_utxo.script_pubkey = script.p2wsh(
+        script.Script(b"wrong")
+    )
+    with pytest.raises(ValueError, match="does not match the UTXO"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_non_all_sighash():
+    seed, bond_psbt, _ = make_bond_psbt()
+    bond_psbt.inputs[0].sighash_type = SIGHASH.NONE
+    with pytest.raises(ValueError, match="SIGHASH_ALL"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_early_transaction_locktime():
+    seed, bond_psbt, _ = make_bond_psbt()
+    bond_psbt.locktime -= 1
+    with pytest.raises(ValueError, match="locktime is too early"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_final_input_sequence():
+    seed, bond_psbt, _ = make_bond_psbt()
+    bond_psbt.inputs[0].sequence = 0xFFFFFFFF
+    with pytest.raises(ValueError, match="sequence is final"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_non_bip46_derivation():
+    seed, bond_psbt, pubkey = make_bond_psbt()
+    derivation = bond_psbt.inputs[0].bip32_derivations.pop(pubkey)
+    derivation.derivation = bip32.parse_path("m/84'/0'/0'/0/0")
+    bond_psbt.inputs[0].bip32_derivations[pubkey] = derivation
+    with pytest.raises(ValueError, match="canonical BIP 46"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_wrong_fingerprint():
+    seed, bond_psbt, pubkey = make_bond_psbt()
+    derivation = bond_psbt.inputs[0].bip32_derivations[pubkey]
+    bond_psbt.inputs[0].bip32_derivations[pubkey] = psbt.DerivationPath(
+        b"\x12\x34\x56\x78",
+        derivation.derivation,
+    )
+    with pytest.raises(ValueError, match="fingerprint does not match"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
+
+
+def test_rejects_multiple_redemption_outputs():
+    seed, bond_psbt, _ = make_bond_psbt()
+    bond_psbt.outputs.append(
+        psbt.OutputScope(vout=transaction.TransactionOutput(0, script.Script(b"\x6a")))
+    )
+    with pytest.raises(ValueError, match="one input and one output"):
+        PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)

--- a/tests/test_fidelity_bond_psbt.py
+++ b/tests/test_fidelity_bond_psbt.py
@@ -12,16 +12,18 @@ from seedsigner.models.settings_definition import SettingsConstants
 MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
 
-def make_bond_psbt(index=0):
+def make_bond_psbt(index=0, network=SettingsConstants.MAINNET):
     seed = Seed(MNEMONIC.split())
-    root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
-    path = bip32.parse_path(fidelity_bonds.derivation_path(index))
+    embit_network = SettingsConstants.map_network_to_embit(network)
+    root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS[embit_network]["xprv"])
+    path = bip32.parse_path(fidelity_bonds.derivation_path(index, network))
     pubkey = root.derive(path).to_public().key
     witness_script = fidelity_bonds.witness_script(
         fidelity_bonds.index_to_locktime(index),
         pubkey,
     )
-    destination = script.p2wpkh(root.derive("m/84'/0'/0'/0/0").key)
+    coin_type = 0 if network == SettingsConstants.MAINNET else 1
+    destination = script.p2wpkh(root.derive(f"m/84'/{coin_type}'/0'/0/0").key)
     tx = transaction.Transaction(
         vin=[transaction.TransactionInput(b"\x11" * 32, 0, sequence=0xFFFFFFFE)],
         vout=[transaction.TransactionOutput(99_000, destination)],
@@ -64,6 +66,14 @@ def test_parse_sign_and_trim_fidelity_bond_psbt():
     assert trimmed_input.witness_script == bond_psbt.inputs[0].witness_script
     assert trimmed_input.sighash_type == SIGHASH.ALL
     assert trimmed_input.partial_sigs[pubkey] == signature
+
+
+def test_parse_signet_fidelity_bond_psbt():
+    seed, bond_psbt, _ = make_bond_psbt(network=SettingsConstants.SIGNET)
+    parser = PSBTParser(bond_psbt, seed, SettingsConstants.SIGNET)
+
+    assert parser.policy["fidelity_bond"] is True
+    assert parser.policy["locktime"] == 1577836800
 
 
 def test_rejects_missing_witness_utxo():

--- a/tests/test_fidelity_bond_psbt.py
+++ b/tests/test_fidelity_bond_psbt.py
@@ -4,7 +4,11 @@ from embit.networks import NETWORKS
 from embit.transaction import SIGHASH
 
 from seedsigner.helpers import fidelity_bonds
-from seedsigner.models.psbt_parser import PSBTParser
+from seedsigner.models.psbt_parser import (
+    PSBTInputOwnershipClaimError,
+    PSBTParser,
+    PSBTSeedCannotSignError,
+)
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
 
@@ -118,7 +122,7 @@ def test_rejects_non_bip46_derivation():
     derivation = bond_psbt.inputs[0].bip32_derivations.pop(pubkey)
     derivation.derivation = bip32.parse_path("m/84'/0'/0'/0/0")
     bond_psbt.inputs[0].bip32_derivations[pubkey] = derivation
-    with pytest.raises(ValueError, match="canonical BIP 46"):
+    with pytest.raises(PSBTInputOwnershipClaimError):
         PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
 
 
@@ -129,7 +133,7 @@ def test_rejects_wrong_fingerprint():
         b"\x12\x34\x56\x78",
         derivation.derivation,
     )
-    with pytest.raises(ValueError, match="fingerprint does not match"):
+    with pytest.raises(PSBTSeedCannotSignError):
         PSBTParser(bond_psbt, seed, SettingsConstants.MAINNET)
 
 

--- a/tests/test_fidelity_bonds.py
+++ b/tests/test_fidelity_bonds.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from embit import bip39
 
@@ -51,6 +53,26 @@ def test_index_and_year_month_conversion():
     assert fidelity_bonds.index_to_year_month(959) == (2099, 12)
     assert fidelity_bonds.year_month_to_index(2040, 1) == 240
     assert fidelity_bonds.year_month_to_index(2099, 12) == 959
+
+
+@pytest.mark.parametrize(
+    "current, expected_first",
+    [
+        (datetime(2026, 1, 1, tzinfo=timezone.utc), (2026, 2)),
+        (datetime(2026, 12, 31, 23, 59, tzinfo=timezone.utc), (2027, 1)),
+    ],
+)
+def test_future_year_months_exclude_current_and_past_months(current, expected_first):
+    months = fidelity_bonds.future_year_months(current)
+
+    assert months[0] == expected_first
+    assert (current.year, current.month) not in months
+    assert (2020, 1) not in months
+    assert months[-1] == (2099, 12)
+
+
+def test_future_year_months_handles_end_of_bip46_range():
+    assert fidelity_bonds.future_year_months(datetime(2100, 1, 1, tzinfo=timezone.utc)) == []
 
 
 @pytest.mark.parametrize("index", [-1, 960, True, "0"])
@@ -170,21 +192,25 @@ def test_signet_derivation_and_registration_payload():
         SEED_BYTES, 240, SettingsConstants.SIGNET
     ) == (
         '{"type":"seedsigner-bip46","version":1,"network":"signet",'
-        '"master_fingerprint":"73c5da0a","origin_path":"m/84\'/1\'/0\'/2",'
-        '"xpub":"tpubDFd87GgwwqSRQWvuBRuqEFnoWjJDHDnDUqu7c8DXoALBU9Kbwuom5U1KrGmYEgiCQoNtSvqdjkysKgrQZVAvU7NcVfPf1j9CRMpD1hwSpwq",'
-        '"locktime_date":"2040-01",'
+        '"master_fingerprint":"73c5da0a","derivation_path":"m/84\'/1\'/0\'/2/240",'
+        '"index":240,"locktime":2208988800,"locktime_date":"2040-01",'
+        '"pubkey":"020bb71ecf99ab2289d16dc0b8b1cb4c51699db38a215bbb212d1a2b30d07b8806",'
         '"address":"tb1qnkuzv3jckcxd9xdnvse36x2m6ylcg4aqgam2gd4tt689k44ft6eq526xlk"}'
     )
 
 
-def test_mainnet_registration_payload_uses_standard_xpub():
+def test_mainnet_registration_payload_uses_leaf_schema():
     payload = fidelity_bonds.registration_payload(
         SEED_BYTES, 240, SettingsConstants.MAINNET
     )
     assert '"network":"mainnet"' in payload
-    assert '"origin_path":"m/84\'/0\'/0\'/2"' in payload
-    assert '"xpub":"xpub' in payload
+    assert '"derivation_path":"m/84\'/0\'/0\'/2/240"' in payload
+    assert '"index":240' in payload
+    assert '"locktime":2208988800' in payload
     assert '"locktime_date":"2040-01"' in payload
+    assert '"pubkey":"03ec8067418537bbb52d5d3e64e2868e67635c33cfeadeb9a46199f89ebfaab226"' in payload
+    assert "origin_path" not in payload
+    assert "xpub" not in payload
 
 
 def test_parse_certificate():

--- a/tests/test_fidelity_bonds.py
+++ b/tests/test_fidelity_bonds.py
@@ -1,0 +1,183 @@
+import pytest
+from embit import bip39
+
+from seedsigner.helpers import fidelity_bonds
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+SEED_BYTES = bip39.mnemonic_to_seed(MNEMONIC)
+
+
+@pytest.mark.parametrize(
+    "index, locktime, expected_script, expected_address",
+    [
+        (
+            0,
+            1577836800,
+            "0400e10b5eb1752102a1b09f93073c63f205086440898141c0c3c6d24f69a18db608224bcf143fa011ac",
+            "bc1qhhhf29f4nlyalyfrrpfrknxj9uwqk4qsyvkujsa7w0ulfur78xkspsqn84",
+        ),
+        (
+            1,
+            1580515200,
+            "0480bf345eb1752102599f6db8b33265a44200fef0be79c927398ed0b46c6a82fa6ddaa5be2714002dac",
+            "bc1qhrufsepej9sg2f8dqnsvvaulvv490u0l5w36xpkds9pjc4fnaxhq7pcm4h",
+        ),
+        (
+            240,
+            2208988800,
+            "05807eaa8300b1752103ec8067418537bbb52d5d3e64e2868e67635c33cfeadeb9a46199f89ebfaab226ac",
+            "bc1qul0q45njptsadnymdtv34at7karyva3v7k2vj8qc7m2702rnvddq0z20u5",
+        ),
+        (
+            959,
+            4099766400,
+            "0580785df400b175210308c5751121b1ae5c973cdc7071312f6fc10ab864262f0cbd8134f056166e50f3ac",
+            "bc1qsqex3czzqzrn0n6rjayvhddygj0rz8df4fj2uwk9dkzdqkt9f7zs5c493u",
+        ),
+    ],
+)
+def test_bip46_vectors(index, locktime, expected_script, expected_address):
+    assert fidelity_bonds.derivation_path(index) == f"m/84'/0'/0'/2/{index}"
+    assert fidelity_bonds.index_to_locktime(index) == locktime
+    witness = fidelity_bonds.derive_witness_script(SEED_BYTES, index)
+    assert witness.data.hex() == expected_script
+    assert fidelity_bonds.derive_address(SEED_BYTES, index) == expected_address
+
+
+def test_index_and_year_month_conversion():
+    assert fidelity_bonds.index_to_year_month(0) == (2020, 1)
+    assert fidelity_bonds.index_to_year_month(959) == (2099, 12)
+    assert fidelity_bonds.year_month_to_index(2040, 1) == 240
+    assert fidelity_bonds.year_month_to_index(2099, 12) == 959
+
+
+@pytest.mark.parametrize("index", [-1, 960, True, "0"])
+def test_invalid_index(index):
+    with pytest.raises(ValueError):
+        fidelity_bonds.index_to_locktime(index)
+
+
+@pytest.mark.parametrize(
+    "year, month", [(2019, 1), (2100, 1), (2020, 0), (2020, 13), (2020, True)]
+)
+def test_invalid_year_month(year, month):
+    with pytest.raises(ValueError):
+        fidelity_bonds.year_month_to_index(year, month)
+
+
+def test_canonical_derivation_path_parsing():
+    parsed = fidelity_bonds.parse_derivation_path(
+        "m/84'/0'/0'/2/240", SettingsConstants.MAINNET
+    )
+    assert parsed == fidelity_bonds.FidelityBondPath(coin_type=0, index=240)
+    assert (
+        fidelity_bonds.parse_derivation_path(
+            "m/84h/1h/0h/2/0", SettingsConstants.TESTNET
+        ).coin_type
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "m/84'/0'/0'/2/00",
+        "m/84'/0'/0'/1/0",
+        "m/84'/0'/0'/2/960",
+        "m/84'/0'/0'/2/-1",
+        "m/84h/0'/0h/2/0",
+        "m/84'/0'/0'/2/0/",
+    ],
+)
+def test_invalid_derivation_paths(path):
+    with pytest.raises(ValueError):
+        fidelity_bonds.parse_derivation_path(path)
+
+
+def test_parse_witness_script():
+    witness = fidelity_bonds.derive_witness_script(SEED_BYTES, 240)
+    parsed = fidelity_bonds.parse_witness_script(witness)
+    assert parsed.locktime == 2208988800
+    assert parsed.index == 240
+    assert (
+        parsed.pubkey.sec().hex()
+        == "03ec8067418537bbb52d5d3e64e2868e67635c33cfeadeb9a46199f89ebfaab226"
+    )
+
+
+@pytest.mark.parametrize(
+    "witness",
+    [
+        bytes.fromhex(
+            "4c0400e10b5eb1752102a1b09f93073c63f205086440898141c0c3c6d24f69a18db608224bcf143fa011ac"
+        ),
+        bytes.fromhex(
+            "0500e10b5e00b1752102a1b09f93073c63f205086440898141c0c3c6d24f69a18db608224bcf143fa011ac"
+        ),
+        bytes.fromhex(
+            "0400e10b5eb1754102a1b09f93073c63f205086440898141c0c3c6d24f69a18db608224bcf143fa011ac"
+        ),
+        bytes.fromhex(
+            "0400e10b5eb1752102a1b09f93073c63f205086440898141c0c3c6d24f69a18db608224bcf143fa011ad"
+        ),
+        bytes.fromhex(
+            "0401000000b1752102a1b09f93073c63f205086440898141c0c3c6d24f69a18db608224bcf143fa011ac"
+        ),
+    ],
+)
+def test_rejects_noncanonical_witness_scripts(witness):
+    with pytest.raises(ValueError):
+        fidelity_bonds.parse_witness_script(witness)
+
+
+def test_testnet_and_regtest_derivation():
+    assert (
+        fidelity_bonds.derivation_path(0, SettingsConstants.TESTNET)
+        == "m/84'/1'/0'/2/0"
+    )
+    assert (
+        fidelity_bonds.derive_pubkey(SEED_BYTES, 0, SettingsConstants.TESTNET)
+        .sec()
+        .hex()
+        == "02d45176146a71dbe2623747898759c2dd1eaf5a6c6a7d9139ffed0a20e54bff22"
+    )
+    assert (
+        fidelity_bonds.derive_address(SEED_BYTES, 0, SettingsConstants.TESTNET)
+        == "tb1q7war3lusq3ez633rzzfkp75unfcgrqqcu80sgp0ellhrdvkzxh5srftzav"
+    )
+    assert (
+        fidelity_bonds.derive_address(SEED_BYTES, 0, SettingsConstants.REGTEST)
+        == "bcrt1q7war3lusq3ez633rzzfkp75unfcgrqqcu80sgp0ellhrdvkzxh5swspygk"
+    )
+
+
+def test_parse_certificate():
+    certificate = "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375"
+    parsed = fidelity_bonds.parse_certificate(certificate)
+    assert (
+        parsed.pubkey_hex
+        == "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c"
+    )
+    assert parsed.pubkey.sec().hex() == parsed.pubkey_hex
+    assert parsed.expiry == 375
+    assert fidelity_bonds.is_valid_certificate(certificate)
+
+
+@pytest.mark.parametrize(
+    "certificate",
+    [
+        "fidelity-bond-cert|0330D54FD0DD420A6E5F8D3624F5F3482CAE350F79D5F0753BF5BEEF9C2D91AF3C|375",
+        "fidelity-bond-cert|0430d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375",
+        "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|0375",
+        "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|65536",
+        "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|-1",
+        "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375|extra",
+        "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375\u00e9",
+    ],
+)
+def test_rejects_invalid_certificates(certificate):
+    with pytest.raises(ValueError):
+        fidelity_bonds.parse_certificate(certificate)
+    assert not fidelity_bonds.is_valid_certificate(certificate)

--- a/tests/test_fidelity_bonds.py
+++ b/tests/test_fidelity_bonds.py
@@ -153,6 +153,40 @@ def test_testnet_and_regtest_derivation():
     )
 
 
+def test_signet_derivation_and_registration_payload():
+    assert (
+        fidelity_bonds.derivation_path(0, SettingsConstants.SIGNET)
+        == "m/84'/1'/0'/2/0"
+    )
+    assert (
+        fidelity_bonds.derive_address(SEED_BYTES, 0, SettingsConstants.SIGNET)
+        == "tb1q7war3lusq3ez633rzzfkp75unfcgrqqcu80sgp0ellhrdvkzxh5srftzav"
+    )
+    assert fidelity_bonds.parse_derivation_path(
+        "m/84'/1'/0'/2/0", SettingsConstants.SIGNET
+    ) == fidelity_bonds.FidelityBondPath(coin_type=1, index=0)
+
+    assert fidelity_bonds.registration_payload(
+        SEED_BYTES, 240, SettingsConstants.SIGNET
+    ) == (
+        '{"type":"seedsigner-bip46","version":1,"network":"signet",'
+        '"master_fingerprint":"73c5da0a","origin_path":"m/84\'/1\'/0\'/2",'
+        '"xpub":"tpubDFd87GgwwqSRQWvuBRuqEFnoWjJDHDnDUqu7c8DXoALBU9Kbwuom5U1KrGmYEgiCQoNtSvqdjkysKgrQZVAvU7NcVfPf1j9CRMpD1hwSpwq",'
+        '"locktime_date":"2040-01",'
+        '"address":"tb1qnkuzv3jckcxd9xdnvse36x2m6ylcg4aqgam2gd4tt689k44ft6eq526xlk"}'
+    )
+
+
+def test_mainnet_registration_payload_uses_standard_xpub():
+    payload = fidelity_bonds.registration_payload(
+        SEED_BYTES, 240, SettingsConstants.MAINNET
+    )
+    assert '"network":"mainnet"' in payload
+    assert '"origin_path":"m/84\'/0\'/0\'/2"' in payload
+    assert '"xpub":"xpub' in payload
+    assert '"locktime_date":"2040-01"' in payload
+
+
 def test_parse_certificate():
     certificate = "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375"
     parsed = fidelity_bonds.parse_certificate(certificate)

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -15,6 +15,36 @@ from seedsigner.models.settings import SettingsConstants
 
 class TestPSBTFlows(FlowTest):
 
+    def test_spend_expired_fidelity_bond(self):
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data("cHNidP8BAFICAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD+////AbiCAQAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIA4QteAAEBK6CGAQAAAAAAIgAgve6VFTWfyd+RIxhSO0zSLxwLVBAjLclDvnP59PB+Oa0BAwQBAAAAAQUqBADhC16xdSECobCfkwc8Y/IFCGRAiYFBwMPG0k9poY22CCJLzxQ/oBGsIgYCobCfkwc8Y/IFCGRAiYFBwMPG0k9poY22CCJLzxQ/oBEYc8XaClQAAIAAAACAAAAAgAIAAAAAAAAAAAA=")
+
+        def load_seed_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data("0000" * 11 + "0003")
+
+        def verify_signed_bond_psbt(view):
+            bond_input = self.controller.psbt.inputs[0]
+            assert len(bond_input.partial_sigs) == 1
+            assert bond_input.witness_utxo is not None
+            assert bond_input.witness_script is not None
+            assert bond_input.sighash_type == 1
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanSeedQRView, before_run=load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+            FlowStep(psbt_views.PSBTOverviewView),
+            FlowStep(psbt_views.PSBTNoChangeWarningView, screen_return_value=0),
+            FlowStep(psbt_views.PSBTMathView),
+            FlowStep(psbt_views.PSBTAddressDetailsView, screen_return_value=0),
+            FlowStep(psbt_views.PSBTFinalizeView, button_data_selection=psbt_views.PSBTFinalizeView.APPROVE_PSBT),
+            FlowStep(psbt_views.PSBTSignedQRDisplayView, before_run=verify_signed_bond_psbt, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
+
     def test_scan_psbt_first_then_correct_seedqr_flow(self):
         """
             Selecting "Scan" from the MainMenuView and scanning a PSBT should enter the PSBTSelectSeedView flow

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -1,4 +1,5 @@
 from binascii import a2b_base64
+from unittest.mock import Mock, patch
 
 from embit.psbt import PSBT
 
@@ -14,6 +15,40 @@ from seedsigner.models.settings import SettingsConstants
 
 
 class TestPSBTFlows(FlowTest):
+
+    def test_signed_fidelity_bond_uses_static_base64_qr(self):
+        self.controller.psbt = Mock()
+        self.controller.psbt_parser = Mock(policy={"fidelity_bond": True})
+        static_encoder = Mock(fits_in_qr=True)
+        view = psbt_views.PSBTSignedQRDisplayView()
+
+        with patch(
+            "seedsigner.models.encode_qr.Base64PsbtQrEncoder",
+            return_value=static_encoder,
+        ) as mock_static_encoder:
+            with patch.object(view, "run_screen", return_value=0) as mock_run_screen:
+                view.run()
+
+        mock_static_encoder.assert_called_once_with(psbt=self.controller.psbt)
+        assert mock_run_screen.call_args.kwargs["qr_encoder"] is static_encoder
+
+    def test_signed_ordinary_psbt_uses_ur_qr(self):
+        self.controller.psbt = Mock()
+        self.controller.psbt_parser = Mock(policy={"type": "p2wpkh"})
+        ur_encoder = Mock()
+        view = psbt_views.PSBTSignedQRDisplayView()
+
+        with patch(
+            "seedsigner.models.encode_qr.UrPsbtQrEncoder", return_value=ur_encoder
+        ) as mock_ur_encoder:
+            with patch.object(view, "run_screen", return_value=0) as mock_run_screen:
+                view.run()
+
+        mock_ur_encoder.assert_called_once_with(
+            psbt=self.controller.psbt,
+            qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+        )
+        assert mock_run_screen.call_args.kwargs["qr_encoder"] is ur_encoder
 
     def test_spend_expired_fidelity_bond(self):
         def load_psbt_into_decoder(view: scan_views.ScanView):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -683,6 +683,14 @@ class TestMessageSigningFlows(FlowTest):
         self.controller.sign_message_data["paged_message"] = paged
 
 
+    def verify_fidelity_bond_certificate_page(self, view: View):
+        self.inject_mesage_as_paged_message(view)
+        pages = self.controller.sign_message_data["paged_message"]
+        assert len(pages) == 1
+        assert pages[0].count("\n") == 3
+        assert pages[0].replace("\n", "") == self.FIDELITY_BOND_CERTIFICATE
+
+
     def test_sign_message_flow(self):
         """
         Should scan a `signmessage` QR and complete the message review, address review,
@@ -764,6 +772,7 @@ class TestMessageSigningFlows(FlowTest):
             FlowStep(scan_views.ScanView, before_run=self.load_no_whitespace_message_into_decoder),  # simulate read message QR; ret val is ignored
             FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
             FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, screen_return_value=0),
             FlowStep(seed_views.SeedSignMessageConfirmAddressView, screen_return_value=0),
             FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),
             FlowStep(MainMenuView),
@@ -787,7 +796,7 @@ class TestMessageSigningFlows(FlowTest):
             FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
             FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
             FlowStep(seed_views.SeedOptionsView, is_redirect=True),
-            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.verify_fidelity_bond_certificate_page, screen_return_value=0),
             FlowStep(seed_views.SeedSignMessageConfirmAddressView, before_run=verify_bond_address, screen_return_value=0),
             FlowStep(seed_views.SeedSignMessageSignedMessageQRView, before_run=verify_signature, screen_return_value=0),
             FlowStep(MainMenuView),

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -37,6 +37,25 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedFidelityBondAddressQRView),
         ])
 
+    def test_export_fidelity_bond_registration(self):
+        def verify_registration(view):
+            assert '"type":"seedsigner-bip46"' in view.payload
+            assert '"network":"mainnet"' in view.payload
+            assert '"origin_path":"m/84\'/0\'/0\'/2"' in view.payload
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
+            FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
+            FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondAddressView, button_data_selection=seed_views.SeedFidelityBondAddressView.EXPORT_REGISTRATION),
+            FlowStep(seed_views.SeedFidelityBondRegistrationWarningView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondRegistrationQRView, before_run=verify_registration),
+        ])
+
     def test_scan_seedqr_flow(self):
         """
             Selecting "Scan" from the MainMenuView and scanning a SeedQR should enter the
@@ -762,6 +781,28 @@ class TestMessageSigningFlows(FlowTest):
         ])
 
 
+    def test_sign_signet_message_flow(self):
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.SIGNET)
+
+        def verify_signet_address(view):
+            assert view.address == "tb1q6rz28mcfaxtmd6v789l9rrlrusdprr9pqcpvkl"
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_testnet_message_into_decoder),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmAddressView, before_run=verify_signet_address, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageSignedMessageQRView, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
+
+
     def test_reject_invalid_fidelity_bond_certificate(self):
         self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
 
@@ -891,4 +932,3 @@ class TestMessageSigningFlows(FlowTest):
 
         self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
         expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
-

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1,3 +1,4 @@
+import json
 from typing import Callable
 from unittest.mock import patch
 import pytest
@@ -20,54 +21,112 @@ def load_seed_into_decoder(view: scan_views.ScanView):
 
 class TestSeedFlows(FlowTest):
 
+    FIDELITY_BOND_DATES = [(2040, 1)]
+    FIDELITY_BOND_MNEMONIC = (
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon about"
+    ).split()
+
+    def test_fidelity_bond_guidance_uses_safe_sequence(self):
+        view = seed_views.SeedFidelityBondWarningView(
+            seed=Seed(mnemonic=self.FIDELITY_BOND_MNEMONIC)
+        )
+        with patch.object(view, "run_screen", return_value=RET_CODE__BACK_BUTTON) as run_screen:
+            view.run()
+
+        assert run_screen.call_args.kwargs["text"] == (
+            "Register with JoinMarket NG, complete certificate setup, perform an "
+            "unfunded signing/redemption test, only then fund JoinMarket's "
+            "independently reconstructed address."
+        )
+
+    def test_fidelity_bond_month_selection_only_offers_future_months(self):
+        view = seed_views.SeedFidelityBondMonthView(
+            seed=Seed(mnemonic=self.FIDELITY_BOND_MNEMONIC), year=2040
+        )
+        with patch(
+            "seedsigner.helpers.fidelity_bonds.future_year_months",
+            return_value=[(2040, 4), (2040, 12), (2041, 1)],
+        ):
+            with patch.object(view, "run_screen", return_value=RET_CODE__BACK_BUTTON) as run_screen:
+                view.run()
+
+        button_data = run_screen.call_args.kwargs["button_data"]
+        assert [button.return_data for button in button_data] == [4, 12]
+
+    def test_fidelity_bond_year_selection_handles_no_future_months(self):
+        view = seed_views.SeedFidelityBondYearView(
+            seed=Seed(mnemonic=self.FIDELITY_BOND_MNEMONIC)
+        )
+        with patch("seedsigner.helpers.fidelity_bonds.future_year_months", return_value=[]):
+            destination = view.run()
+
+        assert destination.View_cls is ErrorView
+
     def test_generate_fidelity_bond_address(self):
         def verify_bond_address(view):
-            assert view.derivation_path == "m/84'/0'/0'/2/0"
-            assert view.address == "bc1qhhhf29f4nlyalyfrrpfrknxj9uwqk4qsyvkujsa7w0ulfur78xkspsqn84"
+            assert view.derivation_path == "m/84'/0'/0'/2/240"
+            assert view.address == "bc1qul0q45njptsadnymdtv34at7karyva3v7k2vj8qc7m2702rnvddq0z20u5"
 
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
-            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
-            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
-            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
-            FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
-            FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondAddressView, before_run=verify_bond_address, button_data_selection=seed_views.SeedFidelityBondAddressView.SHOW_QR),
-            FlowStep(seed_views.SeedFidelityBondAddressQRView),
-        ])
+        with patch("seedsigner.helpers.fidelity_bonds.future_year_months", return_value=self.FIDELITY_BOND_DATES):
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
+                FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
+                FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
+                FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
+                FlowStep(seed_views.SeedFidelityBondAddressView, before_run=verify_bond_address, button_data_selection=seed_views.SeedFidelityBondAddressView.SHOW_QR),
+                FlowStep(seed_views.SeedFidelityBondAddressQRView),
+            ])
 
     def test_export_fidelity_bond_registration(self):
         def verify_registration(view):
-            assert '"type":"seedsigner-bip46"' in view.payload
-            assert '"network":"mainnet"' in view.payload
-            assert '"origin_path":"m/84\'/0\'/0\'/2"' in view.payload
+            payload = json.loads(view.payload)
+            assert list(payload) == [
+                "type", "version", "network", "master_fingerprint", "derivation_path",
+                "index", "locktime", "locktime_date", "pubkey", "address",
+            ]
+            assert payload == {
+                "type": "seedsigner-bip46",
+                "version": 1,
+                "network": "mainnet",
+                "master_fingerprint": "73c5da0a",
+                "derivation_path": "m/84'/0'/0'/2/240",
+                "index": 240,
+                "locktime": 2208988800,
+                "locktime_date": "2040-01",
+                "pubkey": "03ec8067418537bbb52d5d3e64e2868e67635c33cfeadeb9a46199f89ebfaab226",
+                "address": "bc1qul0q45njptsadnymdtv34at7karyva3v7k2vj8qc7m2702rnvddq0z20u5",
+            }
 
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
-            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
-            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
-            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
-            FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
-            FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondAddressView, button_data_selection=seed_views.SeedFidelityBondAddressView.EXPORT_REGISTRATION),
-            FlowStep(seed_views.SeedFidelityBondRegistrationWarningView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondRegistrationQRView, before_run=verify_registration),
-        ])
+        with patch("seedsigner.helpers.fidelity_bonds.future_year_months", return_value=self.FIDELITY_BOND_DATES):
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
+                FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
+                FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
+                FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
+                FlowStep(seed_views.SeedFidelityBondAddressView, button_data_selection=seed_views.SeedFidelityBondAddressView.EXPORT_REGISTRATION),
+                FlowStep(seed_views.SeedFidelityBondRegistrationQRView, before_run=verify_registration),
+            ])
 
     def test_exit_fidelity_bond_summary_returns_to_seed_options(self):
-        self.run_sequence([
-            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
-            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
-            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
-            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
-            FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
-            FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
-            FlowStep(seed_views.SeedFidelityBondAddressView, screen_return_value=RET_CODE__BACK_BUTTON),
-            FlowStep(seed_views.SeedOptionsView),
-        ])
+        with patch("seedsigner.helpers.fidelity_bonds.future_year_months", return_value=self.FIDELITY_BOND_DATES):
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+                FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+                FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
+                FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
+                FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
+                FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
+                FlowStep(seed_views.SeedFidelityBondAddressView, screen_return_value=RET_CODE__BACK_BUTTON),
+                FlowStep(seed_views.SeedOptionsView),
+            ])
 
     def test_scan_seedqr_flow(self):
         """

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -56,6 +56,19 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedFidelityBondRegistrationQRView, before_run=verify_registration),
         ])
 
+    def test_exit_fidelity_bond_summary_returns_to_seed_options(self):
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
+            FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
+            FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondAddressView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.SeedOptionsView),
+        ])
+
     def test_scan_seedqr_flow(self):
         """
             Selecting "Scan" from the MainMenuView and scanning a SeedQR should enter the

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -9,7 +9,7 @@ from base import FlowTestInvalidButtonDataSelectionException
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
-from seedsigner.views.view import MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
+from seedsigner.views.view import ErrorView, MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
 from seedsigner.views import seed_views, scan_views, settings_views
 
 
@@ -19,6 +19,23 @@ def load_seed_into_decoder(view: scan_views.ScanView):
 
 
 class TestSeedFlows(FlowTest):
+
+    def test_generate_fidelity_bond_address(self):
+        def verify_bond_address(view):
+            assert view.derivation_path == "m/84'/0'/0'/2/0"
+            assert view.address == "bc1qhhhf29f4nlyalyfrrpfrknxj9uwqk4qsyvkujsa7w0ulfur78xkspsqn84"
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.FIDELITY_BOND),
+            FlowStep(seed_views.SeedFidelityBondWarningView, button_data_selection=seed_views.SeedFidelityBondWarningView.CONTINUE),
+            FlowStep(seed_views.SeedFidelityBondYearView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondMonthView, screen_return_value=0),
+            FlowStep(seed_views.SeedFidelityBondAddressView, before_run=verify_bond_address, button_data_selection=seed_views.SeedFidelityBondAddressView.SHOW_QR),
+            FlowStep(seed_views.SeedFidelityBondAddressQRView),
+        ])
 
     def test_scan_seedqr_flow(self):
         """
@@ -574,6 +591,8 @@ class TestMessageSigningFlows(FlowTest):
     MAINNET_DERIVATION_PATH = "m/84h/0h/0h/0/0"
     TESTNET_DERIVATION_PATH = "m/84h/1h/0h/0/0"
     CUSTOM_DERIVATION_PATH = "m/99h/0/0"
+    FIDELITY_BOND_DERIVATION_PATH = "m/84h/0h/0h/2/0"
+    FIDELITY_BOND_CERTIFICATE = "fidelity-bond-cert|0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c|375"
     SHORT_MESSAGE = "I attest that I control this bitcoin address blah blah blah"
     NO_WHITESPACE_MESSAGE = """{"height":841407,"lightning_bolt12":"lno1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}"""
     MULTIPAGE_MESSAGE = """Chancellor on brink of second bailout for banks
@@ -611,6 +630,14 @@ class TestMessageSigningFlows(FlowTest):
 
     def load_custom_derivation_into_decoder(self, view: View):
         self.load_signmessage_into_decoder(view, self.CUSTOM_DERIVATION_PATH, self.SHORT_MESSAGE)
+
+
+    def load_fidelity_bond_certificate_into_decoder(self, view: View):
+        self.load_signmessage_into_decoder(
+            view,
+            self.FIDELITY_BOND_DERIVATION_PATH,
+            self.FIDELITY_BOND_CERTIFICATE,
+        )
 
 
     def inject_mesage_as_paged_message(self, view: View):
@@ -710,6 +737,47 @@ class TestMessageSigningFlows(FlowTest):
             FlowStep(MainMenuView),
         ])
 
+
+    def test_sign_fidelity_bond_certificate_flow(self):
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        def verify_bond_address(view):
+            assert view.address == "bc1qhhhf29f4nlyalyfrrpfrknxj9uwqk4qsyvkujsa7w0ulfur78xkspsqn84"
+
+        def verify_signature(view):
+            assert view.signed_message == "INOP3cB9UW7F1e1Aglj8rI9QhnyxmgWDEPt+nOMvl7hJJne7rH/KCNDYvLiqNuB9qWaWUojutjRsgPJrvyDQ+0Y="
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=self.load_fidelity_bond_certificate_into_decoder),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(seed_views.SeedSelectSeedView, button_data_selection=seed_views.SeedSelectSeedView.SCAN_SEED),
+            FlowStep(scan_views.ScanView, before_run=self.load_seed_into_decoder),
+            FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.FINALIZE),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+            FlowStep(seed_views.SeedSignMessageConfirmMessageView, before_run=self.inject_mesage_as_paged_message, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageConfirmAddressView, before_run=verify_bond_address, screen_return_value=0),
+            FlowStep(seed_views.SeedSignMessageSignedMessageQRView, before_run=verify_signature, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
+
+
+    def test_reject_invalid_fidelity_bond_certificate(self):
+        self.settings.set_value(SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED)
+
+        def load_invalid_certificate(view):
+            self.load_signmessage_into_decoder(
+                view,
+                self.FIDELITY_BOND_DERIVATION_PATH,
+                self.FIDELITY_BOND_CERTIFICATE.upper(),
+            )
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_invalid_certificate),
+            FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+            FlowStep(ErrorView),
+        ])
 
     def test_sign_message_network_mismatch_flow(self):
         """
@@ -823,5 +891,4 @@ class TestMessageSigningFlows(FlowTest):
 
         self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
         expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
-
 

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -1,9 +1,50 @@
 import os
+from unittest.mock import patch
+
 from embit import bip39
+from pyzbar import pyzbar
+
+from seedsigner.helpers import fidelity_bonds
 from seedsigner.helpers.qr import QR
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
-from seedsigner.models.encode_qr import SeedQrEncoder, CompactSeedQrEncoder
+from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder
 from seedsigner.models.qr_type import QRType
+from seedsigner.models.seed import Seed
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+def test_qrimage_io_preserves_json_payload_for_qrencode():
+    payload = '{"type":"seedsigner-bip46","xpub":"xpub123"}'
+    qr = QR()
+    fallback_image = object()
+
+    with patch("seedsigner.helpers.qr.subprocess.call", return_value=1) as mock_call:
+        with patch.object(qr, "qrimage", return_value=fallback_image):
+            image = qr.qrimage_io(payload)
+
+    command = mock_call.call_args.args[0]
+    assert isinstance(command, list)
+    assert command[-1] == payload
+    assert image is fallback_image
+
+
+def test_fidelity_bond_registration_qr_round_trip_at_device_size():
+    seed = Seed(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon about".split()
+    )
+    for network in (
+        SettingsConstants.MAINNET,
+        SettingsConstants.TESTNET,
+        SettingsConstants.SIGNET,
+        SettingsConstants.REGTEST,
+    ):
+        payload = fidelity_bonds.registration_payload(seed.seed_bytes, 73, network)
+        image = GenericStaticQrEncoder(data=payload).next_part_image(width=240, height=240)
+
+        decoded = pyzbar.decode(image)
+        assert len(decoded) == 1
+        assert decoded[0].data.decode("ascii") == payload
 
 
 

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -1,5 +1,8 @@
 import os
-from unittest.mock import patch
+from io import BytesIO
+from unittest.mock import Mock, patch
+
+from PIL import Image
 
 from embit import bip39
 from pyzbar import pyzbar
@@ -18,14 +21,30 @@ def test_qrimage_io_preserves_json_payload_for_qrencode():
     qr = QR()
     fallback_image = object()
 
-    with patch("seedsigner.helpers.qr.subprocess.call", return_value=1) as mock_call:
+    failed_result = Mock(returncode=1, stdout=b"")
+    with patch("seedsigner.helpers.qr.subprocess.run", return_value=failed_result) as mock_run:
         with patch.object(qr, "qrimage", return_value=fallback_image):
             image = qr.qrimage_io(payload)
 
-    command = mock_call.call_args.args[0]
+    command = mock_run.call_args.args[0]
     assert isinstance(command, list)
+    assert command[command.index("-o") + 1] == "-"
     assert command[-1] == payload
     assert image is fallback_image
+
+
+def test_qrimage_io_reads_qrencode_output_from_memory():
+    qr = QR()
+    encoded_png = Image.new("RGB", (21, 21), "white")
+    buffer = BytesIO()
+    encoded_png.save(buffer, format="PNG")
+    output = Mock(returncode=0, stdout=buffer.getvalue())
+
+    with patch("seedsigner.helpers.qr.subprocess.run", return_value=output):
+        image = qr.qrimage_io("fidelity bond", width=240, height=240)
+
+    assert image.mode == "RGBA"
+    assert image.size == (240, 240)
 
 
 def test_fidelity_bond_registration_qr_round_trip_at_device_size():
@@ -45,6 +64,25 @@ def test_fidelity_bond_registration_qr_round_trip_at_device_size():
         decoded = pyzbar.decode(image)
         assert len(decoded) == 1
         assert decoded[0].data.decode("ascii") == payload
+
+
+def test_static_qr_encoder_caches_rendered_frames():
+    encoder = GenericStaticQrEncoder(data="fidelity bond")
+    rendered_image = Image.new("RGBA", (240, 240))
+    encoder.qr.qrimage_io = Mock(return_value=rendered_image)
+
+    first_image = encoder.next_part_image(width=240, height=240, background_color="ffffff")
+    second_image = encoder.next_part_image(width=240, height=240, background_color="ffffff")
+
+    encoder.qr.qrimage_io.assert_called_once()
+    assert first_image is not second_image
+    assert first_image is not rendered_image
+
+    first_image.putpixel((0, 0), (255, 255, 255, 255))
+    assert second_image.getpixel((0, 0)) == (0, 0, 0, 0)
+
+    encoder.next_part_image(width=240, height=240, background_color="dedede")
+    assert encoder.qr.qrimage_io.call_count == 2
 
 
 

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -1,3 +1,4 @@
+import json
 import os
 from io import BytesIO
 from unittest.mock import Mock, patch
@@ -17,7 +18,7 @@ from seedsigner.models.settings_definition import SettingsConstants
 
 
 def test_qrimage_io_preserves_json_payload_for_qrencode():
-    payload = '{"type":"seedsigner-bip46","xpub":"xpub123"}'
+    payload = '{"type":"seedsigner-bip46","index":73}'
     qr = QR()
     fallback_image = object()
 
@@ -64,6 +65,13 @@ def test_fidelity_bond_registration_qr_round_trip_at_device_size():
         decoded = pyzbar.decode(image)
         assert len(decoded) == 1
         assert decoded[0].data.decode("ascii") == payload
+        registration = json.loads(payload)
+        assert list(registration) == [
+            "type", "version", "network", "master_fingerprint", "derivation_path",
+            "index", "locktime", "locktime_date", "pubkey", "address",
+        ]
+        assert "origin_path" not in registration
+        assert "xpub" not in registration
 
 
 def test_static_qr_encoder_caches_rendered_frames():


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

SeedSigner did not support [BIP 46 timelocked fidelity bonds](https://github.com/bitcoin/bips/blob/master/bip-0046.mediawiki). JoinMarket users therefore could not derive and verify bond addresses, export the public metadata needed by a watch-only wallet, sign bond certificates, or redeem an expired bond while keeping its seed offline.

### Solution

This adds a native fidelity-bond workflow to SeedSigner:

- derive BIP 46 addresses and display the locktime and derivation details for verification;
- export a compact registration QR containing only public branch metadata;
- parse and sign fidelity-bond certificate requests;
- recognize and sign expired bond-spend PSBTs, preserving the fields required for host-side verification and finalization; and
- use static QR output where the interoperability flow requires it, with stable rendering at device dimensions.

SeedSigner remains the offline signer. Address registration, transaction finalization, Bitcoin Core preflight, and broadcasting stay on the connected JoinMarket side.

### Additional Information

The implementation strictly validates derivation paths, witness scripts, locktimes, certificate messages, and supported network values before signing. Unit tests and FlowTests cover address generation, registration export, certificate signing, PSBT signing, invalid inputs, QR round trips, and screen navigation.

The corresponding JoinMarket NG work verifies and finalizes the signed CLTV spend and requires Bitcoin Core's [`testmempoolaccept`](https://developer.bitcoin.org/reference/rpc/testmempoolaccept.html) before broadcast.

### Screenshots

<img width="240" height="240" alt="01-home-seeds" src="https://github.com/user-attachments/assets/916379e9-9174-4c37-b3a9-803c86910297" />
<img width="240" height="240" alt="02-in-memory-seed" src="https://github.com/user-attachments/assets/39b4e9f0-590f-45e7-8b3e-3db92661c660" />
<img width="240" height="240" alt="03-seed-options" src="https://github.com/user-attachments/assets/603e387d-e0ef-437d-bc1f-ab6f059a3f68" />
<img width="240" height="240" alt="04-bond-warning" src="https://github.com/user-attachments/assets/dab2e3a5-65b3-45c3-b283-1962a5382551" />
<img width="240" height="240" alt="05-bond-year" src="https://github.com/user-attachments/assets/ed57f35d-64fe-4484-837e-46c8829e6ddd" />
<img width="240" height="240" alt="06-bond-month" src="https://github.com/user-attachments/assets/989f582d-ee58-4885-bbd9-2d1317f7f04d" />
<img width="240" height="240" alt="07-bond-address-review" src="https://github.com/user-attachments/assets/49ac9abc-cf81-4f1b-8694-389f6cdbae00" />
<img width="240" height="240" alt="08-registration-warning" src="https://github.com/user-attachments/assets/9e081922-c15d-4a0d-afb7-dbe9f3da3127" />
<img width="240" height="240" alt="09-bond-address-qr" src="https://github.com/user-attachments/assets/ff140f3f-9763-44fe-b7a8-d1c8eb98d475" />
<img width="240" height="240" alt="10-registration-qr" src="https://github.com/user-attachments/assets/77eb9ef0-f906-49bc-859b-3d1233e2063f" />
<img width="240" height="240" alt="11-certificate-review" src="https://github.com/user-attachments/assets/e89f4b09-3899-4aa4-b0b5-5e9153a8d68c" />
<img width="240" height="240" alt="12-certificate-address" src="https://github.com/user-attachments/assets/9441df7a-f0f2-4426-81ff-0bafa8006dc7" />


---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [x] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator