### PR TITLE
Add Seed XOR rebuild flow (issue #738)

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -240,7 +240,7 @@ class Controller(Singleton):
         parts = self.storage.rebuild_seedxor_parts
         if 0 <= index < len(parts):
             parts.pop(index)
-            self.storage.rebuild_seedxor_combined_seed = None
+            self.storage.clear_rebuild_seedxor_combined_seed()
 
     def clear_rebuild_seedxor_data(self):
         self.storage.clear_rebuild_seedxor_data()

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -11,6 +11,7 @@ from PIL.Image import Image
 from seedsigner.gui.toast import BaseToastOverlayManagerThread
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.seed import Seed
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
 from seedsigner.models.seed_storage import SeedStorage
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings import SettingsConstants
@@ -133,6 +134,7 @@ class Controller(Singleton):
     FLOW__VERIFY_SINGLESIG_ADDR = "singlesig_addr"
     FLOW__ADDRESS_EXPLORER = "address_explorer"
     FLOW__SIGN_MESSAGE = "sign_message"
+    FLOW__REBUILD_SEEDXOR = "rebuild_seedxor"
     resume_main_flow: str = None
 
     back_stack: BackStack = None
@@ -221,6 +223,23 @@ class Controller(Singleton):
         self.storage.seeds.remove(seed)
 
 
+    def process_rebuild_seedxor_part(self, new_part_seed: Seed):
+        is_valid, error_dict = SeedXORValidator.validate_part(new_part_seed, self.storage.rebuild_seedxor_parts)
+        if not is_valid:
+            return error_dict
+        self.storage.add_rebuild_seedxor_part(new_part_seed)
+        return None
+
+    def remove_rebuild_seedxor_part(self, index: int):
+        parts = self.storage.rebuild_seedxor_parts
+        if 0 <= index < len(parts):
+            parts.pop(index)
+            self.storage.rebuild_seedxor_combined_seed = None
+
+    def clear_rebuild_seedxor_data(self):
+        self.storage.clear_rebuild_seedxor_data()
+
+
     def pop_prev_from_back_stack(self):
         if len(self.back_stack) > 0:
             # Pop the top View (which is the current View_cls)
@@ -303,6 +322,9 @@ class Controller(Singleton):
                     self.psbt = None
                     self.psbt_parser = None
                     self.psbt_seed = None
+                    # In-progress Seed XOR rebuild data is ephemeral; only the finalized
+                    #   combined Seed is kept (via finalize_pending_seed).
+                    self.clear_rebuild_seedxor_data()
                 
                 logger.info(f"\nback_stack: {self.back_stack}")
 

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -220,7 +220,13 @@ class Controller(Singleton):
 
 
     def discard_seed(self, seed: Seed):
-        self.storage.seeds.remove(seed)
+        # Remove by identity, not equality. Seed.__eq__ compares seed_bytes, so a
+        # value-based list.remove(seed) could delete a distinct pre-existing Seed
+        # object that merely shares the same mnemonic (see SeedXOR discard path).
+        for i, s in enumerate(self.storage.seeds):
+            if s is seed:
+                self.storage.seeds.pop(i)
+                return
 
 
     def process_rebuild_seedxor_part(self, new_part_seed: Seed):

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -203,7 +203,7 @@ class SeedSignerIconConstants:
     CHEVRON_LEFT = "\ue909"
     CHEVRON_RIGHT = "\ue90a"
     CHEVRON_UP = "\ue90b"
-    # CLOSE = "\ue90c"  # Unused icons
+    CLOSE = "\ue90c"
     # PAGE_DOWN = "\ue90d"
     # PAGE_UP = "\ue90e"
     PLUS = "\ue90f"

--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -110,3 +110,45 @@ def get_partial_final_word(coin_flips: str, wordlist_language_code: str = Settin
     wordlist_index = int(binary_string, 2)
 
     return Seed.get_wordlist(wordlist_language_code)[wordlist_index]
+
+
+
+def combine_mnemonics_with_xor(mnemonics: list, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
+    """
+    Combine multiple BIP39 mnemonic seed phrases using XOR (SeedXOR).
+
+    XORs the entropy bytes of each mnemonic together. XOR-ing the parts back
+    together reproduces the original seed phrase.
+
+    Args:
+        mnemonics: List of mnemonic seed phrases (strings or lists of words).
+        wordlist_language_code: Language code for the BIP39 wordlist (default: English).
+
+    Returns:
+        The combined mnemonic as a list of words.
+
+    Raises:
+        ValueError: If the list is empty, contains an invalid mnemonic, or the
+            mnemonics have different entropy lengths.
+    """
+    if not mnemonics:
+        raise ValueError("Mnemonic list cannot be empty")
+
+    wordlist = Seed.get_wordlist(wordlist_language_code)
+
+    try:
+        entropy_list = [
+            bip39.mnemonic_to_bytes(" ".join(mnemonic) if isinstance(mnemonic, list) else mnemonic, wordlist=wordlist)
+            for mnemonic in mnemonics
+        ]
+    except Exception as e:
+        raise ValueError(f"Invalid mnemonic: {str(e)}")
+
+    if len(set(len(entropy) for entropy in entropy_list)) != 1:
+        raise ValueError("All mnemonics must generate entropy of the same length")
+
+    combined_entropy = bytes(len(entropy_list[0]))
+    for entropy in entropy_list:
+        combined_entropy = bytes(a ^ b for a, b in zip(combined_entropy, entropy))
+
+    return bip39.mnemonic_from_bytes(combined_entropy, wordlist=wordlist).split()

--- a/src/seedsigner/helpers/seed_xor_validator.py
+++ b/src/seedsigner/helpers/seed_xor_validator.py
@@ -35,10 +35,25 @@ class SeedXORValidator:
                 }
 
         # Check for inverse parts (which would cancel out)
-        new_entropy = bip39.mnemonic_to_bytes(new_part.mnemonic_str)
+        # Pass the Seed's wordlist explicitly — bip39.mnemonic_to_bytes defaults to
+        #   English, which would fail on a non-English-wordlist Seed.  Wrap in
+        #   try/except so a wordlist mismatch produces a clean error instead of an
+        #   unhandled exception in the fingerprint view.
+        try:
+            new_entropy = bip39.mnemonic_to_bytes(new_part.mnemonic_str, wordlist=new_part.wordlist)
+        except Exception:
+            return False, {
+                "title": "Invalid Part",
+                "status_headline": "Invalid Part",
+                "message": "Could not parse this seed's mnemonic.",
+            }
+
         for i, part in enumerate(existing_parts):
             if len(new_part.mnemonic_list) == len(part.mnemonic_list):
-                existing_entropy = bip39.mnemonic_to_bytes(part.mnemonic_str)
+                try:
+                    existing_entropy = bip39.mnemonic_to_bytes(part.mnemonic_str, wordlist=part.wordlist)
+                except Exception:
+                    continue
                 xored = bytes(a ^ b for a, b in zip(new_entropy, existing_entropy))
                 if all(b == 0xFF for b in xored):
                     return False, {
@@ -46,5 +61,38 @@ class SeedXORValidator:
                         "status_headline": "Invalid Part",
                         "message": "This part is the binary inverse of part #{}. XORing them produces a known all-ones seed with no entropy.".format(i + 1),
                     }
+
+        return True, None
+
+    @classmethod
+    def validate_combined_seed(cls, combined_seed: Seed) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        """Validates the combined XOR result for degenerate cases.
+
+        With 3+ colluding parts the XOR can produce all-zero or all-one entropy,
+        which are known, worthless seeds that pass the BIP39 checksum.
+        Returns (is_valid, error_dict).
+        """
+        try:
+            entropy = bip39.mnemonic_to_bytes(combined_seed.mnemonic_str, wordlist=combined_seed.wordlist)
+        except Exception:
+            return False, {
+                "title": "XOR Error",
+                "status_headline": "Invalid Combined Seed",
+                "message": "Could not parse the combined seed's mnemonic.",
+            }
+
+        if all(b == 0x00 for b in entropy):
+            return False, {
+                "title": "Zero Entropy Result",
+                "status_headline": "Invalid Combined Seed",
+                "message": "XORing these parts produces all-zero entropy (the 'abandon...about' seed). The result is a known, worthless seed.",
+            }
+
+        if all(b == 0xFF for b in entropy):
+            return False, {
+                "title": "Known Seed Result",
+                "status_headline": "Invalid Combined Seed",
+                "message": "XORing these parts produces a known all-ones seed with no entropy.",
+            }
 
         return True, None

--- a/src/seedsigner/helpers/seed_xor_validator.py
+++ b/src/seedsigner/helpers/seed_xor_validator.py
@@ -44,7 +44,7 @@ class SeedXORValidator:
                     return False, {
                         "title": "Seed Inversion",
                         "status_headline": "Invalid Part",
-                        "message": "This part is the binary inverse of part #{} and would cancel it out.".format(i + 1),
+                        "message": "This part is the binary inverse of part #{}. XORing them produces a known all-ones seed with no entropy.".format(i + 1),
                     }
 
         return True, None

--- a/src/seedsigner/helpers/seed_xor_validator.py
+++ b/src/seedsigner/helpers/seed_xor_validator.py
@@ -1,0 +1,50 @@
+from typing import List, Tuple, Optional, Dict, Any
+from embit import bip39
+from seedsigner.models.seed import Seed
+
+
+class SeedXORValidator:
+    """Validates parts for SeedXOR operations."""
+
+    @classmethod
+    def validate_part(cls, new_part: Seed, existing_parts: List[Seed]) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        """Validates a new part against existing parts.
+        Returns (is_valid, error_dict)."""
+        if new_part.has_passphrase:
+            return False, {
+                "title": "Passphrase Not Allowed",
+                "status_headline": "Invalid Part",
+                "message": "You may not XOR a seed that has passphrase.",
+            }
+
+        # Check mnemonic length consistency
+        if existing_parts and len(new_part.mnemonic_list) != len(existing_parts[0].mnemonic_list):
+            return False, {
+                "title": "Mnemonic Length Mismatch",
+                "status_headline": "Invalid Part",
+                "message": "XOR requires seeds of similar mnemonic length!"
+            }
+
+        # Check for duplicate parts
+        for i, part in enumerate(existing_parts):
+            if new_part.mnemonic_str == part.mnemonic_str:
+                return False, {
+                    "title": "Duplicate Part",
+                    "status_headline": "Duplicate Part",
+                    "message": "This part is identical to part #{}".format(i + 1),
+                }
+
+        # Check for inverse parts (which would cancel out)
+        new_entropy = bip39.mnemonic_to_bytes(new_part.mnemonic_str)
+        for i, part in enumerate(existing_parts):
+            if len(new_part.mnemonic_list) == len(part.mnemonic_list):
+                existing_entropy = bip39.mnemonic_to_bytes(part.mnemonic_str)
+                xored = bytes(a ^ b for a, b in zip(new_entropy, existing_entropy))
+                if all(b == 0xFF for b in xored):
+                    return False, {
+                        "title": "Seed Inversion",
+                        "status_headline": "Invalid Part",
+                        "message": "This part is the binary inverse of part #{} and would cancel it out.".format(i + 1),
+                    }
+
+        return True, None

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -10,6 +10,8 @@ class SeedStorage:
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
         self._pending_is_electrum : bool = False
+        self.rebuild_seedxor_parts: List[Seed] = []
+        self.rebuild_seedxor_combined_seed: Seed = None
 
 
     def set_pending_seed(self, seed: Seed):
@@ -31,6 +33,15 @@ class SeedStorage:
 
     def clear_pending_seed(self):
         self.pending_seed = None
+
+
+    def add_rebuild_seedxor_part(self, seed: Seed):
+        self.rebuild_seedxor_parts.append(seed)
+        self.rebuild_seedxor_combined_seed = None
+
+    def clear_rebuild_seedxor_data(self):
+        self.rebuild_seedxor_parts = []
+        self.rebuild_seedxor_combined_seed = None
 
 
     def validate_mnemonic(self, mnemonic: List[str]) -> bool:

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -37,11 +37,20 @@ class SeedStorage:
 
     def add_rebuild_seedxor_part(self, seed: Seed):
         self.rebuild_seedxor_parts.append(seed)
+        self.clear_rebuild_seedxor_combined_seed()
+
+
+    def clear_rebuild_seedxor_combined_seed(self):
+        # Finalize stores the combined seed in both fields. Clear only this
+        # flow's pending seed, never an equal-but-distinct seed from elsewhere.
+        if self.pending_seed is self.rebuild_seedxor_combined_seed:
+            self.clear_pending_seed()
         self.rebuild_seedxor_combined_seed = None
 
+
     def clear_rebuild_seedxor_data(self):
+        self.clear_rebuild_seedxor_combined_seed()
         self.rebuild_seedxor_parts = []
-        self.rebuild_seedxor_combined_seed = None
 
 
     def validate_mnemonic(self, mnemonic: List[str]) -> bool:

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -346,6 +346,7 @@ class SettingsConstants:
     SETTING__CAMERA_ROTATION = "camera_rotation"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
+    SETTING__SEED_XOR = "seed_xor"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
@@ -664,6 +665,12 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,
                       abbreviated_name="bip85",
                       display_name=_mft("BIP-85 child seeds"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SEED_XOR,
+                      display_name=_mft("Seed XOR"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
 

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -79,10 +79,16 @@ class ScanView(View):
                     # Found a valid mnemonic seed! All new seeds should be considered
                     #   pending (might set a passphrase, SeedXOR, etc) until finalized.
                     from seedsigner.models.seed import Seed
-                    from .seed_views import SeedFinalizeView
-                    self.controller.storage.set_pending_seed(
-                        Seed(mnemonic=seed_mnemonic, wordlist_language_code=self.wordlist_language_code)
-                    )
+                    from .seed_views import SeedFinalizeView, RebuildSeedXORShowFingerprintView
+                    new_seed = Seed(mnemonic=seed_mnemonic, wordlist_language_code=self.wordlist_language_code)
+
+                    if getattr(self, "is_rebuild_seedxor_part", False):
+                        # The seed is not yet validated for the SeedXOR operation, so we
+                        #   just pass it to the next View as a pending_seed.
+                        self.controller.storage.set_pending_seed(new_seed)
+                        return Destination(RebuildSeedXORShowFingerprintView)
+
+                    self.controller.storage.set_pending_seed(new_seed)
                     if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) == SettingsConstants.OPTION__REQUIRED:
                         from seedsigner.views.seed_views import SeedAddPassphraseView
                         return Destination(SeedAddPassphraseView)
@@ -183,6 +189,10 @@ class ScanPSBTView(ScanView):
 class ScanSeedQRView(ScanView):
     instructions_text = _mft("Scan SeedQR")
     invalid_qr_type_message = _mft("Expected a SeedQR")
+
+    def __init__(self, is_rebuild_seedxor_part: bool = False):
+        super().__init__()
+        self.is_rebuild_seedxor_part = is_rebuild_seedxor_part
 
     @property
     def is_valid_qr_type(self):

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2678,7 +2678,6 @@ class RebuildSeedXORFinalizeOptionsView(View):
 
     DISCARD_PARTS = ButtonOption("Discard parts", button_label_color="red")
     KEEP_PARTS = ButtonOption("Keep parts")
-    PASSPHRASE = ButtonOption("BIP-39 Passphrase")
 
     def __init__(self):
         super().__init__()
@@ -2690,11 +2689,9 @@ class RebuildSeedXORFinalizeOptionsView(View):
         self.seed = self.controller.storage.pending_seed
 
     def run(self):
+        # Passphrases are rejected on XOR parts (see SeedXORValidator), so the
+        # combined seed is not offered one here either.
         button_data = [self.DISCARD_PARTS, self.KEEP_PARTS]
-
-        self.PASSPHRASE.button_label = self.seed.passphrase_label
-        if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) != SettingsConstants.OPTION__DISABLED:
-            button_data.append(self.PASSPHRASE)
 
         selected_menu_num = self.run_screen(
             LargeIconStatusScreen,
@@ -2732,6 +2729,3 @@ class RebuildSeedXORFinalizeOptionsView(View):
             self.controller.resume_main_flow = None
 
             return Destination(SeedOptionsView, view_args={"seed": combined_seed}, clear_history=True)
-
-        elif button_data[selected_menu_num] == self.PASSPHRASE:
-            return Destination(SeedAddPassphraseView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2734,10 +2734,13 @@ class RebuildSeedXORFinalizeOptionsView(View):
 
             # Discard the individual part seeds from storage by identity, keeping
             #   the combined seed. A part loaded via "Use loaded seed" is the same
-            #   object in both storage.seeds and rebuild_seedxor_parts.
+            #   object in both storage.seeds and rebuild_seedxor_parts. Typed or
+            #   scanned parts are distinct objects that never lived in
+            #   storage.seeds; they must NEVER match by value (Seed.__eq__ compares
+            #   seed_bytes), or a pre-existing user seed would be silently deleted.
             parts_to_discard = list(self.controller.storage.rebuild_seedxor_parts)
             for part in parts_to_discard:
-                if part is not combined_seed and part in self.controller.storage.seeds:
+                if part is not combined_seed and any(part is s for s in self.controller.storage.seeds):
                     self.controller.discard_seed(part)
 
             self.controller.clear_rebuild_seedxor_data()

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -214,6 +214,9 @@ class LoadSeedView(View):
             return Destination(ToolsMenuView)
 
         elif button_data[selected_menu_num] == self.REBUILD_SEED_XOR:
+            # Starting the SeedXOR rebuild flow; clear any stale resume flag from a
+            #   previously aborted flow so it cannot misroute this or a later flow.
+            self.controller.resume_main_flow = None
             return Destination(RebuildSeedXORManageView)
 
 
@@ -242,6 +245,11 @@ class SeedMnemonicEntryView(View):
             # 2. Backing out of the current word returns to the previous word.
             if self.cur_word_index == 0:
                 self.controller.storage.discard_pending_mnemonic()
+                from seedsigner.controller import Controller
+                if self.controller.resume_main_flow == Controller.FLOW__REBUILD_SEEDXOR:
+                    # Abandoning a SeedXOR part entry; disarm the flow flag so it
+                    #   cannot misroute a later unrelated seed load.
+                    self.controller.resume_main_flow = None
             return Destination(BackStackView)
         
         # ret will be our new mnemonic word
@@ -2394,6 +2402,10 @@ class RebuildSeedXORShowFingerprintView(View):
 
         if error_dict:
             self.controller.storage.clear_pending_seed()
+            # The seed-loading sub-flow is over (rejected); clear resume_main_flow
+            #   so a later unrelated SeedMnemonicEntryView is not misrouted back
+            #   into the SeedXOR flow.
+            self.controller.resume_main_flow = None
             return Destination(
                 ErrorView,
                 view_args=dict(

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2649,8 +2649,9 @@ class RebuildSeedXORFinalizeView(View):
 
         try:
             mnemonic_strings = [part.mnemonic_str for part in self.controller.storage.rebuild_seedxor_parts]
-            combined_mnemonic = combine_mnemonics_with_xor(mnemonic_strings)
-            seed = Seed(mnemonic=combined_mnemonic)
+            wordlist_language_code = self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE)
+            combined_mnemonic = combine_mnemonics_with_xor(mnemonic_strings, wordlist_language_code=wordlist_language_code)
+            seed = Seed(mnemonic=combined_mnemonic, wordlist_language_code=wordlist_language_code)
 
             # Check for degenerate XOR results (all-zero / all-ones entropy from
             #   colluding parts). These pass the BIP39 checksum but are worthless.

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3,21 +3,22 @@ import random
 import time
 
 from binascii import hexlify
-from gettext import gettext as _
+from gettext import gettext as _, ngettext
 
 from embit.descriptor import Descriptor
 
-from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
+from seedsigner.gui.components import GUIConstants, FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
-    WarningScreen, DireWarningScreen, seed_screens)
+    WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
 from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
-from seedsigner.views.view import NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView
+from seedsigner.views.view import NotYetImplementedView, OptionDisabledView, View, Destination, BackStackView, MainMenuView, ErrorView
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +166,7 @@ class LoadSeedView(View):
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
     CREATE = ButtonOption("Create a seed", SeedSignerIconConstants.PLUS)
+    REBUILD_SEED_XOR = ButtonOption("Rebuild SeedXOR", SeedSignerIconConstants.PLUS)
 
     def run(self):
         button_data = [
@@ -172,6 +174,9 @@ class LoadSeedView(View):
             self.TYPE_12WORD,
             self.TYPE_24WORD,
         ]
+
+        if self.settings.get_value(SettingsConstants.SETTING__SEED_XOR) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.REBUILD_SEED_XOR)
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
@@ -206,6 +211,9 @@ class LoadSeedView(View):
         elif button_data[selected_menu_num] == self.CREATE:
             from .tools_views import ToolsMenuView
             return Destination(ToolsMenuView)
+
+        elif button_data[selected_menu_num] == self.REBUILD_SEED_XOR:
+            return Destination(RebuildSeedXORManageView)
 
 
 
@@ -261,10 +269,15 @@ class SeedMnemonicEntryView(View):
         else:
             # Attempt to finalize the mnemonic
             from seedsigner.models.seed import InvalidSeedException
+            from seedsigner.controller import Controller
             try:
                 self.controller.storage.convert_pending_mnemonic_to_pending_seed()
             except InvalidSeedException:
                 return Destination(SeedMnemonicInvalidView)
+
+            if self.controller.resume_main_flow == Controller.FLOW__REBUILD_SEEDXOR:
+                # This mnemonic is a SeedXOR part; confirm its fingerprint next.
+                return Destination(RebuildSeedXORShowFingerprintView)
 
             return Destination(SeedFinalizeView)
 
@@ -2268,3 +2281,450 @@ class SeedSignMessageSignedMessageQRView(View):
 
         # Exiting/Canceling the QR display screen always returns Home
         return Destination(MainMenuView, skip_current_view=True)
+
+
+
+"""****************************************************************************
+    Rebuild Seed XOR Views
+****************************************************************************"""
+class RebuildSeedXORLoadPartView(View):
+    """View for loading a part in the Rebuild Seed XOR flow."""
+    SCAN_PART = ButtonOption("Scan SeedQR", SeedSignerIconConstants.QRCODE)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    USE_LOADED_SEED = ButtonOption("Use loaded seed", SeedSignerIconConstants.SEEDS)
+
+    def __init__(self):
+        super().__init__()
+        # Clear previous rebuild data when starting a new flow
+        if not self.controller.storage.rebuild_seedxor_parts:
+            self.controller.clear_rebuild_seedxor_data()
+
+    def run(self):
+        # Current part number is the count + 1
+        part_num = len(self.controller.storage.rebuild_seedxor_parts) + 1
+
+        button_data = [
+            self.SCAN_PART,
+            self.TYPE_12WORD,
+            self.TYPE_24WORD,
+        ]
+
+        # TRANSLATOR_NOTE: This is a screen title for loading a "part", which is one of
+        # several mnemonic seed phrases that will be combined. The variable is the
+        # part's number in the sequence (e.g., "Load Part #1").
+        title = _('Load Part #{}').format(part_num)
+
+        if len(self.controller.storage.seeds) > 0:
+            button_data.append(self.USE_LOADED_SEED)
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=title,
+            is_button_text_centered=False,
+            button_data=button_data
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORManageView, clear_history=True)
+
+
+        elif button_data[selected_menu_num] == self.SCAN_PART:
+            from seedsigner.views.scan_views import ScanSeedQRView
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(ScanSeedQRView, view_args={"is_rebuild_seedxor_part": True})
+
+        elif button_data[selected_menu_num] == self.TYPE_12WORD:
+            self.controller.storage.init_pending_mnemonic(num_words=12)
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(SeedMnemonicEntryView)
+
+        elif button_data[selected_menu_num] == self.TYPE_24WORD:
+            self.controller.storage.init_pending_mnemonic(num_words=24)
+            self.controller.resume_main_flow = self.controller.FLOW__REBUILD_SEEDXOR
+            return Destination(SeedMnemonicEntryView)
+
+        elif button_data[selected_menu_num] == self.USE_LOADED_SEED:
+            return Destination(RebuildSeedXORSelectExistingSeedView)
+
+
+
+class RebuildSeedXORShowFingerprintView(View):
+    """Show the fingerprint of the part being added to the Seed XOR."""
+
+    CONTINUE = ButtonOption("Continue")
+    CANCEL = ButtonOption("Discard part", button_label_color="red")
+
+    def __init__(self):
+        super().__init__()
+        self.seed = self.controller.storage.get_pending_seed()
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        self.fingerprint = self.seed.get_fingerprint(network=network)
+        self.next_part_num = len(self.controller.storage.rebuild_seedxor_parts) + 1
+
+    def run(self):
+        button_data = [self.CONTINUE, self.CANCEL]
+
+        # TRANSLATOR_NOTE: This is a screen title showing the number of a seed "part".
+        # A part is one of several seed phrases being combined. The "{}" will be
+        # replaced by the part's number (e.g., "Part #2").
+        title = _("Part #{}").format(self.next_part_num)
+
+        # TRANSLATOR_NOTE: This is a headline on a screen that displays a seed's
+        # "fingerprint", which is a short, unique identifier for a seed phrase.
+        status_headline = _("Part Fingerprint")
+
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=title,
+            status_icon_name=SeedSignerIconConstants.FINGERPRINT,
+            status_color=GUIConstants.BUTTON_FONT_COLOR,
+            status_headline=status_headline,
+            text=self.fingerprint,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON or button_data[selected_menu_num] == self.CANCEL:
+            self.controller.storage.clear_pending_seed()
+            return Destination(RebuildSeedXORLoadPartView)
+
+        error_dict = self.controller.process_rebuild_seedxor_part(self.seed)
+
+        if error_dict:
+            self.controller.storage.clear_pending_seed()
+            return Destination(
+                ErrorView,
+                view_args=dict(
+                    title=error_dict.get("title"),
+                    status_headline=error_dict.get("status_headline"),
+                    text=error_dict.get("message"),
+                    button_text=_("OK"),
+                    next_destination=Destination(RebuildSeedXORLoadPartView)
+                ),
+                skip_current_view=True
+            )
+
+        self.controller.storage.clear_pending_seed()
+        return Destination(RebuildSeedXORManageView)
+
+
+class RebuildSeedXORManageView(View):
+    """Main management screen for rebuild Seed XOR flow."""
+
+    LOAD_NEXT_PART = ButtonOption("Load Next Part", SeedSignerIconConstants.PLUS)
+    VIEW_LOADED_PARTS = ButtonOption("Loaded Parts", SeedSignerIconConstants.SEEDS)
+    REMOVE_PARTS = ButtonOption("Remove Part", SeedSignerIconConstants.CLOSE)
+    CANCEL = ButtonOption("Cancel Seed XOR", button_label_color="red")
+    FINALIZE = ButtonOption("Combine Parts", SeedSignerIconConstants.CHECK)
+
+    def __init__(self):
+        super().__init__()
+        self.num_parts = len(self.controller.storage.rebuild_seedxor_parts)
+
+    def run(self):
+        button_data = []
+
+        # Always show Load Next Part option
+        button_data.append(self.LOAD_NEXT_PART)
+
+        if self.num_parts > 0:
+            button_data.append(self.VIEW_LOADED_PARTS)
+            button_data.append(self.REMOVE_PARTS)
+            button_data.append(self.CANCEL)
+
+        # Only show Finalize if at least 2 parts are loaded
+        if self.num_parts >= 2:
+            button_data.insert(-1, self.FINALIZE)
+
+        # TRANSLATOR_NOTE: This is a screen title that displays the number of seed
+        # parts that have been loaded. The first argument is for the singular
+        # case (e.g., "1 Part Loaded"), and the second is for the plural
+        # (e.g., "2 Parts Loaded"). The "{}" will be replaced by the number of parts.
+        title = ngettext(
+            "{} Part Loaded",
+            "{} Parts Loaded",
+            self.num_parts
+        ).format(self.num_parts)
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=title,
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(LoadSeedView, clear_history=True)
+
+        elif button_data[selected_menu_num] == self.LOAD_NEXT_PART:
+            return Destination(RebuildSeedXORLoadPartView)
+
+        elif button_data[selected_menu_num] == self.VIEW_LOADED_PARTS:
+            return Destination(RebuildSeedXORViewPartsView)
+
+        elif button_data[selected_menu_num] == self.REMOVE_PARTS:
+            return Destination(RebuildSeedXORRemovePartsView)
+
+        elif button_data[selected_menu_num] == self.CANCEL:
+            return Destination(RebuildSeedXORCancelView)
+
+        elif button_data[selected_menu_num] == self.FINALIZE:
+            return Destination(RebuildSeedXORFinalizeView)
+
+
+class RebuildSeedXORSelectExistingSeedView(View):
+    """View for selecting an existing seed to use as a part."""
+
+    def __init__(self):
+        super().__init__()
+        self.seeds = self.controller.storage.seeds
+
+    def run(self):
+        button_data = []
+        for seed in self.seeds:
+            network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            fingerprint = seed.get_fingerprint(network=network)
+            # TRANSLATOR_NOTE: This is a button label for selecting a seed that is already
+            # loaded in the device's memory. The "{}" will be replaced by the seed's
+            # "fingerprint", a unique identifier (e.g., "Seed abcd1234").
+            button_data.append(ButtonOption("Seed {}".format(fingerprint)))
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Select Seed"),
+            is_button_text_centered=False,
+            button_data=button_data
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORLoadPartView)
+
+        selected_seed = self.seeds[selected_menu_num]
+        self.controller.storage.set_pending_seed(selected_seed)
+        return Destination(RebuildSeedXORShowFingerprintView)
+
+
+class RebuildSeedXORViewPartsView(View):
+    """View all loaded parts in the rebuild Seed XOR flow."""
+
+    def run(self):
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        parts_text = "\n".join(
+            "Part #{}: {}".format(i + 1, part.get_fingerprint(network=network))
+            for i, part in enumerate(self.controller.storage.rebuild_seedxor_parts)
+        )
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Loaded Parts"),
+            status_icon_name=SeedSignerIconConstants.SEEDS,
+            status_headline=None,
+            text=parts_text,
+            button_data=[ButtonOption(_("Done"))]
+        )
+
+        return Destination(RebuildSeedXORManageView)
+
+
+class RebuildSeedXORConfirmRemovePartView(View):
+    CONFIRM_REMOVE = ButtonOption("Remove part", button_label_color="red")
+    KEEP_PART = ButtonOption("Keep part")
+
+    def __init__(self, part_num: int):
+        super().__init__()
+        self.part_num = part_num
+        self.part = self.controller.storage.rebuild_seedxor_parts[part_num]
+
+    def run(self):
+        button_data = [self.KEEP_PART, self.CONFIRM_REMOVE]
+
+        fingerprint = self.part.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+
+        # TRANSLATOR_NOTE: Asks the user to confirm removing a specific part, identified by its number and fingerprint.
+        text = _("Remove part #{} ({}) from the Seed XOR build?").format(self.part_num + 1, fingerprint)
+
+        selected_menu_num = self.run_screen(
+            WarningScreen,
+            title=_("Remove Part?"),
+            status_headline=None,
+            text=text,
+            show_back_button=False,
+            button_data=button_data,
+        )
+
+        if button_data[selected_menu_num] == self.CONFIRM_REMOVE:
+            self.controller.remove_rebuild_seedxor_part(self.part_num)
+            return Destination(RebuildSeedXORManageView, clear_history=True)
+
+        elif button_data[selected_menu_num] == self.KEEP_PART:
+            return Destination(RebuildSeedXORRemovePartsView, skip_current_view=True)
+
+
+class RebuildSeedXORRemovePartsView(View):
+    """Select a part to remove from the rebuild Seed XOR flow."""
+
+    def run(self):
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        button_data = [
+            ButtonOption("Part #{}: {}".format(i + 1, part.get_fingerprint(network=network)))
+            for i, part in enumerate(self.controller.storage.rebuild_seedxor_parts)
+        ]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Remove Part"),
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORManageView)
+
+        return Destination(RebuildSeedXORConfirmRemovePartView, view_args={"part_num": selected_menu_num})
+
+
+class RebuildSeedXORCancelView(View):
+    """Confirm cancellation of rebuild Seed XOR flow."""
+
+    CONFIRM = ButtonOption("Confirm cancel", button_label_color="red")
+    CONTINUE = ButtonOption("Continue Seed XOR")
+
+    def run(self):
+        button_data = [self.CONTINUE, self.CONFIRM]
+
+        num_parts = len(self.controller.storage.rebuild_seedxor_parts)
+
+        # TRANSLATOR_NOTE: This is a confirmation message when canceling the Seed XOR rebuild process.
+        text = _(
+            "Clear all loaded parts and return to Home?"
+        )
+
+        # TRANSLATOR_NOTE: This is a confirmation message asking the user if they want
+        # to clear the seed "parts" they have loaded. The "{}" will be replaced by
+        # the number of parts (e.g., "Clear 2 loaded parts?").
+        status_headline = _("Clear {} loaded parts?".format(num_parts))
+
+        selected_menu_num = self.run_screen(
+            DireWarningScreen,
+            title=_("Cancel Seed XOR"),
+            status_headline=status_headline,
+            text=text,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON or button_data[selected_menu_num] == self.CONTINUE:
+            return Destination(RebuildSeedXORManageView)
+
+        elif button_data[selected_menu_num] == self.CONFIRM:
+            self.controller.clear_rebuild_seedxor_data()
+            return Destination(LoadSeedView, clear_history=True)
+
+
+class RebuildSeedXORFinalizeView(View):
+    """First step of final confirmation before finalizing the Rebuild Seed XOR seed."""
+
+    def __init__(self):
+        super().__init__()
+
+        self.error = None
+        self.fingerprint = None
+
+        try:
+            mnemonic_strings = [part.mnemonic_str for part in self.controller.storage.rebuild_seedxor_parts]
+            combined_mnemonic = combine_mnemonics_with_xor(mnemonic_strings)
+            seed = Seed(mnemonic=combined_mnemonic)
+            self.controller.storage.rebuild_seedxor_combined_seed = seed
+            self.controller.storage.set_pending_seed(seed)
+            self.fingerprint = seed.get_fingerprint(
+                network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            )
+        except Exception as e:
+            self.error = str(e)
+
+    def run(self):
+        if self.error:
+            return Destination(ErrorView, view_args=dict(
+                title=_("XOR Error"),
+                status_headline=_("Error Combining Seeds"),
+                text=self.error,
+                button_text=_("OK"),
+                next_destination=Destination(RebuildSeedXORManageView)
+            ))
+
+        part_count = len(self.controller.storage.rebuild_seedxor_parts)
+        button_data = [ButtonOption("Continue")]
+
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Finalize Seed XOR"),
+            status_headline=_("Combined {} parts".format(part_count)),
+            text=_("Fingerprint: {}\n\nCombined seed calculated successfully.".format(self.fingerprint)),
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORManageView)
+
+        return Destination(RebuildSeedXORFinalizeOptionsView)
+
+
+class RebuildSeedXORFinalizeOptionsView(View):
+    """Second step of finalization - choose what to do with individual parts"""
+
+    DISCARD_PARTS = ButtonOption("Discard parts", button_label_color="red")
+    KEEP_PARTS = ButtonOption("Keep parts")
+    PASSPHRASE = ButtonOption("BIP-39 Passphrase")
+
+    def __init__(self):
+        super().__init__()
+
+        if not self.controller.storage.rebuild_seedxor_combined_seed:
+            self.set_redirect(Destination(RebuildSeedXORManageView))
+            return
+
+        self.seed = self.controller.storage.pending_seed
+
+    def run(self):
+        button_data = [self.DISCARD_PARTS, self.KEEP_PARTS]
+
+        self.PASSPHRASE.button_label = self.seed.passphrase_label
+        if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) != SettingsConstants.OPTION__DISABLED:
+            button_data.append(self.PASSPHRASE)
+
+        selected_menu_num = self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Finalize Options"),
+            status_icon_name=SeedSignerIconConstants.SEEDS,
+            status_color=GUIConstants.BUTTON_FONT_COLOR,
+            status_headline=_("What about the parts?"),
+            text=_("Keep or discard parts?"),
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(RebuildSeedXORFinalizeView)
+
+        elif button_data[selected_menu_num] == self.DISCARD_PARTS:
+            combined_seed = self.controller.storage.pending_seed
+            self.controller.storage.finalize_pending_seed()
+
+            # Discard the individual part seeds from storage by identity, keeping
+            #   the combined seed. A part loaded via "Use loaded seed" is the same
+            #   object in both storage.seeds and rebuild_seedxor_parts.
+            parts_to_discard = list(self.controller.storage.rebuild_seedxor_parts)
+            for part in parts_to_discard:
+                if part is not combined_seed and part in self.controller.storage.seeds:
+                    self.controller.discard_seed(part)
+
+            self.controller.clear_rebuild_seedxor_data()
+            return Destination(SeedOptionsView, view_args={"seed": combined_seed}, clear_history=True)
+
+        elif button_data[selected_menu_num] == self.KEEP_PARTS:
+            combined_seed = self.controller.storage.pending_seed
+            self.controller.storage.finalize_pending_seed()
+            self.controller.clear_rebuild_seedxor_data()
+
+            return Destination(SeedOptionsView, view_args={"seed": combined_seed}, clear_history=True)
+
+        elif button_data[selected_menu_num] == self.PASSPHRASE:
+            return Destination(SeedAddPassphraseView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2386,6 +2386,7 @@ class RebuildSeedXORShowFingerprintView(View):
 
         if selected_menu_num == RET_CODE__BACK_BUTTON or button_data[selected_menu_num] == self.CANCEL:
             self.controller.storage.clear_pending_seed()
+            self.controller.resume_main_flow = None
             return Destination(RebuildSeedXORLoadPartView)
 
         error_dict = self.controller.process_rebuild_seedxor_part(self.seed)
@@ -2404,7 +2405,11 @@ class RebuildSeedXORShowFingerprintView(View):
                 skip_current_view=True
             )
 
