### PR TITLE
Skip inactive letters on seed entry when navigating

### DIFF
--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -362,65 +362,134 @@ class Keyboard:
         return None
 
 
-    def get_key_above(self, cur_x, cur_y):
-        next_y = cur_y - 1
-        # Track if we've wrapped to avoid infinite loop when skipping inactive keys
-        has_wrapped = False
-        start_y = cur_y
+    def _key_is_usable(self, key) -> bool:
+        """Active letter keys and always-on additional keys (e.g. backspace) are usable."""
+        return key is not None and (key.is_active or key.is_additional_key)
 
-        while True:
-            if next_y < 0:
-                # We started from the top row; auto_wrap or exit.
-                if Keyboard.WRAP_TOP in self.auto_wrap:
-                    # Loop it back to the bottom
-                    next_y = len(self.keys) - 1
-                    if has_wrapped:
-                        # Already wrapped once; no active key found in this column
-                        return (cur_x, cur_y, Keyboard.EXIT_TOP)
-                    has_wrapped = True
-                else:
-                    # Undo selection change and notify controlling loop that we've left
-                    #   the keyboard
-                    return (cur_x, cur_y, Keyboard.EXIT_TOP)
 
-            target_key = self.get_key_at(cur_x, next_y)
-            if target_key and (target_key.is_active or target_key.is_additional_key):
-                return (cur_x, next_y, None)
+    def _nearest_usable_key_in_row(self, row_y: int, prefer_x: int):
+        """
+        Return the usable key in row_y whose horizontal span is closest to prefer_x.
+        Distance is 0 if prefer_x falls inside the key's [index_x, index_x+size).
+        """
+        if row_y < 0 or row_y >= len(self.keys):
+            return None
+
+        best = None
+        best_dist = None
+        for key in self.keys[row_y]:
+            if not self._key_is_usable(key):
+                continue
+            start = key.index_x
+            end = key.index_x + key.size - 1
+            if prefer_x < start:
+                dist = start - prefer_x
+            elif prefer_x > end:
+                dist = prefer_x - end
             else:
-                # No match or inactive. Move up one more row.
-                next_y -= 1
-                if next_y == start_y and has_wrapped:
-                    # Full cycle with no active key
-                    return (cur_x, cur_y, Keyboard.EXIT_TOP)
+                dist = 0
+            if best is None or dist < best_dist:
+                best = key
+                best_dist = dist
+                if dist == 0:
+                    break
+        return best
+
+
+    def _ordered_keys_in_row(self, row_y: int):
+        """Keys in left-to-right visual order (already stored that way)."""
+        return list(self.keys[row_y])
+
+
+    def get_key_above(self, cur_x, cur_y):
+        """
+        Move up to the nearest usable key in a higher row (closest horizontally
+        to the current x). Skip empty/fully-inactive rows. Exit at the top edge
+        unless WRAP_TOP is enabled.
+        """
+        # Search upward row by row
+        for next_y in range(cur_y - 1, -1, -1):
+            key = self._nearest_usable_key_in_row(next_y, cur_x)
+            if key is not None:
+                return (key.index_x, next_y, None)
+
+        if Keyboard.WRAP_TOP in self.auto_wrap:
+            for next_y in range(len(self.keys) - 1, cur_y, -1):
+                key = self._nearest_usable_key_in_row(next_y, cur_x)
+                if key is not None:
+                    return (key.index_x, next_y, None)
+
+        return (cur_x, cur_y, Keyboard.EXIT_TOP)
 
 
     def get_key_below(self, cur_x, cur_y):
-        next_y = cur_y + 1
-        has_wrapped = False
-        start_y = cur_y
+        """
+        Move down to the nearest usable key in a lower row (closest horizontally
+        to the current x). Skip empty/fully-inactive rows. Exit at the bottom edge
+        unless WRAP_BOTTOM is enabled.
+        """
+        for next_y in range(cur_y + 1, len(self.keys)):
+            key = self._nearest_usable_key_in_row(next_y, cur_x)
+            if key is not None:
+                return (key.index_x, next_y, None)
 
-        while True:
-            if next_y == len(self.keys):
-                # We started from the bottom row; auto_wrap or exit.
-                if Keyboard.WRAP_BOTTOM in self.auto_wrap:
-                    # Loop it back to the top
-                    next_y = 0
-                    if has_wrapped:
-                        return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
-                    has_wrapped = True
-                else:
-                    # Undo selection change and notify controlling loop that we've left
-                    #   the keyboard
-                    return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
+        if Keyboard.WRAP_BOTTOM in self.auto_wrap:
+            for next_y in range(0, cur_y):
+                key = self._nearest_usable_key_in_row(next_y, cur_x)
+                if key is not None:
+                    return (key.index_x, next_y, None)
 
