### PR TITLE
[chore] Align dev requirements pins with the versions SeedSigner OS ships

### DIFF
--- a/requirements-raspi.txt
+++ b/requirements-raspi.txt
@@ -1,5 +1,5 @@
 picamera==1.13
 # numpy = transitive picamera dependency
-numpy==1.25.2
-RPi.GPIO==0.7.0
-spidev==3.5
+numpy==1.25.0
+RPi.GPIO==0.7.1
+spidev==3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 embit==0.8.0
 Pillow==10.3.0
 pyzbar @ git+https://github.com/seedsigner/pyzbar.git@c3c237821c6a20b17953efe59b90df0b514a1c03
-qrcode==7.3.1
-urtypes==1.0.1
+qrcode==8.0
+urtypes @ git+https://github.com/selfcustody/urtypes.git@7fb280eab3b3563dfc57d2733b0bf5cbc0a96a6a


### PR DESCRIPTION
Trivial update. Does NOT affect the actual SeedSigner OS release builds.

Writeup by Claude, reviewed by Keith:

---

## Motivation

`requirements.txt` and `requirements-raspi.txt` only govern dev
environments — shipped images get all of these packages from
SeedSigner OS's buildroot tree, where every one is version-pinned and
hash-verified at download. While auditing dependency pinning on the
seedsigner-os side, we found several entries here had drifted from
what devices actually run, meaning dev environments were exercising
different dependency versions than production hardware.

This PR treats the SeedSigner OS buildroot pins as definitive and
brings both files back in line. No shipped image changes behavior —
every version here is what devices have been running all along.

## Changes

### requirements.txt

| Package | Was | Now |
|---|---|---|
| qrcode | 7.3.1 | **8.0** |
| urtypes | 1.0.1 (PyPI) | **selfcustody/urtypes @ `7fb280e` (tag v0.1.0)** |
| embit, Pillow, pyzbar | — | unchanged (already match the OS) |

- **qrcode 7.3.1 → 8.0** matches buildroot's `python-qrcode`. Although
  it's a major bump, the app's full API surface in `helpers/qr.py`
  (`QRCode`, `ERROR_CORRECT_L`, `StyledPilImage`, the module drawers)
  was verified working under 8.0 — and devices already run it.
- **urtypes 1.0.1 → v0.1.0 commit pin** is a *downgrade*: dev
  environments were ahead of the hardware. The OS builds
  `selfcustody/urtypes` tag `v0.1.0` from GitHub, and PyPI only
  publishes 1.0.0/1.0.1, so matching exactly requires a git commit
  pin (same style as the existing pyzbar entry). `7fb280e` is the
  commit the OS's `v0.1.0` tag resolves to.
- The pyzbar commit pin was verified identical to the OS's
  `v0.1.9-ss` tag, and embit 0.8.0 / Pillow 10.3.0 already match, so
  those entries are untouched.

### requirements-raspi.txt

| Package | Was | Now |
|---|---|---|
| numpy | 1.25.2 | **1.25.0** |
| RPi.GPIO | 0.7.0 | **0.7.1** |
| spidev | 3.5 | **3.6** |
| picamera | — | unchanged (already matches at 1.13) |

numpy is another ahead-of-hardware downgrade; RPi.GPIO and spidev
catch up to the buildroot pins. All three target versions were
confirmed available on PyPI.

## Testing

- qrcode 8.0 + urtypes v0.1.0 pins install cleanly from this file and
  import; the qrcode calls used by `helpers/qr.py` were exercised
  directly under 8.0.
- The raspi entries are Pi-hardware-bound and can't be meaningfully
  exercised off-device, but they are byte-for-byte the versions every
  shipped image installs via buildroot.


---

This pull request is categorized as a:
- [x] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.