+        # The part was accepted; the seed-loading sub-flow is complete, so clear
+        #   resume_main_flow (otherwise any later SeedMnemonicEntryView in this
+        #   session would be misrouted back into the SeedXOR flow).
         self.controller.storage.clear_pending_seed()
+        self.controller.resume_main_flow = None
         return Destination(RebuildSeedXORManageView)
 
 
@@ -2717,12 +2722,14 @@ class RebuildSeedXORFinalizeOptionsView(View):
                     self.controller.discard_seed(part)
 
             self.controller.clear_rebuild_seedxor_data()
+            self.controller.resume_main_flow = None
             return Destination(SeedOptionsView, view_args={"seed": combined_seed}, clear_history=True)
 
         elif button_data[selected_menu_num] == self.KEEP_PARTS:
             combined_seed = self.controller.storage.pending_seed
             self.controller.storage.finalize_pending_seed()
             self.controller.clear_rebuild_seedxor_data()
+            self.controller.resume_main_flow = None
 
             return Destination(SeedOptionsView, view_args={"seed": combined_seed}, clear_history=True)
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -12,6 +12,7 @@ from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
 from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed
@@ -2638,6 +2639,14 @@ class RebuildSeedXORFinalizeView(View):
             mnemonic_strings = [part.mnemonic_str for part in self.controller.storage.rebuild_seedxor_parts]
             combined_mnemonic = combine_mnemonics_with_xor(mnemonic_strings)
             seed = Seed(mnemonic=combined_mnemonic)
