### PR TITLE
 [Bugfix] Back navigation when cancelling Multisig Descriptor Loading

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2037,7 +2037,7 @@ class LoadMultisigWalletDescriptorView(View):
 
         elif button_data[selected_menu_num] == self.CANCEL:
             from seedsigner.controller import Controller
-            if self.controller.resume_main_flow == Controller.FLOW__PSBT:
+            if self.controller.resume_main_flow in [Controller.FLOW__PSBT, Controller.FLOW__VERIFY_MULTISIG_ADDR]:
                 return Destination(BackStackView)
             else:
                 return Destination(MainMenuView)

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -281,6 +281,82 @@ class TestToolsFlows(FlowTest):
             ])
 
 
+    def test_verify_address_cancel_from_multisig_descriptor_loading_returns_to_sig_type_view(self):
+        """
+            Cancelling out of multisig descriptor loading during nested segwit address verification
+            must safely return to the sig type selection view and preserve state.
+            Backing out fully to MainMenu should wipe the verification state.
+        """
+        def load_address_into_decoder(view: scan_views.ScanView):
+            # 2-of-3 Nested SegWit multisig address
+            view.decoder.add_data("3Qzhs5zKVeSJUKTmECvvq3ZEuuZkZQcMYq")
+
+        settings = Controller.get_instance().settings
+        settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate read address QR
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.AddressVerificationSigTypeView, button_data_selection=seed_views.AddressVerificationSigTypeView.MULTISIG),
+            FlowStep(seed_views.LoadMultisigWalletDescriptorView, button_data_selection=seed_views.LoadMultisigWalletDescriptorView.CANCEL),
+            FlowStep(seed_views.AddressVerificationSigTypeView),
+        ])
+
+        controller = Controller.get_instance()
+        assert controller.resume_main_flow == Controller.FLOW__VERIFY_MULTISIG_ADDR
+        assert controller.unverified_address is not None
+
+        self.run_sequence([
+            FlowStep(seed_views.AddressVerificationSigTypeView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+
+        controller = Controller.get_instance()
+        assert controller.resume_main_flow is None
+        assert controller.unverified_address is None
+
+
+    def test_verify_address_cancel_from_native_multisig_descriptor_loading_returns_to_tools_menu(self):
+        """
+            Native segwit multisig addresses are deterministically multisig,
+            so they skip the AddressVerificationSigTypeView entirely.
+            Because of this, cancelling out of multisig descriptor loading must safely return
+            to the previous view, rather than the AddressVerificationSigTypeView.
+            Backing out fully to MainMenu should wipe the verification state.
+        """
+        def load_address_into_decoder(view: scan_views.ScanView):
+            # 2-of-3 Native SegWit multisig address
+            view.decoder.add_data("bc1qecqflvqj6skhxxw7k0v863u0fgscjhkjnw3l3mc3n6hfxx6p9atsqqadwd")
+
+        settings = Controller.get_instance().settings
+        settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+            FlowStep(scan_views.ScanAddressView, before_run=load_address_into_decoder),  # simulate read address QR
+            FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+            FlowStep(seed_views.LoadMultisigWalletDescriptorView, button_data_selection=seed_views.LoadMultisigWalletDescriptorView.CANCEL),
+            FlowStep(tools_views.ToolsMenuView),
+        ])
+
+        controller = Controller.get_instance()
+        assert controller.resume_main_flow == Controller.FLOW__VERIFY_MULTISIG_ADDR
+        assert controller.unverified_address is not None
+
+        self.run_sequence([
+            FlowStep(tools_views.ToolsMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(MainMenuView),
+        ])
+
+        controller = Controller.get_instance()
+        assert controller.resume_main_flow is None
+        assert controller.unverified_address is None
+
+
 class TestToolsImageEntropyFlows(FlowTest):
 
     def test__image_entropy__incorrect_preview_frame_count_aborts(self):


### PR DESCRIPTION
## Description
This PR fixes a back navigation bug in `LoadMultisigWalletDescriptorView` during address verification.

When a multisig address is scanned without an already loaded wallet descriptor, the user is navigated to `LoadMultisigWalletDescriptorView` and the address verification resume flow is preserved.

Pressing Cancel previously returned directly to `MainMenuView`, which cleared the back stack and the ongoing user flow.

### Problem or Issue being addressed

The descriptor loading screen is reached through two address-verification paths:

- Nested SegWit multisig address: AddressVerificationSigTypeView → LoadMultisigWalletDescriptorView
- Native SegWit multisig address: AddressVerificationStartView → LoadMultisigWalletDescriptorView

`LoadMultisigWalletDescriptorView` ONLY returned through the back stack for the PSBT flow. This wiped the ongoing flow and the user was sent to the Main Menu.

### Solution

`Controller.FLOW__VERIFY_MULTISIG_ADDR` is now handled like `Controller.FLOW__PSBT` when Cancel is selected, preserving the flow.

The view now returns `Destination(BackStackView)`. This restores the correct previous view:
- Nested SegWit returns to AddressVerificationSigTypeView.
- Native SegWit returns to ToolsMenuView.

The pending verification state remains, if the user backs out again to MainMenuView, the controller clears the pending state.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [x] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---