### PR TITLE
Export xpub in text format

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -647,6 +647,146 @@ class SeedExportXpubDetailsScreen(WarningEdgesMixin, ButtonListScreen):
 
 
 @dataclass
+class SeedExportXpubTextScreen(BaseTopNavScreen):
+    """Display the full xpub as wrapped, vertically scrollable text."""
+    xpub: str = None
+
+    def __post_init__(self):
+        self.title = _("Xpub")
+        super().__post_init__()
+
+        self.done_button = Button(
+            text=_("Done"),
+            screen_x=GUIConstants.EDGE_PADDING,
+            screen_y=self.canvas_height - GUIConstants.EDGE_PADDING - GUIConstants.BUTTON_HEIGHT,
+            width=self.canvas_width - 2 * GUIConstants.EDGE_PADDING,
+            height=GUIConstants.BUTTON_HEIGHT,
+            is_text_centered=True,
+        )
+        self.done_button.is_selected = True
+
+        font_name = GUIConstants.FIXED_WIDTH_FONT_NAME
+        font_size = GUIConstants.get_body_font_size() + 2
+        font = Fonts.get_font(font_name, font_size)
+        (left, top, right, bottom) = font.getbbox("X", anchor="ls")
+        char_width = right - left
+        usable_width = self.canvas_width - 2 * GUIConstants.EDGE_PADDING
+        chars_per_line = max(1, int(usable_width / char_width))
+        wrapped = "\n".join(
+            self.xpub[i:i + chars_per_line]
+            for i in range(0, len(self.xpub), chars_per_line)
+        )
+
+        self.xpub_textarea = TextArea(
+            text=wrapped,
+            font_name=font_name,
+            font_size=font_size,
+            is_text_centered=False,
+            edge_padding=GUIConstants.EDGE_PADDING,
+        )
+        self.text_img = self.xpub_textarea.rendered_text_img
+
+        self.content_y = self.top_nav.height + GUIConstants.COMPONENT_PADDING
+        self.content_bottom = self.done_button.screen_y - GUIConstants.COMPONENT_PADDING
+        self.visible_height = self.content_bottom - self.content_y
+        self.scroll_y = 0
+        self.max_scroll = max(0, self.text_img.height - self.visible_height)
+        self.scroll_step = self.xpub_textarea.text_height_above_baseline + GUIConstants.BODY_LINE_SPACING
+
+        self.has_scroll_arrows = self.max_scroll > 0
+        if self.has_scroll_arrows:
+            self.arrow_half_width = 10
+            self.up_arrow_img = Image.new("RGBA", size=(2 * self.arrow_half_width, 8), color="black")
+            self.up_arrow_img_y = self.top_nav.height - 12
+            arrow_draw = ImageDraw.Draw(self.up_arrow_img)
+            arrow_draw.line((self.arrow_half_width, 1, 0, 7), fill=GUIConstants.BUTTON_FONT_COLOR)
+            arrow_draw.line((self.arrow_half_width, 1, 2 * self.arrow_half_width, 7), fill=GUIConstants.BUTTON_FONT_COLOR)
+
+            self.down_arrow_img = Image.new("RGBA", size=(2 * self.arrow_half_width, 8), color="black")
+            self.down_arrow_img_y = self.done_button.screen_y - 12
+            arrow_draw = ImageDraw.Draw(self.down_arrow_img)
+            arrow_draw.line((self.arrow_half_width, 7, 0, 1), fill=GUIConstants.BUTTON_FONT_COLOR)
+            arrow_draw.line((self.arrow_half_width, 7, 2 * self.arrow_half_width, 1), fill=GUIConstants.BUTTON_FONT_COLOR)
+
+
+    def _render_up_arrow(self):
+        self.canvas.paste(self.up_arrow_img, (int(self.canvas_width / 2) - self.arrow_half_width, self.up_arrow_img_y))
+
+
+    def _render_down_arrow(self):
+        self.canvas.paste(self.down_arrow_img, (int(self.canvas_width / 2) - self.arrow_half_width, self.down_arrow_img_y))
+
+
+    def _render(self):
+        self.clear_screen()
+        self.top_nav.render()
+
+        crop_bottom = min(self.text_img.height, self.scroll_y + self.visible_height)
+        visible = self.text_img.crop((0, self.scroll_y, self.text_img.width, crop_bottom))
+        self.canvas.paste(visible, (0, self.content_y))
+
+        if self.has_scroll_arrows:
+            if self.scroll_y > 0:
+                self._render_up_arrow()
+            if self.scroll_y < self.max_scroll:
+                self._render_down_arrow()
+
+        self.done_button.render()
+        self.renderer.show_image()
+
+
+    def _run(self):
+        while True:
+            user_input = self.hw_inputs.wait_for(
+                [
+                    HardwareButtonsConstants.KEY_UP,
+                    HardwareButtonsConstants.KEY_DOWN,
+                    HardwareButtonsConstants.KEY_LEFT,
+                    HardwareButtonsConstants.KEY_RIGHT,
+                ] + HardwareButtonsConstants.KEYS__ANYCLICK
+            )
+
+            with self.renderer.lock:
+                if user_input == HardwareButtonsConstants.KEY_UP:
+                    if self.top_nav.is_selected:
+                        continue
+                    if self.scroll_y > 0:
+                        self.scroll_y = max(0, self.scroll_y - self.scroll_step)
+                        self._render()
+                    else:
+                        self.top_nav.is_selected = True
+                        self.done_button.is_selected = False
+                        self._render()
+
+                elif user_input == HardwareButtonsConstants.KEY_DOWN:
+                    if self.top_nav.is_selected:
+                        self.top_nav.is_selected = False
+                        self.done_button.is_selected = True
+                        self._render()
+                    elif self.scroll_y < self.max_scroll:
+                        self.scroll_y = min(self.max_scroll, self.scroll_y + self.scroll_step)
+                        self._render()
+
+                elif user_input == HardwareButtonsConstants.KEY_LEFT:
+                    if not self.top_nav.is_selected:
+                        self.top_nav.is_selected = True
+                        self.done_button.is_selected = False
+                        self._render()
+
+                elif user_input == HardwareButtonsConstants.KEY_RIGHT:
+                    if self.top_nav.is_selected:
+                        self.top_nav.is_selected = False
+                        self.done_button.is_selected = True
+                        self._render()
+
+                elif user_input in HardwareButtonsConstants.KEYS__ANYCLICK:
+                    if self.top_nav.is_selected:
+                        return RET_CODE__BACK_BUTTON
+                    return 0
+
+
+
+@dataclass
 class SeedAddPassphraseScreen(BaseTopNavScreen):
     passphrase: str = ""
 

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -42,15 +42,19 @@ class SettingsConstants:
     XPUB_QR_FORMAT__UR_CRYPTO_ACCOUNT = "urca"
     XPUB_QR_FORMAT__STATIC = "sta"
     XPUB_QR_FORMAT__SPECTER_LEGACY = "spl"