+
+            # Check for degenerate XOR results (all-zero / all-ones entropy from
+            #   colluding parts). These pass the BIP39 checksum but are worthless.
+            is_valid, error_dict = SeedXORValidator.validate_combined_seed(seed)
+            if not is_valid:
+                self.error = error_dict.get("message")
+                return
+
             self.controller.storage.rebuild_seedxor_combined_seed = seed
             self.controller.storage.set_pending_seed(seed)
             self.fingerprint = seed.get_fingerprint(

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -45,7 +45,7 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, RemoveMicroSDWarningView, NotYetImplementedView, UnhandledExceptionView, 
     psbt_views, seed_views, settings_views, tools_views, scan_views)
 from seedsigner.views.screensaver import OpeningSplashView
-from seedsigner.views.view import CameraConnectionErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView
+from seedsigner.views.view import CameraConnectionErrorView, ErrorView, NetworkMismatchErrorView, OptionDisabledView, PowerOffView
 
 from .utils import ScreenshotComplete, ScreenshotConfig, ScreenshotRenderer
 
@@ -321,6 +321,54 @@ def generate_screenshots(locale):
             with patch.object(controller, 'psbt_seed', None):
                 yield
 
+        # --- Seed XOR rebuild flow state helpers -------------------------------
+        # Test mnemonics shared with tests/test_flow_seedxor.py (see
+        #   tests/seedxor_test_vectors.py). The feature is gated behind the
+        #   Advanced setting SETTING__SEED_XOR (default DISABLED), so every
+        #   SeedXOR screenshot must enable it first.
+        SEEDXOR_PART_12_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability"  # EXAMPLE_12_A
+        SEEDXOR_PART_12_B = "boat unfair shell violin tree robust open ride visual forest vintage approve"  # EXAMPLE_12_B
+
+        def _seedxor_make_part(mnemonic) -> Seed:
+            mnemonic_list = mnemonic.split() if isinstance(mnemonic, str) else mnemonic
+            return Seed(mnemonic=mnemonic_list, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+        @contextmanager
+        def mock_seedxor_enabled():
+            prev = controller.settings.get_value(SettingsConstants.SETTING__SEED_XOR)
+            controller.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+            try:
+                yield
+            finally:
+                controller.settings.set_value(SettingsConstants.SETTING__SEED_XOR, prev)
+
+        @contextmanager
+        def mock_seedxor_parts_loaded(num_parts: int = 2):
+            """Preload `num_parts` XOR parts into storage for the Rebuild Seed XOR views."""
+            part_mnemonics = [SEEDXOR_PART_12_A, SEEDXOR_PART_12_B][:num_parts]
+            parts = [_seedxor_make_part(m) for m in part_mnemonics]
+            with mock_seedxor_enabled():
+                with patch.object(controller.storage, 'rebuild_seedxor_parts', parts):
+                    yield
+
+        @contextmanager
+        def mock_seedxor_pending_part(num_parts: int = 1):
+            """Parts loaded plus a pending seed awaiting fingerprint confirmation."""
+            with mock_seedxor_parts_loaded(num_parts):
+                with patch.object(controller.storage, 'pending_seed', _seedxor_make_part(SEEDXOR_PART_12_B)):
+                    yield
+
+        @contextmanager
+        def mock_seedxor_combined_seed():
+            """Two parts loaded plus their combined seed (for finalize options)."""
+            from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+            part_mnemonics = [SEEDXOR_PART_12_A, SEEDXOR_PART_12_B]
+            combined = _seedxor_make_part(combine_mnemonics_with_xor(part_mnemonics))
+            with mock_seedxor_parts_loaded(num_parts=2):
+                with patch.object(controller.storage, 'rebuild_seedxor_combined_seed', combined):
+                    with patch.object(controller.storage, 'pending_seed', combined):
+                        yield
+
 
         @contextmanager
         def mock_psbt_with_op_return_loaded():
@@ -433,6 +481,33 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedSignMessageConfirmAddressView),
 
                 ScreenshotConfig(seed_views.SeedElectrumMnemonicStartView),