-            target_key = self.get_key_at(cur_x, next_y)
-            if target_key is not None and (target_key.is_active or target_key.is_additional_key):
-                return (cur_x, next_y, None)
+        return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
 
-            # No keys in this col in this row or inactive. Move down again and recheck.
-            next_y += 1
-            if next_y == start_y and has_wrapped:
-                return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
+
+    def _move_horizontal(self, direction: int):
+        """
+        direction: +1 = right, -1 = left.
+        Stay in the current row. Land on the next usable key in that direction.
+        Honor WRAP_LEFT / WRAP_RIGHT. If no other usable key exists in the row,
+        stay put (return None exit code path via no EXIT).
+        Returns EXIT_LEFT / EXIT_RIGHT if movement would leave the keyboard, else None.
+        """
+        row_y = self.selected_key["y"]
+        row_keys = self._ordered_keys_in_row(row_y)
+        if not row_keys:
+            return None
+
+        # Locate current key index within the row list
+        current = self.get_key_at(self.selected_key["x"], row_y)
+        try:
+            cur_i = row_keys.index(current) if current in row_keys else 0
+        except ValueError:
+            cur_i = 0
+
+        n = len(row_keys)
+        wrap = (
+            (direction > 0 and Keyboard.WRAP_RIGHT in self.auto_wrap)
+            or (direction < 0 and Keyboard.WRAP_LEFT in self.auto_wrap)
+        )
+
+        for step in range(1, n + 1):
+            i = cur_i + direction * step
+            if i < 0 or i >= n:
+                if not wrap:
+                    # Would leave the row / keyboard edge
+                    if direction > 0:
+                        return Keyboard.EXIT_RIGHT
+                    return Keyboard.EXIT_LEFT
+                i = i % n
+
+            candidate = row_keys[i]
+            if self._key_is_usable(candidate):
+                self.selected_key["x"] = candidate.index_x
+                self.selected_key["y"] = row_y
+                return None
+
+            # If we've wrapped all the way around back to current, stop
+            if i == cur_i:
+                break
+
+        # No other usable key — stay on current selection
+        return None
 
 
     def update_from_input(self, input):
@@ -441,68 +510,14 @@ class Keyboard:
         key.render_key()
 
         if input == HardwareButtonsConstants.KEY_RIGHT:
-            # Keep moving right, skipping over inactive (grayed-out) keys
-            start_x = self.selected_key["x"]
-            start_y = self.selected_key["y"]
-            while True:
-                self.selected_key["x"] = key.index_x + key.size
-                new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
-                if new_key is None:
-                    if Keyboard.WRAP_RIGHT in self.auto_wrap:
-                        # Loop it back to the left side
-                        self.selected_key["x"] = 0
-                        new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
-                    else:
-                        # Undo selection change and notify controlling loop that we've left
-                        #   the keyboard
-                        self.selected_key["x"] = start_x
-                        return Keyboard.EXIT_RIGHT
-
-                if new_key is None:
-                    # Should not happen, but safety
-                    self.selected_key["x"] = start_x
-                    return Keyboard.EXIT_RIGHT
-
-                if new_key.is_active or new_key.is_additional_key:
-                    # Found a usable key
-                    break
-
-                # Inactive key; continue from here
-                key = new_key
-                # Safety: if we wrapped all the way around without finding an active key
-                if self.selected_key["x"] == start_x and self.selected_key["y"] == start_y:
-                    # Stay on original (or could EXIT, but prefer stay)
-                    break
+            exit_code = self._move_horizontal(+1)
+            if exit_code:
+                return exit_code
 
         elif input == HardwareButtonsConstants.KEY_LEFT:
-            # Keep moving left, skipping over inactive (grayed-out) keys
-            start_x = self.selected_key["x"]
-            start_y = self.selected_key["y"]
-            while True:
-                key = self.get_selected_key()  # current before this step
-                self.selected_key["x"] = key.index_x - 1
-                if self.selected_key["x"] < 0:
-                    if Keyboard.WRAP_LEFT in self.auto_wrap:
-                        # Loop it back to the right side of the row
-                        self.selected_key["x"] = self.keys[self.selected_key["y"]][-1].index_x
-                    else:
-                        # Undo and exit
-                        self.selected_key["x"] = start_x
-                        return Keyboard.EXIT_LEFT
-
-                new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
-                if new_key is None:
-                    # Safety fallback
-                    self.selected_key["x"] = start_x
-                    return Keyboard.EXIT_LEFT
-
-                if new_key.is_active or new_key.is_additional_key:
-                    break
-
-                # Inactive; continue left from this key
-                key = new_key
-                if self.selected_key["x"] == start_x and self.selected_key["y"] == start_y:
-                    break
+            exit_code = self._move_horizontal(-1)
+            if exit_code:
+                return exit_code
 
         elif input == HardwareButtonsConstants.KEY_DOWN:
             new_index_x, new_index_y, keyboard_exit = self.get_key_below(self.selected_key["x"], self.selected_key["y"])
@@ -519,34 +534,63 @@ class Keyboard:
                 return keyboard_exit
 
         elif input == Keyboard.ENTER_LEFT:
-            # User has returned to the keyboard along the left edge
-            # Keep the last y position that was selected.
-            self.selected_key["x"] = 0
+            # User has returned to the keyboard along the left edge.
+            # Prefer a usable key near the left of the current row.
+            row_y = self.selected_key["y"]
+            key = self._nearest_usable_key_in_row(row_y, 0)
+            if key is not None:
+                self.selected_key["x"] = key.index_x
+            else:
+                self.selected_key["x"] = 0
 
         elif input == Keyboard.ENTER_RIGHT:
-            # User has returned to the keyboard along the right edge
-            # Keep the last y position that was selected.
-            self.selected_key["x"] = self.keys[self.selected_key["y"]][-1].index_x
+            # User has returned along the right edge — prefer usable key near the right.
+            row_y = self.selected_key["y"]
+            last_x = self.keys[row_y][-1].index_x
+            key = self._nearest_usable_key_in_row(row_y, last_x)
+            if key is not None:
+                self.selected_key["x"] = key.index_x
+            else:
+                self.selected_key["x"] = last_x
 
         elif input == Keyboard.ENTER_TOP:
-            # User has returned to the keyboard along the top edge
-            # Keep the last x position that was selected.
-            self.selected_key["y"] = 0
+            # Re-enter from top edge: topmost row with a usable key near last x.
+            prefer_x = self.selected_key["x"]
+            for y in range(0, len(self.keys)):
+                key = self._nearest_usable_key_in_row(y, prefer_x)
+                if key is not None:
+                    self.selected_key["x"] = key.index_x
+                    self.selected_key["y"] = y
+                    break
 
         elif input == Keyboard.ENTER_BOTTOM:
-            # User has returned to the keyboard along the bottom edge
-            # Keep the last x position that was selected.
-            self.selected_key["y"] = len(self.keys) - 1
-            while True:
-                key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
+            # Re-enter from bottom edge: bottommost row with a usable key near last x.
+            prefer_x = self.selected_key["x"]
+            for y in range(len(self.keys) - 1, -1, -1):
+                key = self._nearest_usable_key_in_row(y, prefer_x)
                 if key is not None:
+                    self.selected_key["x"] = key.index_x
+                    self.selected_key["y"] = y
                     break
-                else:
-                    # Can't enter here. Jump up a row
-                    self.selected_key["y"] -= 1
 
-        # Render the newly self.selected_key letter
+        # Render the newly selected key. If we somehow landed on a missing/inactive
+        # key, snap to the nearest usable key in this row (then any row).
         key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
+        if not self._key_is_usable(key):
+            key = self._nearest_usable_key_in_row(self.selected_key["y"], self.selected_key["x"])
+            if key is None:
+                for y, row in enumerate(self.keys):
+                    key = self._nearest_usable_key_in_row(y, self.selected_key["x"])
+                    if key is not None:
+                        self.selected_key["y"] = y
+                        break
+            if key is not None:
+                self.selected_key["x"] = key.index_x
+
+        if key is None:
+            # Should be unreachable if the charset has any keys
+            return None
+
         key.is_selected = True
         key.render_key()
 

--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -364,6 +364,9 @@ class Keyboard:
 
     def get_key_above(self, cur_x, cur_y):
         next_y = cur_y - 1
+        # Track if we've wrapped to avoid infinite loop when skipping inactive keys
+        has_wrapped = False
+        start_y = cur_y
 
         while True:
             if next_y < 0:
@@ -371,21 +374,30 @@ class Keyboard:
                 if Keyboard.WRAP_TOP in self.auto_wrap:
                     # Loop it back to the bottom
                     next_y = len(self.keys) - 1