+    XPUB_FORMAT__TEXT = "txt"
     ALL_XPUB_QR_FORMATS = [
         # TRANSLATOR_NOTE: QR code format option; "default" = this is the format most wallets use
-        (XPUB_QR_FORMAT__UR_CRYPTO_ACCOUNT, _mft("Animated (default)")),
+        (XPUB_QR_FORMAT__UR_CRYPTO_ACCOUNT, _mft("Animated QR (default)")),
 
         # TRANSLATOR_NOTE: QR code format option (static = single frame, not animated)
-        (XPUB_QR_FORMAT__STATIC, _mft("Static")),
+        (XPUB_QR_FORMAT__STATIC, _mft("Static QR")),
 
         # TRANSLATOR_NOTE: QR code format option: old format that Specter Desktop used to use
-        (XPUB_QR_FORMAT__SPECTER_LEGACY, _mft("Specter legacy")),
+        (XPUB_QR_FORMAT__SPECTER_LEGACY, _mft("Specter legacy QR")),
+
+        # TRANSLATOR_NOTE: Xpub export format option: display as text instead of a QR code
+        (XPUB_FORMAT__TEXT, _mft("Text")),
     ]
 
     # Over-specifying current and possible future locales to reduce/eliminate main repo
@@ -622,13 +626,14 @@ class SettingsDefinition:
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__XPUB_QR_FORMAT,
-                      display_name=_mft("Xpub QR format"),
+                      display_name=_mft("Xpub Format"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       type=SettingsConstants.TYPE__MULTISELECT,
                       selection_options=SettingsConstants.ALL_XPUB_QR_FORMATS,
                       default_value=[
                             SettingsConstants.XPUB_QR_FORMAT__UR_CRYPTO_ACCOUNT,
                             SettingsConstants.XPUB_QR_FORMAT__STATIC,
+                            SettingsConstants.XPUB_FORMAT__TEXT,
                       ]),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -816,9 +816,12 @@ class SeedExportXpubQRFormatView(View):
             args["xpub_qr_format"] = self.settings.get_value(SettingsConstants.SETTING__XPUB_QR_FORMAT)[0]
             return Destination(SeedExportXpubWarningView, view_args=args, skip_current_view=True)
 