+
+                # Rebuild Seed XOR flow (issue #738); feature is gated behind the
+                #   Advanced setting SETTING__SEED_XOR (default DISABLED), so every
+                #   entry enables it via mock context managers.
+                ScreenshotConfig(seed_views.LoadSeedView, screenshot_name="LoadSeedView_seedxor_enabled", mock_context_manager=mock_seedxor_enabled),
+                ScreenshotConfig(seed_views.RebuildSeedXORManageView, screenshot_name="RebuildSeedXORManageView_no_parts", mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=0)),
+                ScreenshotConfig(seed_views.RebuildSeedXORManageView, screenshot_name="RebuildSeedXORManageView_one_part",  mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=1)),
+                ScreenshotConfig(seed_views.RebuildSeedXORManageView, screenshot_name="RebuildSeedXORManageView_two_parts", mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=2)),
+                ScreenshotConfig(seed_views.RebuildSeedXORLoadPartView, mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=1)),
+                ScreenshotConfig(seed_views.RebuildSeedXORShowFingerprintView, mock_context_manager=lambda: mock_seedxor_pending_part(num_parts=1)),
+                ScreenshotConfig(seed_views.RebuildSeedXORSelectExistingSeedView, mock_context_manager=mock_seedxor_enabled),
+                ScreenshotConfig(seed_views.RebuildSeedXORViewPartsView, mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=2)),
+                ScreenshotConfig(seed_views.RebuildSeedXORRemovePartsView, mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=2)),
+                ScreenshotConfig(seed_views.RebuildSeedXORConfirmRemovePartView, dict(part_num=0), mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=2)),
+                ScreenshotConfig(seed_views.RebuildSeedXORCancelView, mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=2)),
+                ScreenshotConfig(seed_views.RebuildSeedXORFinalizeView, mock_context_manager=lambda: mock_seedxor_parts_loaded(num_parts=2)),
+                ScreenshotConfig(seed_views.RebuildSeedXORFinalizeOptionsView, mock_context_manager=mock_seedxor_combined_seed),
+
+                # Degenerate-result warning rendered by RebuildSeedXORFinalizeView's
+                #   error branch when the XORed parts produce all-zero entropy
+                #   (mirrors the "XOR Error" ErrorView the flow routes to).
+                ScreenshotConfig(ErrorView, dict(
+                    title="XOR Error",
+                    status_headline="Error Combining Seeds",
+                    text="XORing these parts produces all-zero entropy (the 'abandon...about' seed). The result is a known, worthless seed.",
+                    button_text="OK",
+                ), screenshot_name="RebuildSeedXORFinalizeView_zero_entropy_error"),
             ],
             "PSBT Views": [
                 ScreenshotConfig(psbt_views.PSBTSelectSeedView, mock_context_manager=mock_controller_psbt_seed_empty),

--- a/tests/seedxor_test_vectors.py
+++ b/tests/seedxor_test_vectors.py
@@ -1,0 +1,14 @@
+"""Shared test vectors for SeedXOR tests."""
+
+EXAMPLE_24_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability miss spice fitness easy legal release recall obey exchange recycle dragon room"
+EXAMPLE_24_B = "lion misery divide hurry latin fluid camp advance illegal lab pyramid unaware eager fringe sick camera series noodle toy crowd jeans select depth lounge"
+EXAMPLE_24_C = "vault nominee cradle silk own frown throw leg cactus recall talent worry gadget surface shy planet purpose coffee drip few seven term squeeze educate"
+RESULT_24_ABC = "silent toe meat possible chair blossom wait occur this worth option bag nurse find fish scene bench asthma bike wage world quit primary indoor"
+
+EXAMPLE_12_A = "romance wink lottery autumn shop bring dawn tongue range crater truth ability"
+EXAMPLE_12_B = "boat unfair shell violin tree robust open ride visual forest vintage approve"
+EXAMPLE_12_C = "lion misery divide hurry latin fluid camp advance illegal lab pyramid unhappy"
+RESULT_12_ABC = "cannon opinion leader nephew found yard metal galaxy crouch between real trade"
+
+ZERO_ENTROPY_MNEMONIC_12 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+ZERO_ENTROPY_MNEMONIC_24 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"

--- a/tests/test_flow_seedxor.py
+++ b/tests/test_flow_seedxor.py
@@ -6,7 +6,10 @@ from seedsigner.views import seed_views, scan_views
 from seedsigner.views.seed_views import SeedsMenuView
 from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
 
-from seedxor_test_vectors import EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C, EXAMPLE_12_A
+from seedxor_test_vectors import (
+    EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C,
+    EXAMPLE_12_A, EXAMPLE_12_B,
+)
 
 
 def type_mnemonic(mnemonic: str):
@@ -175,3 +178,55 @@ class TestSeedXORFlows(FlowTest):
 
         self.run_sequence(sequence)
         assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+
+    def test_resume_flow_cleared_after_finalize(self):
+        """
+        Regression test: resume_main_flow must be cleared when the SeedXOR flow
+        completes, otherwise a subsequent normal seed load (SeedMnemonicEntryView)
+        would be misrouted into the SeedXOR fingerprint view instead of
+        SeedFinalizeView.
+        """
+        from seedsigner.views.seed_views import SeedFinalizeView
+
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        # Complete a 2-part XOR and finalize with KEEP_PARTS (lands on SeedOptionsView,
+        #   NOT MainMenuView, so Home's resume_main_flow wipe is not what clears it).
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_B)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(seed_views.RebuildSeedXORFinalizeView, button_data_selection=0),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView, button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.KEEP_PARTS),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+        ]
+        self.run_sequence(sequence)
+
+        # The flow is complete; resume_main_flow must not still point at SeedXOR.
+        assert self.controller.resume_main_flow != self.controller.FLOW__REBUILD_SEEDXOR
+
+        # Now load a NEW, unrelated seed via the normal flow in the same session.
+        #   It must finalize normally (SeedFinalizeView), NOT be captured as an XOR part.
+        sequence = [
+            FlowStep(SeedsMenuView, button_data_selection=SeedsMenuView.LOAD),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(SeedFinalizeView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 0

--- a/tests/test_flow_seedxor.py
+++ b/tests/test_flow_seedxor.py
@@ -478,3 +478,100 @@ class TestSeedXORAdditionalFlows(FlowTest):
         is_valid, error_dict = SeedXORValidator.validate_combined_seed(all_ones_seed)
         assert not is_valid
         assert error_dict["title"] == "Known Seed Result"
+
+
+class TestSeedXORWordlistLanguage(FlowTest):
+    """The finalize path must honor SETTING__WORDLIST_LANGUAGE instead of
+    silently defaulting to English (ref: PR #1014 review feedback). The app is
+    English-only today, so these tests mock the wordlist boundary rather than
+    loading a real foreign wordlist."""
+
+    def _load_two_parts(self):
+        """Common prefix: enable XOR, type two 12-word parts, land on Finalize.
+
+        Note: SETTING__WORDLIST_LANGUAGE is left at English during entry, because
+        LoadSeedView also resolves the wordlist and would raise on an unrecognized
+        code before the flow ever reaches Finalize."""
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_B)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+        ]
+        return sequence
+
+    def test_finalize_passes_wordlist_language_from_settings(self):
+        """
+        RebuildSeedXORFinalizeView must call combine_mnemonics_with_xor() and Seed()
+        with the wordlist_language_code from settings, not the English default.
+        """
+        captured = {}
+        real_combine = combine_mnemonics_with_xor
+        real_seed_init = Seed.__init__
+
+        def spy_combine(mnemonics, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH):
+            captured["combine_lang"] = wordlist_language_code
+            # Run for real with English so parsing doesn't die on the mocked code
+            return real_combine(mnemonics, wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+        def spy_seed_init(self_seed, mnemonic=None, passphrase="", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH):
+            captured.setdefault("seed_langs", []).append(wordlist_language_code)
+            # Force English so the mocked language doesn't break real parsing
+            return real_seed_init(self_seed, mnemonic=mnemonic, passphrase=passphrase,
+                                  wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+        def set_lang_xx(view):
+            self.settings.set_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE, "xx")
+
+        from unittest.mock import patch
+        with patch("seedsigner.views.seed_views.combine_mnemonics_with_xor", side_effect=spy_combine), \
+             patch.object(Seed, "__init__", spy_seed_init):
+            sequence = self._load_two_parts()
+            # Flip the (hidden) setting after parts are loaded but before Finalize runs,
+            #   mimicking a future build where a non-English wordlist is selectable.
+            sequence[-1].before_run = set_lang_xx
+            sequence += [
+                FlowStep(seed_views.RebuildSeedXORFinalizeView, button_data_selection=0),
+                FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView, button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.KEEP_PARTS),
+                FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+            ]
+            self.run_sequence(sequence)
+
+        assert captured["combine_lang"] == "xx"
+        assert "xx" in captured["seed_langs"]
+
+    def test_finalize_unrecognized_wordlist_language_fails_closed(self):
+        """
+        If the settings wordlist code is unrecognized, Seed.get_wordlist() raises,
+        and the finalize view must surface the error screen instead of producing
+        a seed from the wrong wordlist.
+        """
+        def set_lang_xx(view):
+            self.settings.set_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE, "xx")
+
+        # Run combine for real: Seed.get_wordlist("xx") raises -> view captures the
+        #   error and routes to ErrorView without calling run_screen (is_redirect).
+        sequence = self._load_two_parts()
+        sequence[-1].before_run = set_lang_xx
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORFinalizeView, is_redirect=True),
+            FlowStep(ErrorView, button_data_selection=0),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+
+        # No combined seed may be stored after a failed finalize
+        assert self.controller.storage.rebuild_seedxor_combined_seed is None