+                    if has_wrapped:
+                        # Already wrapped once; no active key found in this column
+                        return (cur_x, cur_y, Keyboard.EXIT_TOP)
+                    has_wrapped = True
                 else:
                     # Undo selection change and notify controlling loop that we've left
                     #   the keyboard
                     return (cur_x, cur_y, Keyboard.EXIT_TOP)
 
             target_key = self.get_key_at(cur_x, next_y)
-            if target_key:
-                return(cur_x, next_y, None)
+            if target_key and (target_key.is_active or target_key.is_additional_key):
+                return (cur_x, next_y, None)
             else:
-                # No match was found. Move up one more row.
+                # No match or inactive. Move up one more row.
                 next_y -= 1
+                if next_y == start_y and has_wrapped:
+                    # Full cycle with no active key
+                    return (cur_x, cur_y, Keyboard.EXIT_TOP)
 
 
     def get_key_below(self, cur_x, cur_y):
         next_y = cur_y + 1
+        has_wrapped = False
+        start_y = cur_y
 
         while True:
             if next_y == len(self.keys):
@@ -393,18 +405,22 @@ class Keyboard:
                 if Keyboard.WRAP_BOTTOM in self.auto_wrap:
                     # Loop it back to the top
                     next_y = 0
-                    return (cur_x, next_y, None)
+                    if has_wrapped:
+                        return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
+                    has_wrapped = True
                 else:
                     # Undo selection change and notify controlling loop that we've left
                     #   the keyboard
                     return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
 
             target_key = self.get_key_at(cur_x, next_y)
-            if target_key is not None:
+            if target_key is not None and (target_key.is_active or target_key.is_additional_key):
                 return (cur_x, next_y, None)
 
-            # No keys in this col in this row. Move down again and recheck.
+            # No keys in this col in this row or inactive. Move down again and recheck.
             next_y += 1
+            if next_y == start_y and has_wrapped:
+                return (cur_x, cur_y, Keyboard.EXIT_BOTTOM)
 
 
     def update_from_input(self, input):
@@ -425,30 +441,68 @@ class Keyboard:
         key.render_key()
 
         if input == HardwareButtonsConstants.KEY_RIGHT:
-            self.selected_key["x"] = key.index_x + key.size
-            new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
-            if new_key is None:
-                if Keyboard.WRAP_RIGHT in self.auto_wrap:
-                    # Loop it back to the right side
-                    self.selected_key["x"] = 0
-                else:
-                    # Undo selection change and notify controlling loop that we've left
-                    #   the keyboard
-                    self.selected_key["x"] -= 1
+            # Keep moving right, skipping over inactive (grayed-out) keys
+            start_x = self.selected_key["x"]
+            start_y = self.selected_key["y"]
+            while True:
+                self.selected_key["x"] = key.index_x + key.size
+                new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
+                if new_key is None:
+                    if Keyboard.WRAP_RIGHT in self.auto_wrap:
+                        # Loop it back to the left side
+                        self.selected_key["x"] = 0
+                        new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
+                    else:
+                        # Undo selection change and notify controlling loop that we've left
+                        #   the keyboard
+                        self.selected_key["x"] = start_x
+                        return Keyboard.EXIT_RIGHT
+
+                if new_key is None:
+                    # Should not happen, but safety
+                    self.selected_key["x"] = start_x
                     return Keyboard.EXIT_RIGHT
 
+                if new_key.is_active or new_key.is_additional_key:
+                    # Found a usable key
+                    break
+
+                # Inactive key; continue from here
+                key = new_key
+                # Safety: if we wrapped all the way around without finding an active key
+                if self.selected_key["x"] == start_x and self.selected_key["y"] == start_y:
+                    # Stay on original (or could EXIT, but prefer stay)
+                    break
+
         elif input == HardwareButtonsConstants.KEY_LEFT:
-            key = self.get_selected_key()
-            self.selected_key["x"] = key.index_x - 1
-            if self.selected_key["x"] < 0:
-                if Keyboard.WRAP_LEFT in self.auto_wrap:
-                    # Loop it back to the left side
-                    self.selected_key["x"] = self.keys[self.selected_key["y"]][-1].index_x
-                else:
-                    # Undo selection change and notify controlling loop that we've left
-                    #   the keyboard
-                    self.selected_key["x"] += 1
+            # Keep moving left, skipping over inactive (grayed-out) keys
+            start_x = self.selected_key["x"]
+            start_y = self.selected_key["y"]
+            while True:
+                key = self.get_selected_key()  # current before this step
+                self.selected_key["x"] = key.index_x - 1
+                if self.selected_key["x"] < 0:
+                    if Keyboard.WRAP_LEFT in self.auto_wrap:
+                        # Loop it back to the right side of the row
+                        self.selected_key["x"] = self.keys[self.selected_key["y"]][-1].index_x
+                    else:
+                        # Undo and exit
+                        self.selected_key["x"] = start_x
+                        return Keyboard.EXIT_LEFT
+
+                new_key = self.get_key_at(self.selected_key["x"], self.selected_key["y"])
+                if new_key is None:
+                    # Safety fallback
+                    self.selected_key["x"] = start_x
                     return Keyboard.EXIT_LEFT
