### PR TITLE
[security] Hash-lock the l10n requirements pins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,13 @@ jobs:
         run: |
           sudo apt-get install libzbar0
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r tests/requirements.txt -r l10n/requirements-l10n.txt
+          pip install -r requirements.txt -r tests/requirements.txt
+          # requirements-l10n.txt is hash-locked (SeedSigner OS installs it
+          # during image builds). It needs its own pip invocation: one hashed
+          # requirement makes pip demand hashes for everything else in the
+          # same invocation, which the unhashed files above and `-e .` below
+          # can't satisfy.
+          pip install -r l10n/requirements-l10n.txt
           pip install -e .
       - name: Compile translations
         run: python setup.py compile_catalog

--- a/l10n/requirements-l10n.txt
+++ b/l10n/requirements-l10n.txt
@@ -1,2 +1,19 @@
-Babel==2.16.0
-setuptools>=82.0.0
+# Dependencies for the translation workflow (setup.py extract_messages /
+# compile_catalog). Also installed during SeedSigner OS image builds to
+# compile the .mo catalogs, so entries are pinned and hash-locked: pip
+# refuses any artifact that does not match a hash below. Hashes cover every
+# published file of each release (wheel + sdist).
+#
+# To update a pin: change the version, then refresh its hashes from
+# https://pypi.org/pypi/<package>/<version>/json (or pip download + pip hash).
+#
+# NOTE: install this file in its own `pip install` invocation. Combining it
+# with unhashed requirements files (or `-e .`) in one invocation fails,
+# because any hash in an invocation makes pip require hashes for everything
+# in it.
+Babel==2.16.0 \
+    --hash=sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b \
+    --hash=sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
+setuptools==84.0.0 \
+    --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670 \
+    --hash=sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73


### PR DESCRIPTION
Description written by Claude, reviewed and edited by Keith:

## Motivation

`l10n/requirements-l10n.txt` is not just a dev convenience — SeedSigner
OS installs it during image builds to compile the .mo translation
catalogs. A version pin alone still trusts whatever artifact PyPI
serves for that version; recording sha256 hashes makes pip verify
every downloaded file against digests audited here, so a tampered
artifact fails the install instead of entering the build. This is
part of a broader effort on the seedsigner-os side to make every
network install in the image build pipeline pinned and hash-verified.

## Changes

**Commit 1** hash-locks the l10n pins:

- **Babel** stays at 2.16.0, now with sha256 hashes covering the full
  release (wheel + sdist), so installs work on any host.
- **setuptools** moves from `>=82.0.0` to `==84.0.0` — hash-checking
  mode rejects range specifiers. 84.0.0 is what the floor resolves to
  today, and `compile_catalog` was verified working under it.
- Neither package pulls transitive dependencies on Python ≥ 3.10, so
  these two entries are the complete set pip needs.
- The file header records how to refresh a hash when bumping a pin.

**Commit 2** splits CI's dependency install (`tests.yml`):

pip enables hash-checking for an entire invocation the moment any
requirement in it carries a hash, then demands hashes for everything
else installed alongside. The combined line mixed this file with two
unhashed files and an editable install, so it would fail — and
`requirements.txt` can't simply join hash mode while it carries
git-pinned entries, which hash-checking rejects outright. The l10n
install now runs in its own invocation (with a comment explaining
why), keeping its hashes enforced while the other files continue to
install unhashed.

## Testing

- `pip install --require-hashes -r l10n/requirements-l10n.txt` into a
  fresh venv succeeds and installs exactly Babel 2.16.0 +
  setuptools 84.0.0.
- `python setup.py compile_catalog` was run against that venv and
  compiled all locale catalogs.

## Notes for reviewers

- CI is red at commit 1 in isolation (the split lands in commit 2);
  only bisectability at that one commit is affected.
- Follow-up on the seedsigner-os side: once this lands on `dev`, its
  build script's l10n install gains an explicit `--require-hashes` so
  the image build fails closed if this file ever regresses to
  unhashed pins.

## Additional info
Responsibly disclosed by @asafmod

---

This pull request is categorized as a:
- [x] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR

Also verified that the `extract_messages` and `compile_catalog` steps worked as expected.

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.