--- a/tests/test_flow_seedxor.py
+++ b/tests/test_flow_seedxor.py
@@ -1,0 +1,177 @@
+from base import FlowTest, FlowStep
+from seedsigner.models.seed import Seed
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.views.view import MainMenuView, ErrorView
+from seedsigner.views import seed_views, scan_views
+from seedsigner.views.seed_views import SeedsMenuView
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+
+from seedxor_test_vectors import EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C, EXAMPLE_12_A
+
+
+def type_mnemonic(mnemonic: str):
+    """ Helper function to generate a list of FlowSteps for typing a mnemonic. """
+    flow = []
+    for word in mnemonic.split():
+        flow.append(FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=word))
+    return flow
+
+
+class TestSeedXORFlows(FlowTest):
+    def test_recombine_3_parts_24_words_success_flow(self):
+        """
+        Tests the complete, successful SeedXOR flow using three 24-word seeds.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        self.controller.storage.seeds.append(Seed(mnemonic=EXAMPLE_24_C.split()))
+
+        # Calculate the expected result dynamically
+        expected_mnemonic_list = combine_mnemonics_with_xor([EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C])
+        expected_seed = Seed(mnemonic=expected_mnemonic_list)
+        expected_fingerprint = expected_seed.get_fingerprint()
+
+        def check_fingerprint(view):
+            assert view.fingerprint == expected_fingerprint
+
+        # Helper to simulate scanning a seed by adding its numeric representation to the decoder
+        def load_seed_qr_into_decoder(view: scan_views.ScanView):
+            wordlist = Seed.get_wordlist()
+            indexes = [wordlist.index(word) for word in EXAMPLE_24_B.split()]
+            numeric_seed_str = "".join([str(i).zfill(4) for i in indexes])
+            view.decoder.add_data(numeric_seed_str)
+
+        # === Start Flow and Add Part 1 (Typing) ===
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, button_data_selection=SeedsMenuView.LOAD),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_24WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_24_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+
+        # === Add Part 2 (Scan QR) ===
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.SCAN_PART),
+            FlowStep(scan_views.ScanSeedQRView, before_run=load_seed_qr_into_decoder),
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 2
+
+        # === Add Part 3 (Use Loaded Seed) ===
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.USE_LOADED_SEED),
+            FlowStep(seed_views.RebuildSeedXORSelectExistingSeedView, screen_return_value=0),
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 3
+
+        # === Finalize and Verify ===
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(
+                seed_views.RebuildSeedXORFinalizeView,
+                before_run=check_fingerprint,
+                button_data_selection=0
+            ),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView, button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.KEEP_PARTS),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+        ])
+        assert len(self.controller.storage.seeds) == 2
+
+    def test_error_on_duplicate_part(self):
+        """
+        Tests that the system prevents a user from adding the same part twice.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        def check_error_title(view):
+            assert view.title == "Duplicate Part"
+
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+
+        # Attempt to load the same part again
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(
+                ErrorView,
+                before_run=check_error_title,
+                button_data_selection=0
+            ),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, is_redirect=True),
+        ]
+
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+
+    def test_error_on_mismatched_length(self):
+        """
+        Tests that the system prevents adding a 24-word part after a 12-word part.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        def check_error_title(view):
+            assert view.title == "Mnemonic Length Mismatch"
+
+        # Load a 12-word part
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+
+        # Attempt to load a 24-word part
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_24WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_24_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(
+                ErrorView,
+                before_run=check_error_title,
+                button_data_selection=0
+            ),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, is_redirect=True),
+        ]
+
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1

--- a/tests/test_flow_seedxor.py
+++ b/tests/test_flow_seedxor.py
@@ -1,10 +1,14 @@
 from base import FlowTest, FlowStep
+from unittest.mock import MagicMock
+
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.views.view import MainMenuView, ErrorView
 from seedsigner.views import seed_views, scan_views
 from seedsigner.views.seed_views import SeedsMenuView
 from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
 
 from seedxor_test_vectors import (
     EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C,
@@ -230,3 +234,247 @@ class TestSeedXORFlows(FlowTest):
         ]
         self.run_sequence(sequence)
         assert len(self.controller.storage.rebuild_seedxor_parts) == 0
+
+
+class TestSeedXORAdditionalFlows(FlowTest):
+    """Tests for the DISCARD_PARTS finalize branch, remove-part flow,
+    back-button routing, zero-entropy rejection, and Finalize-hidden-with-<2-parts."""
+
+    def _load_two_parts_12w(self):
+        """Helper: load two 12-word parts and return at RebuildSeedXORManageView."""
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_B)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 2
+
+    def test_finalize_discard_parts_flow(self):
+        """
+        Tests the DISCARD_PARTS finalize branch: after combining, choosing
+        "Discard parts" should remove the individual part seeds from storage
+        while keeping only the combined seed.
+        """
+        self._load_two_parts_12w()
+
+        expected_mnemonic = combine_mnemonics_with_xor([EXAMPLE_12_A, EXAMPLE_12_B])
+        expected_fingerprint = Seed(mnemonic=expected_mnemonic).get_fingerprint()
+
+        def check_fingerprint(view):
+            assert view.fingerprint == expected_fingerprint
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(
+                seed_views.RebuildSeedXORFinalizeView,
+                before_run=check_fingerprint,
+                button_data_selection=0,
+            ),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView, button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.DISCARD_PARTS),
+            FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+        ])
+
+        # The combined seed should be in storage; the XOR rebuild data should be cleared.
+        assert len(self.controller.storage.seeds) == 1
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 0
+        assert self.controller.storage.rebuild_seedxor_combined_seed is None
+
+    def test_remove_part_flow(self):
+        """
+        Tests the remove-part flow: load two parts, remove the first one,
+        and verify only one part remains.
+        """
+        self._load_two_parts_12w()
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.REMOVE_PARTS),
+            FlowStep(seed_views.RebuildSeedXORRemovePartsView, screen_return_value=0),
+            FlowStep(seed_views.RebuildSeedXORConfirmRemovePartView, button_data_selection=seed_views.RebuildSeedXORConfirmRemovePartView.CONFIRM_REMOVE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+
+        # Only one part should remain (part 2 = EXAMPLE_12_B)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+        remaining = self.controller.storage.rebuild_seedxor_parts[0]
+        assert remaining.mnemonic_str == EXAMPLE_12_B
+
+    def test_remove_part_keep_part_backflow(self):
+        """
+        Tests the remove-part flow: selecting "Keep part" in the confirm
+        screen returns to the RemovePartsView, not the ManageView.
+        """
+        self._load_two_parts_12w()
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.REMOVE_PARTS),
+            FlowStep(seed_views.RebuildSeedXORRemovePartsView, screen_return_value=0),
+            FlowStep(seed_views.RebuildSeedXORConfirmRemovePartView, button_data_selection=seed_views.RebuildSeedXORConfirmRemovePartView.KEEP_PART),
+            # skip_current_view=True means we go back to RemovePartsView
+            FlowStep(seed_views.RebuildSeedXORRemovePartsView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+
+        # Both parts should still be present
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 2
+
+    def test_back_button_from_load_part_view(self):
+        """
+        Tests that pressing BACK from RebuildSeedXORLoadPartView returns
+        to RebuildSeedXORManageView (clear_history=True).
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+
+    def test_back_button_from_manage_view(self):
+        """
+        Tests that pressing BACK from RebuildSeedXORManageView returns
+        to LoadSeedView (clear_history=True).
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.LoadSeedView),
+        ])
+
+    def test_back_button_from_finalize_view(self):
+        """
+        Tests that pressing BACK from RebuildSeedXORFinalizeView returns
+        to RebuildSeedXORManageView.
+        """
+        self._load_two_parts_12w()
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(seed_views.RebuildSeedXORFinalizeView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+
+    def test_back_button_from_finalize_options_view(self):
+        """
+        Tests that pressing BACK from RebuildSeedXORFinalizeOptionsView returns
+        to RebuildSeedXORFinalizeView.
+        """
+        self._load_two_parts_12w()
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(seed_views.RebuildSeedXORFinalizeView, button_data_selection=0),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORFinalizeView),
+        ])
+
+    def test_cancel_seed_xor_flow(self):
+        """
+        Tests the Cancel Seed XOR flow: confirms cancellation, which should
+        clear all loaded parts and return to LoadSeedView.
+        """
+        self._load_two_parts_12w()
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.CANCEL),
+            FlowStep(seed_views.RebuildSeedXORCancelView, button_data_selection=seed_views.RebuildSeedXORCancelView.CONFIRM),
+            FlowStep(seed_views.LoadSeedView),
+        ])
+
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 0
+        assert self.controller.storage.rebuild_seedxor_combined_seed is None
+
+    def test_finalize_hidden_with_less_than_two_parts(self):
+        """
+        Tests that the Finalize button is NOT shown when only one part is loaded.
+        """
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        # Load one part
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 1
+
+        # Instantiate the ManageView and replicate its button_data construction
+        # to verify FINALIZE is absent when num_parts < 2.
+        view = seed_views.RebuildSeedXORManageView()
+        assert view.num_parts == 1
+
+        button_data = []
+        button_data.append(seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART)
+        if view.num_parts > 0:
+            button_data.append(seed_views.RebuildSeedXORManageView.VIEW_LOADED_PARTS)
+            button_data.append(seed_views.RebuildSeedXORManageView.REMOVE_PARTS)
+            button_data.append(seed_views.RebuildSeedXORManageView.CANCEL)
+        if view.num_parts >= 2:
+            button_data.insert(-1, seed_views.RebuildSeedXORManageView.FINALIZE)
+
+        assert seed_views.RebuildSeedXORManageView.FINALIZE not in button_data
+
+    def test_zero_entropy_combined_result_rejected(self):
+        """
+        Tests that the validator catches a zero-entropy combined seed
+        (all-zero bytes, i.e. the 'abandon...about' seed). With 3+ colluding
+        parts the XOR can bypass the duplicate check and produce this result.
+        """
+        from seedxor_test_vectors import ZERO_ENTROPY_MNEMONIC_12
+
+        zero_seed = MagicMock()
+        zero_seed.mnemonic_str = ZERO_ENTROPY_MNEMONIC_12
+        zero_seed.wordlist = Seed.get_wordlist()
+
+        is_valid, error_dict = SeedXORValidator.validate_combined_seed(zero_seed)
+        assert not is_valid
+        assert error_dict["title"] == "Zero Entropy Result"
+
+    def test_all_ones_combined_result_rejected(self):
+        """
+        Tests that the validator rejects an all-ones entropy combined seed.
+        """
+        from embit import bip39 as _bip39
+
+        # Construct an all-0xFF 16-byte entropy and convert to mnemonic
+        all_ones_entropy = bytes([0xFF] * 16)
+        all_ones_mnemonic = _bip39.mnemonic_from_bytes(all_ones_entropy)
+
+        all_ones_seed = MagicMock()
+        all_ones_seed.mnemonic_str = all_ones_mnemonic
+        all_ones_seed.wordlist = Seed.get_wordlist()
+
+        is_valid, error_dict = SeedXORValidator.validate_combined_seed(all_ones_seed)
+        assert not is_valid
+        assert error_dict["title"] == "Known Seed Result"

--- a/tests/test_redteam_seedxor.py
+++ b/tests/test_redteam_seedxor.py
@@ -1,0 +1,97 @@
+"""Red-team regression tests for the SeedXOR rebuild flow.
+
+Covers F1: resume_main_flow leaks that misrouted later normal seed loads
+into the SeedXOR fingerprint view.
+"""
+from base import FlowTest, FlowStep
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+from seedsigner.views.view import MainMenuView, ErrorView
+from seedsigner.views import seed_views, scan_views
+from seedsigner.views.seed_views import SeedsMenuView, SeedFinalizeView
+
+from seedxor_test_vectors import EXAMPLE_12_A, EXAMPLE_12_B
+
+
+def type_mnemonic(mnemonic: str):
+    return [FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=w) for w in mnemonic.split()]
+
+
+class TestResumeFlowLeak(FlowTest):
+    def test_back_out_of_word0_then_normal_seed_load_not_misrouted(self):
+        """Start SeedXOR typed entry, BACK out at word 0, back out to
+        LoadSeedView, then type a normal seed -> must route to SeedFinalizeView,
+        NOT RebuildSeedXORShowFingerprintView."""
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView),  # back-landing
+        ]
+        self.run_sequence(sequence)
+
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORManageView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        # Fixed behavior: normal seed load routes to SeedFinalizeView.
+        sequence += [FlowStep(seed_views.SeedFinalizeView)]
+        self.run_sequence(sequence)
+
+    def test_scan_rejected_part_then_normal_seed_load_not_misrouted(self):
+        """Scan a valid-but-rejected XOR part (duplicate). After the ErrorView,
+        resume_main_flow must be cleared; a later normal seed load routes to
+        SeedFinalizeView."""
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+
+        # Load part 1 normally (typed)
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ]
+        self.run_sequence(sequence)
+
+        # Scan the SAME part again (duplicate -> rejected)
+        def load_seed_qr(view: scan_views.ScanView):
+            from seedsigner.models.seed import Seed
+            wordlist = Seed.get_wordlist()
+            indexes = [wordlist.index(word) for word in EXAMPLE_12_A.split()]
+            numeric = "".join([str(i).zfill(4) for i in indexes])
+            view.decoder.add_data(numeric)
+
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.SCAN_PART),
+            FlowStep(scan_views.ScanSeedQRView, before_run=load_seed_qr),
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(ErrorView, button_data_selection=0),   # duplicate part error
+            FlowStep(seed_views.RebuildSeedXORLoadPartView),
+        ]
+        self.run_sequence(sequence)
+        assert self.controller.resume_main_flow is None, "resume_main_flow must be cleared after validation error"
+
+        # Back all the way out to LoadSeedView, then type a NORMAL new seed
+        sequence = [
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORManageView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_B)
+        # Fixed behavior: normal seed load routes to SeedFinalizeView.
+        sequence += [FlowStep(seed_views.SeedFinalizeView)]
+        self.run_sequence(sequence)

--- a/tests/test_redteam_seedxor.py
+++ b/tests/test_redteam_seedxor.py
@@ -4,7 +4,11 @@ Covers F1: resume_main_flow leaks that misrouted later normal seed loads
 into the SeedXOR fingerprint view.
 Covers F2: DISCARD_PARTS must delete parts by identity, never a pre-existing
 user seed that merely shares a mnemonic with a typed/scanned part.
+Covers F3: cancellation and part changes clear only the flow's pending
+combined seed, preserving unrelated pending seeds and finalized seeds.
 """