+        # Iterate selection_options in fixed order. Ignore the order in which they were selected.
         button_data = []
-        for display_name, setting_option in zip(self.settings.get_multiselect_value_display_names(SettingsConstants.SETTING__XPUB_QR_FORMAT), self.settings.get_value(SettingsConstants.SETTING__XPUB_QR_FORMAT)):
-            button_data.append(ButtonOption(display_name, return_data=setting_option))
+        selected_formats = self.settings.get_value(SettingsConstants.SETTING__XPUB_QR_FORMAT)
+        for setting_option, display_name in SettingsConstants.ALL_XPUB_QR_FORMATS:
+            if setting_option in selected_formats:
+                button_data.append(ButtonOption(display_name, return_data=setting_option))
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -825,7 +825,7 @@ class SeedExportXpubQRFormatView(View):
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
-            title=_("Xpub QR Format"),
+            title=_("Xpub Format"),
             is_button_text_centered=False,
             button_data=button_data,
             is_bottom_list=True,
@@ -968,6 +968,9 @@ class SeedExportXpubQRDisplayView(View):
     def __init__(self, seed: Seed, xpub_qr_format: str, derivation_path: str, sig_type: str = SettingsConstants.SINGLE_SIG):
         super().__init__()
         self.seed = seed
+        self.xpub_qr_format = xpub_qr_format
+        self.xpub_text = None
+        self.qr_encoder = None
 
         encoder_args = dict(
             seed=self.seed,
@@ -977,7 +980,11 @@ class SeedExportXpubQRDisplayView(View):
             sig_type=sig_type
         )
 
-        if xpub_qr_format == SettingsConstants.XPUB_QR_FORMAT__STATIC:
+        if xpub_qr_format == SettingsConstants.XPUB_FORMAT__TEXT:
+            # Reuse the static encoder to get the standard origin-prefixed xpub string
+            self.xpub_text = StaticXpubQrEncoder(**encoder_args).xpubstring
+
+        elif xpub_qr_format == SettingsConstants.XPUB_QR_FORMAT__STATIC:
             self.qr_encoder = StaticXpubQrEncoder(**encoder_args)
 
         elif xpub_qr_format == SettingsConstants.XPUB_QR_FORMAT__SPECTER_LEGACY:
@@ -989,6 +996,15 @@ class SeedExportXpubQRDisplayView(View):
 
 
     def run(self):
+        if self.xpub_qr_format == SettingsConstants.XPUB_FORMAT__TEXT:
+            selected_menu_num = self.run_screen(
+                seed_screens.SeedExportXpubTextScreen,
+                xpub=self.xpub_text,
+            )
+            if selected_menu_num == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+            return Destination(MainMenuView)
+
         from seedsigner.gui.screens.screen import QRDisplayScreen
         self.run_screen(
             QRDisplayScreen,

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -391,6 +391,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedExportXpubWarningView,          dict(seed=seed_12, sig_type="msig", script_type="nes", xpub_qr_format="urca", custom_derivation="")),
                 ScreenshotConfig(seed_views.SeedExportXpubDetailsView,          dict(seed=seed_12, sig_type="ss",   script_type="nat", xpub_qr_format="urca", custom_derivation="")),
                 ScreenshotConfig(SeedExportXpubQR_ScreenBrightnessView,         dict(seed=seed_12, xpub_qr_format="urca", derivation_path="m/84'/0'/0'")),
+                ScreenshotConfig(seed_views.SeedExportXpubQRDisplayView,        dict(seed=seed_12, xpub_qr_format="txt", derivation_path="m/84'/0'/0'"), screenshot_name="SeedExportXpubQRDisplayView_text"),
 
                 ScreenshotConfig(seed_views.SeedWordsWarningView, dict(seed=seed_12)),
                 ScreenshotConfig(seed_views.SeedWordsView, dict(seed=seed_12)),

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -231,6 +231,48 @@ class TestSeedFlows(FlowTest):
                         flowtest_standard_xpub(sig_tuple, script_tuple, xpub_qr_tuple)
 
 