+
+                if new_key.is_active or new_key.is_additional_key:
+                    break
+
+                # Inactive; continue left from this key
+                key = new_key
+                if self.selected_key["x"] == start_x and self.selected_key["y"] == start_y:
+                    break
 
         elif input == HardwareButtonsConstants.KEY_DOWN:
             new_index_x, new_index_y, keyboard_exit = self.get_key_below(self.selected_key["x"], self.selected_key["y"])

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for Keyboard navigation, including skip-over-inactive (grayed-out) keys.
+
+These tests exercise the pure navigation logic with a small in-memory keyboard and
+do not require Raspberry Pi hardware.
+"""
+from unittest.mock import patch
+
+from PIL import Image, ImageDraw, ImageFont
+
+# Must import test base before most SeedSigner modules (mocks hardware deps).
+from base import BaseTest
+
+from seedsigner.gui.keyboard import Keyboard
+from seedsigner.hardware.buttons import HardwareButtonsConstants
+
+
+def _dummy_font(*args, **kwargs):
+    """Avoid depending on packaged .ttf/.otf paths in CI/dev machines."""
+    return ImageFont.load_default()
+
+
+class TestKeyboardNavigation(BaseTest):
+    """
+    Layout under test (3x3 letter grid, no additional keys for clarity):
+
+        a b c
+        d e f
+        g h i
+
+    After deactivating b, e, h (middle column), usable keys are:
+        a   c
+        d   f
+        g   i
+    """
+
+    def _make_keyboard(self, charset="abcdefghi", selected="e", rows=3, cols=3):
+        image = Image.new("RGB", (240, 240), "black")
+        draw = ImageDraw.Draw(image)
+        with patch("seedsigner.gui.keyboard.Fonts.get_font", side_effect=_dummy_font):
+            kb = Keyboard(
+                draw=draw,
+                charset=charset,
+                selected_char=selected,
+                rows=rows,
+                cols=cols,
+                rect=(0, 0, 240, 240),
+                additional_keys=[],
+                auto_wrap=[Keyboard.WRAP_LEFT, Keyboard.WRAP_RIGHT],
+                render_now=True,
+            )
+        return kb
+
+    def _code(self, kb) -> str:
+        return kb.get_selected_key().code
+
+    def _usable(self, kb) -> bool:
+        key = kb.get_selected_key()
+        return key is not None and (key.is_active or key.is_additional_key)
+
+    def test_right_skips_inactive_in_same_row(self):
+        kb = self._make_keyboard(selected="a")
+        # Deactivate b so a → right should land on c
+        kb.update_active_keys(active_keys=list("acdefghi"))  # no b
+        kb.render_keys()
+
+        kb.set_selected_key("a")
+        result = kb.update_from_input(HardwareButtonsConstants.KEY_RIGHT)
+
+        assert result == "c"
+        assert self._code(kb) == "c"
+        assert self._usable(kb)
+
+    def test_left_skips_inactive_in_same_row(self):
+        kb = self._make_keyboard(selected="c")
+        kb.update_active_keys(active_keys=list("acdefghi"))  # no b
+        kb.render_keys()
+
+        kb.set_selected_key("c")
+        result = kb.update_from_input(HardwareButtonsConstants.KEY_LEFT)
+
+        assert result == "a"
+        assert self._code(kb) == "a"
+        assert self._usable(kb)
+
+    def test_down_goes_to_nearest_usable_not_strict_column(self):
+        """
+        From 'b' (inactive neighbors in column), with middle column deactivated,
+        down from 'a' should reach a usable key in a lower row near that x —
+        e.g. 'd' (not jump unpredictably or exit).
+        """
+        kb = self._make_keyboard(selected="a")
+        # Deactivate entire middle column: b, e, h
+        kb.update_active_keys(active_keys=list("acdfgi"))
+        kb.render_keys()
+
+        kb.set_selected_key("a")
+        result = kb.update_from_input(HardwareButtonsConstants.KEY_DOWN)
+
+        assert result not in Keyboard.EXIT_DIRECTIONS
+        assert self._usable(kb)
+        # Nearest usable in the next row to column of 'a' (x=0) is 'd'
+        assert self._code(kb) == "d"
+
+    def test_up_goes_to_nearest_usable(self):
+        kb = self._make_keyboard(selected="g")
+        kb.update_active_keys(active_keys=list("acdfgi"))  # no b,e,h
+        kb.render_keys()
+
+        kb.set_selected_key("g")
+        result = kb.update_from_input(HardwareButtonsConstants.KEY_UP)
+
+        assert result not in Keyboard.EXIT_DIRECTIONS
+        assert self._usable(kb)
+        assert self._code(kb) == "d"
+
+    def test_never_lands_on_inactive_key(self):
+        kb = self._make_keyboard(selected="a")
+        # Only corners active
+        kb.update_active_keys(active_keys=list("acgi"))
+        kb.render_keys()
+
+        kb.set_selected_key("a")
+        path = ["a"]
+        # Crawl around the keyboard; every stop must be usable
+        for direction in [
+            HardwareButtonsConstants.KEY_RIGHT,
+            HardwareButtonsConstants.KEY_DOWN,
+            HardwareButtonsConstants.KEY_LEFT,
+            HardwareButtonsConstants.KEY_UP,
+            HardwareButtonsConstants.KEY_RIGHT,
+            HardwareButtonsConstants.KEY_RIGHT,
+            HardwareButtonsConstants.KEY_DOWN,
+            HardwareButtonsConstants.KEY_LEFT,
+        ]:
+            ret = kb.update_from_input(direction)
+            if ret in Keyboard.EXIT_DIRECTIONS:
+                # Re-enter from the opposite edge if we exited
+                if ret == Keyboard.EXIT_TOP:
+                    kb.update_from_input(Keyboard.ENTER_TOP)
+                elif ret == Keyboard.EXIT_BOTTOM:
+                    kb.update_from_input(Keyboard.ENTER_BOTTOM)
+                elif ret == Keyboard.EXIT_LEFT:
+                    kb.update_from_input(Keyboard.ENTER_LEFT)
+                elif ret == Keyboard.EXIT_RIGHT:
+                    kb.update_from_input(Keyboard.ENTER_RIGHT)
+            assert self._usable(kb), f"Landed on unusable key after {direction}; path={path}"
+            path.append(self._code(kb))
+
+    def test_wrap_right_to_left_within_row_skips_inactive(self):
+        kb = self._make_keyboard(selected="c")
+        # Row 0: a b c — deactivate a so wrapping from c goes... only c is active
+        # in that row if a and b inactive; stay or wrap to only usable.
+        kb.update_active_keys(active_keys=list("cdefghi"))  # no a, b
+        kb.render_keys()
+
+        kb.set_selected_key("c")
+        # Right from c with WRAP_RIGHT should wrap; a and b inactive → only c in row
+        # so we stay on c (no other usable in row after full scan)
+        result = kb.update_from_input(HardwareButtonsConstants.KEY_RIGHT)
+        assert result not in Keyboard.EXIT_DIRECTIONS
+        assert self._code(kb) == "c"
+        assert self._usable(kb)
+
+    def test_active_neighbor_still_one_step(self):
+        """With all keys active, right from a is still b (no over-skip)."""
+        kb = self._make_keyboard(selected="a")
+        kb.update_active_keys(active_keys=list("abcdefghi"))
+        kb.render_keys()
+
+        kb.set_selected_key("a")
+        result = kb.update_from_input(HardwareButtonsConstants.KEY_RIGHT)
+        assert result == "b"
+        assert self._code(kb) == "b"


### PR DESCRIPTION
## AI Disclosure:

I used Grok to generate the code and assist with the tests. I have verified that it works as intended on a home-made Seedsigner.

## Description

Navigating the letters is frustrating as it doesn't ignore the un-selectable letters.

### Solution

The python file has been updated so that navigation works more intelligently and skips over un-selectable letters.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included a video of the new functionality

https://github.com/user-attachments/assets/5fadf75e-56f5-4bfc-a041-32f7858d1715

Should be part of the PR description above.
- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.