+import pytest
+
 from base import FlowTest, FlowStep
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
@@ -194,3 +198,128 @@ class TestDiscardPartsByIdentity(FlowTest):
         assert len(self.controller.storage.seeds) == 0
         # no-op on a seed not in storage
         self.controller.discard_seed(Seed(mnemonic=EXAMPLE_12_B.split()))
+
+
+class TestCancelCombinedSeedCleanup(FlowTest):
+    """F3: canceling a rebuild must not leave its combined seed pending."""
+
+    @pytest.mark.parametrize("cleanup", ["cancel", "add", "remove"])
+    @pytest.mark.parametrize("pending_kind", ["equal_distinct", "different", "none"])
+    def test_cleanup_preserves_unrelated_pending_seed(self, cleanup, pending_kind):
+        storage = self.controller.storage
+        combined = Seed(mnemonic=EXAMPLE_12_A.split())
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_B.split()))
+        storage.rebuild_seedxor_combined_seed = combined
+        pending = None
+        if pending_kind == "equal_distinct":
+            pending = Seed(mnemonic=EXAMPLE_12_A.split())
+            assert pending == combined and pending is not combined
+        elif pending_kind == "different":
+            pending = Seed(mnemonic=EXAMPLE_12_B.split())
+        storage.set_pending_seed(pending)
+
+        if cleanup == "cancel":
+            self.run_sequence([
+                FlowStep(seed_views.RebuildSeedXORCancelView,
+                         button_data_selection=seed_views.RebuildSeedXORCancelView.CONFIRM),
+                FlowStep(seed_views.LoadSeedView),
+            ])
+        elif cleanup == "add":
+            storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_A.split()))
+        else:
+            self.controller.remove_rebuild_seedxor_part(0)
+
+        assert storage.rebuild_seedxor_combined_seed is None
+        assert storage.get_pending_seed() is pending
+
+    @pytest.mark.parametrize("choice", [0, RET_CODE__BACK_BUTTON])
+    def test_declining_cancel_preserves_combined_seed(self, choice):
+        storage = self.controller.storage
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_A.split()))
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_B.split()))
+        finalize = seed_views.RebuildSeedXORFinalizeView()
+        assert finalize.error is None
+        combined = storage.get_pending_seed()
+        assert combined is not None
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORCancelView, screen_return_value=choice),
+            FlowStep(seed_views.RebuildSeedXORManageView),
+        ])
+
+        assert storage.get_pending_seed() is combined
+        assert storage.rebuild_seedxor_combined_seed is combined
+        assert len(storage.rebuild_seedxor_parts) == 2
+
+    def test_cleanup_preserves_finalized_seed(self):
+        storage = self.controller.storage
+        combined = Seed(mnemonic=EXAMPLE_12_A.split())
+        storage.rebuild_seedxor_combined_seed = combined
+        storage.set_pending_seed(combined)
+        storage.finalize_pending_seed()
+
+        self.controller.clear_rebuild_seedxor_data()
+        self.controller.clear_rebuild_seedxor_data()  # Idempotent cleanup.
+
+        assert len(storage.seeds) == 1
+        assert storage.seeds[0] is combined
+        assert storage.get_pending_seed() is None
+        assert storage.rebuild_seedxor_combined_seed is None
+
+    def test_cancel_after_finalize_clears_pending_combined_seed(self):
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        storage = self.controller.storage
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_A.split()))
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_B.split()))
+
+        def check_combined_is_pending(view):
+            assert view.error is None
+            assert storage.rebuild_seedxor_combined_seed is not None
+            assert storage.get_pending_seed() is storage.rebuild_seedxor_combined_seed
+
+        self.run_sequence([
+            FlowStep(seed_views.RebuildSeedXORFinalizeView,
+                     before_run=check_combined_is_pending,
+                     screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.RebuildSeedXORManageView,
+                     button_data_selection=seed_views.RebuildSeedXORManageView.CANCEL),
+            FlowStep(seed_views.RebuildSeedXORCancelView,
+                     button_data_selection=seed_views.RebuildSeedXORCancelView.CONFIRM),
+            FlowStep(seed_views.LoadSeedView),
+        ])
+
+        assert storage.rebuild_seedxor_parts == []
+        assert storage.rebuild_seedxor_combined_seed is None
+        assert storage.get_pending_seed() is None
+        assert storage.seeds == []
+
+    def test_add_part_after_finalize_clears_pending_combined_seed(self):
+        storage = self.controller.storage
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_A.split()))
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_B.split()))
+        finalize = seed_views.RebuildSeedXORFinalizeView()
+        assert finalize.error is None
+        combined = storage.get_pending_seed()
+        assert combined is not None
+
+        # Exercise storage invalidation directly; validation belongs to controller.
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_A.split()))
+
+        assert len(storage.rebuild_seedxor_parts) == 3
+        assert storage.rebuild_seedxor_combined_seed is None
+        assert storage.get_pending_seed() is None
+
+    def test_remove_part_after_finalize_clears_pending_combined_seed(self):
+        storage = self.controller.storage
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_A.split()))
+        storage.add_rebuild_seedxor_part(Seed(mnemonic=EXAMPLE_12_B.split()))
+        finalize = seed_views.RebuildSeedXORFinalizeView()
+        assert finalize.error is None
+        assert storage.get_pending_seed() is storage.rebuild_seedxor_combined_seed
+        assert storage.get_pending_seed() is not None
+
+        self.controller.remove_rebuild_seedxor_part(0)
+
+        assert len(storage.rebuild_seedxor_parts) == 1
+        assert storage.rebuild_seedxor_combined_seed is None
+        assert storage.get_pending_seed() is None