+    def test_export_xpub_format_selection_when_enabled_out_of_order(self):
+        """
+        Enabling Specter legacy after the defaults appends it to the stored value list.
+        Labels must still map to the matching format value (not zip by index).
+        """
+        seed = Seed(mnemonic="blush twice taste dawn feed second opinion lazy thumb play neglect impact".split())
+        self.controller.storage.set_pending_seed(seed)
+        self.controller.storage.finalize_pending_seed()
+
+        self.settings.set_value(SettingsConstants.SETTING__SIG_TYPES, [SettingsConstants.SINGLE_SIG])
+        self.settings.set_value(SettingsConstants.SETTING__SCRIPT_TYPES, [SettingsConstants.NATIVE_SEGWIT])
+        # Same order as toggling Specter on in Advanced settings (appended last).
+        self.settings.set_value(SettingsConstants.SETTING__XPUB_QR_FORMAT, [
+            SettingsConstants.XPUB_QR_FORMAT__UR_CRYPTO_ACCOUNT,
+            SettingsConstants.XPUB_QR_FORMAT__STATIC,
+            SettingsConstants.XPUB_FORMAT__TEXT,
+            SettingsConstants.XPUB_QR_FORMAT__SPECTER_LEGACY,
+        ])
+
+        def format_button(format_value: str) -> ButtonOption:
+            display_name = dict(SettingsConstants.ALL_XPUB_QR_FORMATS)[format_value]
+            return ButtonOption(display_name, return_data=format_value)
+
+        def flowtest_format(format_value: str):
+            self.run_sequence(
+                initial_destination_view_args=dict(seed=seed),
+                sequence=[
+                    FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.EXPORT_XPUB),
+                    FlowStep(seed_views.SeedExportXpubSigTypeView, is_redirect=True),
+                    FlowStep(seed_views.SeedExportXpubScriptTypeView, is_redirect=True),
+                    FlowStep(seed_views.SeedExportXpubQRFormatView, button_data_selection=format_button(format_value)),
+                    FlowStep(seed_views.SeedExportXpubWarningView, screen_return_value=0),
+                    FlowStep(seed_views.SeedExportXpubDetailsView, screen_return_value=0),
+                    FlowStep(seed_views.SeedExportXpubQRDisplayView, screen_return_value=0),
+                    FlowStep(MainMenuView),
+                ]
+            )
+
+        flowtest_format(SettingsConstants.XPUB_QR_FORMAT__SPECTER_LEGACY)
+        flowtest_format(SettingsConstants.XPUB_FORMAT__TEXT)
+
+
     def test_export_xpub_disabled_not_available_flow(self):
         """
             If sig_type/script_type/xpub_qr_format disabled, then these options are not available


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

In multisig scenarios (i.e. 2-of-2 multi-vendor), when verifying a Receive Address on a hardware wallet, it is important to also verify all the co-signers, preferably by reading the xpubs directly from the hardware wallets themselves because the coordinator computer/phone might be compromised.

See discussion at: https://github.com/SeedSigner/seedsigner/issues/213

### Solution

In the menu for exporting the xpub, add an option to simply show it as text. No need to scan it with a possibly-compromised device, just compare the text to what you see on the other hardware wallets (i.e. Trezor) or write it down.

### Additional Information

I wish that in the future verifying a Receive Address of a multisig wallet will also involve a step of verifying all the xpubs of the other co-signers. This is not covered in this PR.

The PR will also fix a small bug that I found:
https://github.com/SeedSigner/seedsigner/issues/1006

### Screenshots

<img width="592" height="404" alt="Screenshot 2026-08-15 at 20 06 35" src="https://github.com/user-attachments/assets/64bd8280-652b-44d5-a9ac-2471138ff08d" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 20 06 27" src="https://github.com/user-attachments/assets/0519b7c9-99ec-409f-8ec8-e270d9cf6ee5" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 20 06 23" src="https://github.com/user-attachments/assets/cb79fca9-0fde-4a32-afbd-dc03bc200cf4" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 20 06 00" src="https://github.com/user-attachments/assets/8ca809cc-aa23-492d-9208-98fc35bc004a" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 18 20 56" src="https://github.com/user-attachments/assets/047c683e-aa27-4945-b1ff-a940df970e07" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 18 20 50" src="https://github.com/user-attachments/assets/94914a19-5493-42c2-99cc-9c746670508f" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 18 20 23" src="https://github.com/user-attachments/assets/b630e1e4-06ee-494c-bf59-9a627f214a45" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 18 19 58" src="https://github.com/user-attachments/assets/2aa62191-88e8-4379-8dea-410bb5a5bdc3" />
<img width="592" height="404" alt="Screenshot 2026-08-15 at 18 19 35" src="https://github.com/user-attachments/assets/434ee6a8-4f20-4d02-98d1-21755018112b" />


---

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.