--- a/tests/test_redteam_seedxor.py
+++ b/tests/test_redteam_seedxor.py
@@ -2,8 +2,11 @@
 
 Covers F1: resume_main_flow leaks that misrouted later normal seed loads
 into the SeedXOR fingerprint view.
+Covers F2: DISCARD_PARTS must delete parts by identity, never a pre-existing
+user seed that merely shares a mnemonic with a typed/scanned part.
 """
 from base import FlowTest, FlowStep
+from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
 from seedsigner.views.view import MainMenuView, ErrorView
@@ -95,3 +98,99 @@ class TestResumeFlowLeak(FlowTest):
         # Fixed behavior: normal seed load routes to SeedFinalizeView.
         sequence += [FlowStep(seed_views.SeedFinalizeView)]
         self.run_sequence(sequence)
+
+
+class TestDiscardPartsByIdentity(FlowTest):
+    """F2 regression: DISCARD_PARTS must not delete a pre-existing user seed
+    that merely shares a mnemonic with a typed/scanned part."""
+
+    def test_typed_duplicate_of_preexisting_seed_survives_discard(self):
+        """Pre-load Seed(A) into storage. In the XOR flow, TYPE mnemonic A as
+        part 1 (a DISTINCT object equal by value), B as part 2. FINALIZE ->
+        DISCARD_PARTS. The pre-existing seed must survive; only the combined
+        seed is added alongside it."""
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        preexisting = Seed(mnemonic=EXAMPLE_12_A.split())
+        self.controller.storage.seeds.append(preexisting)
+
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, button_data_selection=SeedsMenuView.LOAD),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_A)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_B)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(seed_views.RebuildSeedXORFinalizeView, button_data_selection=0),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView,
+                     button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.DISCARD_PARTS),
+            FlowStep(seed_views.SeedOptionsView),
+        ]
+        self.run_sequence(sequence)
+
+        seeds = self.controller.storage.seeds
+        assert any(s is preexisting for s in seeds), \
+            "F2 regression: pre-existing seed deleted by DISCARD_PARTS"
+        assert len(seeds) == 2, \
+            f"expected pre-existing + combined seed, got {len(seeds)}"
+        assert len(self.controller.storage.rebuild_seedxor_parts) == 0
+
+    def test_use_loaded_seed_part_is_discarded(self):
+        """A part loaded via 'Use loaded seed' IS the same object in storage,
+        so DISCARD_PARTS legitimately removes it (user chose to consume it as
+        a part). Combined seed survives; the other typed part never touches
+        storage."""
+        self.settings.set_value(SettingsConstants.SETTING__SEED_XOR, SettingsConstants.OPTION__ENABLED)
+        preexisting = Seed(mnemonic=EXAMPLE_12_A.split())
+        self.controller.storage.seeds.append(preexisting)
+
+        # Part 1 via "Use loaded seed"
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(SeedsMenuView, button_data_selection=SeedsMenuView.LOAD),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.REBUILD_SEED_XOR),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.USE_LOADED_SEED),
+            FlowStep(seed_views.RebuildSeedXORSelectExistingSeedView, screen_return_value=0),
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.LOAD_NEXT_PART),
+            FlowStep(seed_views.RebuildSeedXORLoadPartView, button_data_selection=seed_views.RebuildSeedXORLoadPartView.TYPE_12WORD),
+        ]
+        sequence += type_mnemonic(EXAMPLE_12_B)
+        sequence += [
+            FlowStep(seed_views.RebuildSeedXORShowFingerprintView, button_data_selection=seed_views.RebuildSeedXORShowFingerprintView.CONTINUE),
+            FlowStep(seed_views.RebuildSeedXORManageView, button_data_selection=seed_views.RebuildSeedXORManageView.FINALIZE),
+            FlowStep(seed_views.RebuildSeedXORFinalizeView, button_data_selection=0),
+            FlowStep(seed_views.RebuildSeedXORFinalizeOptionsView,
+                     button_data_selection=seed_views.RebuildSeedXORFinalizeOptionsView.DISCARD_PARTS),
+            FlowStep(seed_views.SeedOptionsView),
+        ]
+        self.run_sequence(sequence)
+
+        seeds = self.controller.storage.seeds
+        assert not any(s is preexisting for s in seeds), \
+            "the 'Use loaded seed' part should have been discarded from storage"
+        assert len(seeds) == 1, "only the combined seed should remain"
+
+    def test_discard_seed_by_identity_only(self):
+        """controller.discard_seed() must not remove an equal-but-distinct seed."""
+        a = Seed(mnemonic=EXAMPLE_12_A.split())
+        b = Seed(mnemonic=EXAMPLE_12_A.split())
+        assert a == b and a is not b
+        self.controller.storage.seeds.append(a)
+        self.controller.discard_seed(b)
+        assert a in self.controller.storage.seeds, \
+            "discard_seed deleted an equal-but-distinct seed"
+        self.controller.discard_seed(a)
+        assert len(self.controller.storage.seeds) == 0
+        # no-op on a seed not in storage
+        self.controller.discard_seed(Seed(mnemonic=EXAMPLE_12_B.split()))

--- a/tests/test_seedxor.py
+++ b/tests/test_seedxor.py
@@ -140,7 +140,7 @@ class TestSeedXORValidator(unittest.TestCase):
 
 
     def test_rejects_inverse_part(self):
-        """ A binary inverse part (which would cancel another out) should be rejected. """
+        """ A binary inverse part should be rejected: XORing a part with its complement yields a known all-ones (zero-entropy) seed. """
         entropy_a = bip39.mnemonic_to_bytes(EXAMPLE_12_A)
         inverse_entropy = bytes(b ^ 0xFF for b in entropy_a)
         inverse_mnemonic_str = bip39.mnemonic_from_bytes(inverse_entropy)

--- a/tests/test_seedxor.py
+++ b/tests/test_seedxor.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
 from seedsigner.helpers.seed_xor_validator import SeedXORValidator
+from seedsigner.models.seed import Seed
 
 from embit import bip39
 
@@ -86,20 +87,25 @@ class TestSeedXORValidator(unittest.TestCase):
     """
     def setUp(self):
         """ Set up mock Seed objects for testing using the provided examples. """
+        wordlist = Seed.get_wordlist()
+
         self.part_12_A = MagicMock()
         self.part_12_A.has_passphrase = False
         self.part_12_A.mnemonic_str = EXAMPLE_12_A
         self.part_12_A.mnemonic_list = EXAMPLE_12_A.split()
+        self.part_12_A.wordlist = wordlist
 
         self.part_12_B = MagicMock()
         self.part_12_B.has_passphrase = False
         self.part_12_B.mnemonic_str = EXAMPLE_12_B
         self.part_12_B.mnemonic_list = EXAMPLE_12_B.split()
+        self.part_12_B.wordlist = wordlist
         
         self.part_24_A = MagicMock()
         self.part_24_A.has_passphrase = False
         self.part_24_A.mnemonic_str = EXAMPLE_24_A
         self.part_24_A.mnemonic_list = EXAMPLE_24_A.split()
+        self.part_24_A.wordlist = wordlist
 
 
     def test_valid_first_part(self):
@@ -149,9 +155,81 @@ class TestSeedXORValidator(unittest.TestCase):
         inverse_part.has_passphrase = False
         inverse_part.mnemonic_str = inverse_mnemonic_str
         inverse_part.mnemonic_list = inverse_mnemonic_str.split()
+        inverse_part.wordlist = Seed.get_wordlist()
 
         is_valid, error = SeedXORValidator.validate_part(inverse_part, [self.part_12_A])
         self.assertFalse(is_valid)
         self.assertEqual(error["title"], "Seed Inversion")
         self.assertIn("binary inverse of part #1", error["message"])
+
+
+    def test_validate_part_uses_seed_wordlist(self):
+        """
+        validate_part must pass the Seed's wordlist to bip39.mnemonic_to_bytes
+        instead of relying on the English default.  Verifies the wordlist
+        attribute is present and forwarded correctly.
+        """
+        # The mocks from setUp already have .wordlist set; verify validate_part
+        # works with it (the inversion check reads .wordlist).
+        is_valid, error = SeedXORValidator.validate_part(self.part_12_B, [self.part_12_A])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+    def test_validate_part_handles_unparseable_mnemonic(self):
+        """
+        If bip39.mnemonic_to_bytes raises (e.g. wordlist mismatch), validate_part
+        must return a clean error dict instead of propagating the exception.
+        """
+        bad_part = MagicMock()
+        bad_part.has_passphrase = False
+        bad_part.mnemonic_str = "totally invalid mnemonic words that do not exist"
+        bad_part.mnemonic_list = "totally invalid mnemonic words that do not exist".split()
+        # Use a wordlist that won't contain these words.
+        bad_part.wordlist = Seed.get_wordlist()
+
+        is_valid, error = SeedXORValidator.validate_part(bad_part, [])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Invalid Part")
+
+
+class TestSeedXORValidatorCombinedSeed(unittest.TestCase):
+    """
+    Tests for SeedXORValidator.validate_combined_seed — catches degenerate
+    XOR results (all-zero / all-ones entropy) that pass the BIP39 checksum
+    but are known, worthless seeds.
+    """
+
+    def test_valid_combined_seed_passes(self):
+        """ A normal combined seed should pass validation. """
+        combined_mnemonic = combine_mnemonics_with_xor([EXAMPLE_12_A, EXAMPLE_12_B])
+        seed = MagicMock()
+        seed.mnemonic_str = " ".join(combined_mnemonic)
+        seed.wordlist = Seed.get_wordlist()
+
+        is_valid, error = SeedXORValidator.validate_combined_seed(seed)
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+    def test_zero_entropy_combined_seed_rejected(self):
+        """ All-zero entropy (the 'abandon...about' seed) must be rejected. """
+        seed = MagicMock()
+        seed.mnemonic_str = ZERO_ENTROPY_MNEMONIC_12
+        seed.wordlist = Seed.get_wordlist()
+
+        is_valid, error = SeedXORValidator.validate_combined_seed(seed)
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Zero Entropy Result")
+
+    def test_all_ones_entropy_combined_seed_rejected(self):
+        """ All-0xFF entropy (a known, worthless seed) must be rejected. """
+        all_ones_entropy = bytes([0xFF] * 16)
+        all_ones_mnemonic = bip39.mnemonic_from_bytes(all_ones_entropy)
+
+        seed = MagicMock()
+        seed.mnemonic_str = all_ones_mnemonic
+        seed.wordlist = Seed.get_wordlist()
+
+        is_valid, error = SeedXORValidator.validate_combined_seed(seed)
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Known Seed Result")
 

--- a/tests/test_seedxor.py
+++ b/tests/test_seedxor.py
@@ -1,0 +1,157 @@
+import unittest
+from unittest.mock import MagicMock
+
+from seedsigner.helpers.mnemonic_generation import combine_mnemonics_with_xor
+from seedsigner.helpers.seed_xor_validator import SeedXORValidator
+
+from embit import bip39
+
+from seedxor_test_vectors import (
+    EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C, RESULT_24_ABC,
+    EXAMPLE_12_A, EXAMPLE_12_B, EXAMPLE_12_C, RESULT_12_ABC,
+    ZERO_ENTROPY_MNEMONIC_12, ZERO_ENTROPY_MNEMONIC_24,
+)
+
+
+
+class TestCombineMnemonicsWithXOR(unittest.TestCase):
+    """
+    Tests the core XOR calculation logic, input validation, and error handling.
+    """
+    
+    def test_xor_24_word_example(self):
+        """Tests the 3-part 24-word XOR calculation from the provided example. """
+        mnemonics = [EXAMPLE_24_A, EXAMPLE_24_B, EXAMPLE_24_C]
+        result = combine_mnemonics_with_xor(mnemonics)
+        self.assertEqual(result, RESULT_24_ABC.split())
+
+
+    def test_xor_12_word_example(self):
+        """Tests the 3-part 12-word XOR calculation from the provided example. """
+        mnemonics = [EXAMPLE_12_A, EXAMPLE_12_B, EXAMPLE_12_C]
+        result = combine_mnemonics_with_xor(mnemonics)
+        self.assertEqual(result, RESULT_12_ABC.split())
+
+
+    def test_xor_identity_property(self):
+        """ Tests the XOR identity property (A ^ B ^ B = A). """
+        mnemonics = [EXAMPLE_12_A, EXAMPLE_12_B, EXAMPLE_12_B]
+        result = combine_mnemonics_with_xor(mnemonics)
+        self.assertEqual(result, EXAMPLE_12_A.split())
+
+
+    def test_xor_null_property(self):
+        """ Tests the XOR null property (A ^ A = 0) for both 12 and 24-word mnemonics. """
+        # Test 12-word case
+        result_12 = combine_mnemonics_with_xor([EXAMPLE_12_A, EXAMPLE_12_A])
+        self.assertEqual(result_12, ZERO_ENTROPY_MNEMONIC_12.split())
+        
+        # Test 24-word case
+        result_24 = combine_mnemonics_with_xor([EXAMPLE_24_A, EXAMPLE_24_A])
+        self.assertEqual(result_24, ZERO_ENTROPY_MNEMONIC_24.split())
+
+
+    def test_handles_list_of_words_input(self):
+        """Tests that the function correctly processes mnemonics formatted as a list of words. """
+        mnemonics = [EXAMPLE_12_A.split(), EXAMPLE_12_B]
+        result = combine_mnemonics_with_xor(mnemonics)
+        
+        expected_result = "person bitter door winner candy polar proud fringe early have bulb apple".split()
+        self.assertEqual(result, expected_result)
+
+
+    def test_raises_error_for_empty_list(self):
+        """Ensures ValueError is raised for an empty mnemonic list. """
+        with self.assertRaisesRegex(ValueError, "Mnemonic list cannot be empty"):
+            combine_mnemonics_with_xor([])
+
+
+    def test_raises_error_for_invalid_mnemonic(self):
+        """Ensures ValueError is raised for a mnemonic with a bad checksum or invalid word. """
+        invalid_mnemonic = "romance wink lottery autumn shop bring dawn tongue range crater truth zebra" # 'zebra' is invalid
+        with self.assertRaisesRegex(ValueError, "Invalid mnemonic"):
+            combine_mnemonics_with_xor([EXAMPLE_12_A, invalid_mnemonic])
+
+
+    def test_raises_error_for_mismatched_lengths(self):
+        """ Ensures ValueError is raised when mnemonics have different entropy lengths. """
+        with self.assertRaisesRegex(ValueError, "All mnemonics must generate entropy of the same length"):
+            combine_mnemonics_with_xor([EXAMPLE_12_A, EXAMPLE_24_A])
+
+
+
+class TestSeedXORValidator(unittest.TestCase):
+    """
+    Tests the validation logic for adding new parts to an XOR operation.
+    """
+    def setUp(self):
+        """ Set up mock Seed objects for testing using the provided examples. """
+        self.part_12_A = MagicMock()
+        self.part_12_A.has_passphrase = False
+        self.part_12_A.mnemonic_str = EXAMPLE_12_A
+        self.part_12_A.mnemonic_list = EXAMPLE_12_A.split()
+
+        self.part_12_B = MagicMock()
+        self.part_12_B.has_passphrase = False
+        self.part_12_B.mnemonic_str = EXAMPLE_12_B
+        self.part_12_B.mnemonic_list = EXAMPLE_12_B.split()
+        
+        self.part_24_A = MagicMock()
+        self.part_24_A.has_passphrase = False
+        self.part_24_A.mnemonic_str = EXAMPLE_24_A
+        self.part_24_A.mnemonic_list = EXAMPLE_24_A.split()
+
+
+    def test_valid_first_part(self):
+        """ A valid part added to an empty list should pass. """
+        is_valid, error = SeedXORValidator.validate_part(self.part_12_A, [])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+
+    def test_valid_second_part(self):
+        """ A second, valid, unique part of the same length should pass. """
+        is_valid, error = SeedXORValidator.validate_part(self.part_12_B, [self.part_12_A])
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+
+    def test_rejects_part_with_passphrase(self):
+        """ Parts with passphrases should be rejected. """
+        self.part_12_A.has_passphrase = True
+        is_valid, error = SeedXORValidator.validate_part(self.part_12_A, [])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Passphrase Not Allowed")
+
+
+    def test_rejects_mismatched_mnemonic_length(self):
+        """ Parts of different lengths should be rejected. """
+        is_valid, error = SeedXORValidator.validate_part(self.part_24_A, [self.part_12_A])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Mnemonic Length Mismatch")
+
+
+    def test_rejects_duplicate_part(self):
+        """ An identical part should be rejected. """
+        is_valid, error = SeedXORValidator.validate_part(self.part_12_A, [self.part_12_A])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Duplicate Part")
+        self.assertIn("part #1", error["message"])
+
+
+    def test_rejects_inverse_part(self):
+        """ A binary inverse part (which would cancel another out) should be rejected. """
+        entropy_a = bip39.mnemonic_to_bytes(EXAMPLE_12_A)
+        inverse_entropy = bytes(b ^ 0xFF for b in entropy_a)
+        inverse_mnemonic_str = bip39.mnemonic_from_bytes(inverse_entropy)
+
+        inverse_part = MagicMock()
+        inverse_part.has_passphrase = False
+        inverse_part.mnemonic_str = inverse_mnemonic_str
+        inverse_part.mnemonic_list = inverse_mnemonic_str.split()
+
+        is_valid, error = SeedXORValidator.validate_part(inverse_part, [self.part_12_A])
+        self.assertFalse(is_valid)
+        self.assertEqual(error["title"], "Seed Inversion")
+        self.assertIn("binary inverse of part #1", error["message"])
+


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Implements the long-requested Seed XOR rebuild flow from issue #738.

Seed XOR (documented by Coldcard in [seed-xor.md](https://github.com/Coldcard/firmware/blob/master/docs/seed-xor.md)) lets users split a seed into N parts that are combined by bitwise XOR. SeedSigner does not currently provide a Seed XOR splitting or reconstruction flow. This PR adds on-device reconstruction of a seed from existing Seed XOR parts, so users can restore their wallet without first combining the parts on another system.

This is a port of PR #738 (Advaitgaur004) / PR #885 (berlinxray) onto current `dev`, implemented natively against the Seed-object paradigm (65e312c) rather than the removed `seed_num` indexing.

### Solution

Rebuild only; creating XOR parts from an existing seed is outside this PR’s scope.

- Tools/Load A Seed -> **Rebuild SeedXOR** entry, gated behind a new Advanced setting `Seed XOR` (default **disabled**; hidden in the General settings UI).
- Load parts one at a time via SeedQR scan, 12/24-word manual entry, or by selecting a seed already in memory. Each part's fingerprint is shown for confirmation before it is committed.
- Validation (`helpers/seed_xor_validator.py`) rejects: passphrases on parts, mnemonic-length mismatches between parts, duplicate parts, and binary-inversion parts (XORing a part with its complement is a footgun). Finalize requires >= 2 parts.
- Finalize combines parts via `combine_mnemonics_with_xor` and shows the resulting fingerprint, then offers keep/discard of the loaded parts. A degenerate all-zero-entropy result (the publicly-known "abandon…about" seed) is detected and rejected with an explicit error screen instead of silently loading a worthless wallet.
- Design decisions carried over from the issue thread: terminology is "part" (per Coldcard docs), and returning Home wipes in-progress XOR parts (wipe-everything-except-finalized-Seeds guarantee) via `clear_rebuild_seedxor_data` in the MainMenuView branch of `Controller.start()`.

Also extends `tests/screenshot_generator/generator.py` with the full set of Rebuild Seed XOR screens so the flow is covered by the standard per-locale screenshot generation.

### Additional Information

- Scope is deliberately limited to reconstruction from existing Seed XOR parts; this PR does not add a splitting workflow.
- Validation guards verified hands-on on hardware (Pi Zero v1.3, SeedSigner OS build from this branch): mismatched lengths, duplicate parts, and zero-entropy result (a+b+c=0) are all rejected as designed; 6 XOR combinations cross-checked against Coldcard (x+y, x+z, y+z, x+n, y+n, z+n, where n is the all-zeros test vector fp 73c5da0a).
- Test coverage: `tests/test_seedxor.py` (unit: XOR combination + validators), `tests/test_flow_seedxor.py` (FlowTests for the full rebuild flow), `tests/seedxor_test_vectors.py` (shared vectors). Full suite: 243 passed.
- Co-authored by the original PR authors: Advaitgaur004, berlinxray.

### Screenshots

All 240x240, generated with `tests/screenshot_generator/generator.py --locale en` (the generator entries are part of this PR):

Load A Seed with "Rebuild SeedXOR" entry visible (Advanced setting enabled):

![LoadSeedView_seedxor_enabled](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/LoadSeedView_seedxor_enabled.png?raw=true)

Manage parts — empty / one / two loaded:

![RebuildSeedXORManageView_no_parts](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORManageView_no_parts.png?raw=true)
![RebuildSeedXORManageView_one_part](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORManageView_one_part.png?raw=true)
![RebuildSeedXORManageView_two_parts](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORManageView_two_parts.png?raw=true)

Load a part / fingerprint confirmation / select an already-loaded seed:

![RebuildSeedXORLoadPartView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORLoadPartView.png?raw=true)
![RebuildSeedXORShowFingerprintView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORShowFingerprintView.png?raw=true)
![RebuildSeedXORSelectExistingSeedView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORSelectExistingSeedView.png?raw=true)

View / remove loaded parts:

![RebuildSeedXORViewPartsView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORViewPartsView.png?raw=true)
![RebuildSeedXORRemovePartsView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORRemovePartsView.png?raw=true)
![RebuildSeedXORConfirmRemovePartView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORConfirmRemovePartView.png?raw=true)

Finalize (combined fingerprint) / finalize options / cancel:

![RebuildSeedXORFinalizeView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORFinalizeView.png?raw=true)
![RebuildSeedXORFinalizeOptionsView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORFinalizeOptionsView.png?raw=true)
![RebuildSeedXORCancelView](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORCancelView.png?raw=true)

Degenerate-result guard (zero-entropy XOR is rejected):

![RebuildSeedXORFinalizeView_zero_entropy_error](https://github.com/21bitstep/seedsigner/blob/pr-screenshots/screenshots/RebuildSeedXORFinalizeView_zero_entropy_error.png?raw=true)

---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally

- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

`pytest tests/ --ignore=tests/screenshot_generator`: **243 passed** (Python 3.11, deps per requirements.txt; l10n catalogs compiled as in CI). The 34 Seed XOR tests all pass. `tests/screenshot_generator/generator.py --locale en`: 1 passed (used to produce the screenshots above).

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.

- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.

- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:

* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.
