### PR TITLE
Sd removal prompt

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -288,6 +288,7 @@ class Controller(Singleton):
                 Settings.HOSTNAME == Settings.SEEDSIGNER_OS
                 and self.microsd.is_inserted
                 and not initial_destination
+                and self.settings.get_value(SettingsConstants.SETTING__MICROSD_BOOT_PROMPT) == SettingsConstants.OPTION__ENABLED
             ):
                 next_destination = Destination(RemoveMicroSDWarningView)
             elif self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS:

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -280,11 +280,20 @@ class Controller(Singleton):
             else:
                 next_destination = Destination(MainMenuView)
             
-            # Set up our one-time toast notification tip to remove the SD card
-            if self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS:
-                self.activate_toast(RemoveSDCardToastManagerThread())
-            elif self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FOREVER:
+            # SeedSigner OS: if the MicroSD is still inserted after boot, require
+            # eject (or an explicit Skip on that screen) before the Main Menu.
+            # Desktop / test hosts always report is_inserted=True, so only enforce
+            # this gate on the real OS image.
+            if (
+                Settings.HOSTNAME == Settings.SEEDSIGNER_OS
+                and self.microsd.is_inserted
+                and not initial_destination
+            ):
                 next_destination = Destination(RemoveMicroSDWarningView)
+            elif self.settings.get_value(SettingsConstants.SETTING__MICROSD_TOAST_TIMER) == SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS:
+                self.activate_toast(RemoveSDCardToastManagerThread())
+            # MICROSD_TOAST_TIMER_FOREVER is superseded by the OS gate above when the
+            # card is present; keep the setting for backward compatibility / toast path.
 
             while True:
                 # Destination(None) is a special case; render the Home screen

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1062,10 +1062,7 @@ class RemoveMicroSDScreen(WarningScreen):
     title: str = _mft("Action Required")
     status_icon_name: str = SeedSignerIconConstants.MICROSD
     status_headline: str = None
-    text: str = _mft(
-        "Remove the MicroSD card to continue.\n\n"
-        "Press Skip only if you need the card inserted (e.g. persistent settings)."
-    )
+    text: str = _mft("Do you want to remove the SD card before continuing?")
     show_back_button: bool = False
     button_data: list = field(default_factory=lambda: [ButtonOption("Skip")])
 

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1059,7 +1059,7 @@ class RemoveMicroSDScreen(WarningScreen):
 
     Polls MicroSD insertion so ejecting the card advances without a button press.
     """
-    title: str = _mft("Action Required")
+    title: str = ""
     status_icon_name: str = SeedSignerIconConstants.MICROSD
     status_headline: str = None
     text: str = _mft("Do you want to remove the SD card before continuing?")

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 #   screens with buttons.
 RET_CODE__BACK_BUTTON = 1000
 RET_CODE__POWER_BUTTON = 1001
+RET_CODE__SD_REMOVED = 1002
 
 
 
@@ -1047,6 +1048,52 @@ class WarningScreen(WarningEdgesMixin, LargeIconStatusScreen):
     status_color: str = GUIConstants.WARNING_COLOR
     status_headline: str = _mft("Privacy Leak!")     # The colored text under the alert icon
     button_data: list = field(default_factory=lambda: [ButtonOption("I understand")])
+
+
+
+
+@dataclass
+class RemoveMicroSDScreen(WarningScreen):
+    """
+    Boot gate: stay here until the MicroSD is removed, or the user explicitly Skips.
+
+    Polls MicroSD insertion so ejecting the card advances without a button press.
+    """
+    title: str = _mft("Action Required")
+    status_icon_name: str = SeedSignerIconConstants.MICROSD
+    status_headline: str = None
+    text: str = _mft(
+        "Remove the MicroSD card to continue.\n\n"
+        "Press Skip only if you need the card inserted (e.g. persistent settings)."
+    )
+    show_back_button: bool = False
+    button_data: list = field(default_factory=lambda: [ButtonOption("Skip")])
+
+
+    def _run(self):
+        from seedsigner.hardware.microsd import MicroSD
+
+        # Ensure the single Skip button is highlighted
+        if self.buttons:
+            self.buttons[self.selected_button].is_selected = True
+            with self.renderer.lock:
+                self.buttons[self.selected_button].render()
+                self.renderer.show_image()
+
+        while True:
+            # Auto-advance as soon as the card is gone
+            if not MicroSD.get_instance().is_inserted:
+                return RET_CODE__SD_REMOVED
+
+            # Non-blocking-ish input poll so we can keep checking the SD slot
+            if self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
+                # Debounce: wait for release
+                while self.hw_inputs.check_for_low(keys=HardwareButtonsConstants.KEYS__ANYCLICK):
+                    time.sleep(0.05)
+                self.hw_inputs.update_last_input_time()
+                return self.selected_button
+
+            time.sleep(0.1)
 
 
 

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -109,6 +109,9 @@ class BaseToastOverlayManagerThread(BaseThread):
         self.activation_delay: int = activation_delay
         self.duration: int = duration
         self._toggle_renderer_lock: bool = False
+        # When True, do not blit previous_screen_state on exit (e.g. navigation already
+        # drew a new screen while the toast released the lock).
+        self.skip_restore: bool = False
 
         self.renderer = Renderer.get_instance()
         self.controller = Controller.get_instance()
@@ -191,11 +194,15 @@ class BaseToastOverlayManagerThread(BaseThread):
             logger.info(f"{self.__class__.__name__}: exiting")
             if has_rendered and self.renderer.lock.locked():
                 # As far as we know, we currently hold the Renderer.lock
-                self.renderer.show_image(previous_screen_state)
-                logger.info(f"{self.__class__.__name__}: restored previous screen state")
+                if not self.skip_restore and previous_screen_state is not None:
+                    self.renderer.show_image(previous_screen_state)
+                    logger.info(f"{self.__class__.__name__}: restored previous screen state")
+                else:
+                    logger.info(f"{self.__class__.__name__}: skip_restore; leaving current screen")
 
             # We're done, release the lock
-            self.renderer.lock.release()
+            if self.renderer.lock.locked():
+                self.renderer.lock.release()
 
 
 

--- a/src/seedsigner/hardware/microsd.py
+++ b/src/seedsigner/hardware/microsd.py
@@ -26,7 +26,12 @@ class MicroSD(Singleton, BaseThread):
 
             # explicitly call BaseThread __init__ since multiple class inheritance
             BaseThread.__init__(microsd)
-    
+
+            # Latest hotplug event from mdev FIFO, if any. None until the first event.
+            # Used so UI can react as soon as the card is pulled, without waiting for
+            # the mount point to disappear (unmount can lag several seconds).
+            microsd._hotplug_inserted = None
+
         return cls._instance
 
 
@@ -35,6 +40,10 @@ class MicroSD(Singleton, BaseThread):
         from seedsigner.models.settings import Settings  # Import here to avoid circular import issues
 
         if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+            # Prefer the most recent hotplug event when available so callers (boot gate,
+            # toasts) agree on timing. Fall back to the mount point before any event.
+            if self._hotplug_inserted is not None:
+                return self._hotplug_inserted
             return os.path.exists(MicroSD.MOUNT_POINT)
         else:
             # Always True for Raspi OS
@@ -50,7 +59,7 @@ class MicroSD(Singleton, BaseThread):
         from seedsigner.gui.toast import SDCardStateChangeToastManagerThread
         from seedsigner.models.settings import Settings  # Import here to avoid circular import issues
         action = ""
-        
+
         # explicitly only microsd add/remove detection in seedsigner-os
         if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
 
@@ -61,13 +70,18 @@ class MicroSD(Singleton, BaseThread):
 
             if os.path.exists(self.FIFO_PATH):
                 os.remove(self.FIFO_PATH)
-            
+
             os.mkfifo(self.FIFO_PATH, self.FIFO_MODE)
 
             while self.keep_running:
                 with open(self.FIFO_PATH) as fifo:
-                    action = fifo.read()
+                    action = fifo.read().strip()
                     logger.info(f"fifo message: {action}")
+
+                    if action == MicroSD.ACTION__INSERTED:
+                        self._hotplug_inserted = True
+                    elif action == MicroSD.ACTION__REMOVED:
+                        self._hotplug_inserted = False
 
                     Settings.handle_microsd_state_change(action=action)
                     Controller.get_instance().activate_toast(SDCardStateChangeToastManagerThread(action=action))

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -353,6 +353,7 @@ class SettingsConstants:
     SETTING__QR_BRIGHTNESS_TIPS = "qr_brightness_tips"
     SETTING__PARTNER_LOGOS = "partner_logos"
     SETTING__MICROSD_TOAST_TIMER = "microsd_toast_timer"
+    SETTING__MICROSD_BOOT_PROMPT = "microsd_boot_prompt"
 
     SETTING__DEBUG = "debug"
 
@@ -682,6 +683,15 @@ class SettingsDefinition:
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.ALL_MICROSD_TOAST_TIMERS,
                       default_value=SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__MICROSD_BOOT_PROMPT,
+                      abbreviated_name="sd_boot",
+                      display_name=_mft("MicroSD boot prompt"),
+                      # TRANSLATOR_NOTE: When enabled, ask to remove the MicroSD after boot before the main menu
+                      help_text=_mft("Ask to remove MicroSD after boot"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__ENABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__MESSAGE_SIGNING,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -442,35 +442,25 @@ class OptionDisabledView(View):
 
 
 class RemoveMicroSDWarningView(View):
-    CONTINUE = ButtonOption("Continue")
-    SETTINGS = ButtonOption("Settings")
+    """
+    Post-boot gate: block until MicroSD is removed, or the user explicitly skips.
+
+    Skip is intentional — e.g. user needs the card in for persistent settings.
+    """
+    SKIP = ButtonOption("Skip")
 
     def run(self):
-        button_data = [self.CONTINUE, self.SETTINGS]
-        selected_menu_num = self.run_screen(
-            WarningScreen,
-            title=_("Action Required"),
-            status_icon_name=SeedSignerIconConstants.MICROSD,
-            status_headline=None,
-            text=_("You must remove the\nMicroSD card to continue."),
-            show_back_button=False,
-            button_data=button_data,
-        )
+        from seedsigner.hardware.microsd import MicroSD
+        from seedsigner.gui.screens.screen import RemoveMicroSDScreen, RET_CODE__SD_REMOVED
 
-        if button_data[selected_menu_num] == self.CONTINUE:
-            from seedsigner.hardware.microsd import MicroSD
-            if not MicroSD.get_instance().is_inserted:
-                return Destination(MainMenuView, clear_history=True)
-            else:
-                return Destination(RemoveMicroSDWarningView, clear_history=True)
+        # Already ejected (or never present) → go straight home
+        if not MicroSD.get_instance().is_inserted:
+            return Destination(MainMenuView, clear_history=True)
 
-        elif button_data[selected_menu_num] == self.SETTINGS:
-            from seedsigner.views.settings_views import SettingsEntryUpdateSelectionView
-            return Destination(
-                SettingsEntryUpdateSelectionView, 
-                view_args=dict(
-                    attr_name=SettingsConstants.SETTING__MICROSD_TOAST_TIMER,
-                    blocking_view=RemoveMicroSDWarningView,
-                    unblocking_view=MainMenuView
-                )
-            )
+        result = self.run_screen(RemoveMicroSDScreen)
+
+        if result == RET_CODE__SD_REMOVED:
+            return Destination(MainMenuView, clear_history=True)
+
+        # Skip pressed — continue with card still inserted
+        return Destination(MainMenuView, clear_history=True)

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -460,6 +460,15 @@ class RemoveMicroSDWarningView(View):
         result = self.run_screen(RemoveMicroSDScreen)
 
         if result == RET_CODE__SD_REMOVED:
+            # The SD-removed toast grabs the Renderer lock for its full duration and
+            # would otherwise block Main Menu from painting (~3s), then restore the
+            # gate screen on top. Release the lock so Main Menu can draw immediately,
+            # and skip restoring the previous (gate) framebuffer.
+            from seedsigner.controller import Controller
+            toast = Controller.get_instance().toast_notification_thread
+            if toast is not None and toast.is_alive():
+                toast.skip_restore = True
+                toast.toggle_renderer_lock()
             return Destination(MainMenuView, clear_history=True)
 
         # Skip pressed — continue with card still inserted

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -468,8 +468,13 @@ class RemoveMicroSDWarningView(View):
             toast = Controller.get_instance().toast_notification_thread
             if toast is not None and toast.is_alive():
                 toast.skip_restore = True
-                toast.toggle_renderer_lock()
-            return Destination(MainMenuView, clear_history=True)
+                toast.stop()
+                # Wait briefly for toast.run() finally to release the lock
+                import time
+                for _ in range(50):
+                    if not toast.is_alive():
+                        break
+                    time.sleep(0.02)
 
         # Skip pressed — continue with card still inserted
         return Destination(MainMenuView, clear_history=True)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -160,6 +160,15 @@ class TestFlowTest(FlowTest):
             FlowStep(MainMenuView, screen_return_value=Exception("Test exception")),
             FlowStep(UnhandledExceptionView),
         ])
+
+
+    def test_remove_microsd_warning_skip(self):
+        """With MicroSD inserted, Skip proceeds to MainMenuView."""
+        self.mock_microsd.is_inserted = True
+        self.run_sequence([
+            FlowStep(RemoveMicroSDWarningView, screen_return_value=0),
+            FlowStep(MainMenuView),
+        ])
     
 
     def test_raise_exception_on_bad_button_data_type(self):
@@ -196,47 +205,4 @@ class TestFlowTest(FlowTest):
             FlowStep(MainMenuView),  # Need a next Destination to force the first step to run
         ])
 
-    def test_remove_microsd_blocking(self):
-        """
-        Verifies three related behaviors:
 
-        1) If the RemoveMicroSDWarningView launches the SettingsEntryUpdateSelectionView
-           and the user presses Back without changing the tracked setting, the flow
-           returns to RemoveMicroSDWarningView (the blocking condition remains).
-        2) If the user changes the tracked setting while in the settings entry, the
-           flow unblocks and navigates to MainMenuView.
-        3) If the MicroSD is physically removed and the user presses Continue on the
-           warning, the flow proceeds to MainMenuView.
-        """
-        controller = Controller.get_instance()
-
-        settings_entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__MICROSD_TOAST_TIMER)
-        controller.settings.set_value(settings_entry.attr_name, SettingsConstants.MICROSD_TOAST_TIMER_FOREVER)
-
-        # There are only two ways of exiting RemoveMicroSDWarningView when SETTING__MICROSD_TOAST_TIMER -> MICROSD_TOAST_TIMER_FOREVER
-        self.run_sequence([
-            FlowStep(RemoveMicroSDWarningView, button_data_selection=RemoveMicroSDWarningView.SETTINGS),
-            FlowStep(SettingsEntryUpdateSelectionView, screen_return_value=RET_CODE__BACK_BUTTON),
-            FlowStep(RemoveMicroSDWarningView, button_data_selection=RemoveMicroSDWarningView.SETTINGS),
-            # 1) Modifying the setting
-            FlowStep(SettingsEntryUpdateSelectionView, screen_return_value=0),
-            FlowStep(MainMenuView)
-        ])
-
-        self.reset_controller()
-        controller = Controller.get_instance()
-
-        settings_entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__MICROSD_TOAST_TIMER)
-        controller.settings.set_value(settings_entry.attr_name, SettingsConstants.MICROSD_TOAST_TIMER_FOREVER)
-
-        # 2) Removing the MicroSD card and pressing CONTINUE
-        self.mock_microsd.is_inserted = False
-        assert MicroSD.get_instance().is_inserted is False
-
-        self.run_sequence([
-            FlowStep(RemoveMicroSDWarningView, button_data_selection=RemoveMicroSDWarningView.CONTINUE),
-            FlowStep(MainMenuView)
-        ])
-
-        # Restore the setting for the controller
-        controller.settings.set_value(settings_entry.attr_name, SettingsConstants.MICROSD_TOAST_TIMER_FIVE_SECONDS)

--- a/tests/test_microsd_boot_prompt.py
+++ b/tests/test_microsd_boot_prompt.py
@@ -1,0 +1,112 @@
+"""
+Tests for the post-boot MicroSD removal prompt and its Advanced setting.
+"""
+from unittest.mock import MagicMock, patch
+
+from base import BaseTest, FlowTest, FlowStep
+
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, RET_CODE__SD_REMOVED, ButtonOption
+from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
+from seedsigner.views.view import Destination, MainMenuView, RemoveMicroSDWarningView
+from seedsigner.views import settings_views
+
+
+class TestMicroSDBootPromptSetting(BaseTest):
+    def test_setting_exists_and_defaults_enabled(self):
+        entry = SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__MICROSD_BOOT_PROMPT)
+        assert entry is not None
+        assert entry.visibility == SettingsConstants.VISIBILITY__ADVANCED
+        assert entry.default_value == SettingsConstants.OPTION__ENABLED
+        assert entry.category == SettingsConstants.CATEGORY__FEATURES
+
+        assert (
+            self.settings.get_value(SettingsConstants.SETTING__MICROSD_BOOT_PROMPT)
+            == SettingsConstants.OPTION__ENABLED
+        )
+
+    def test_setting_can_be_disabled(self):
+        self.settings.set_value(
+            SettingsConstants.SETTING__MICROSD_BOOT_PROMPT,
+            SettingsConstants.OPTION__DISABLED,
+        )
+        assert (
+            self.settings.get_value(SettingsConstants.SETTING__MICROSD_BOOT_PROMPT)
+            == SettingsConstants.OPTION__DISABLED
+        )
+
+
+class TestRemoveMicroSDWarningView(BaseTest):
+    def test_already_removed_goes_to_main_menu(self):
+        with patch("seedsigner.hardware.microsd.MicroSD.get_instance") as mock_get:
+            microsd = MagicMock()
+            microsd.is_inserted = False
+            mock_get.return_value = microsd
+
+            dest = RemoveMicroSDWarningView().run()
+            assert isinstance(dest, Destination)
+            assert dest.View_cls == MainMenuView
+            assert dest.clear_history is True
+
+    def test_skip_goes_to_main_menu(self):
+        with patch("seedsigner.hardware.microsd.MicroSD.get_instance") as mock_get, patch.object(
+            RemoveMicroSDWarningView, "run_screen", return_value=0
+        ):
+            microsd = MagicMock()
+            microsd.is_inserted = True
+            mock_get.return_value = microsd
+
+            dest = RemoveMicroSDWarningView().run()
+            assert dest.View_cls == MainMenuView
+            assert dest.clear_history is True
+
+    def test_sd_removed_during_screen_goes_to_main_menu(self):
+        with patch("seedsigner.hardware.microsd.MicroSD.get_instance") as mock_get, patch.object(
+            RemoveMicroSDWarningView,
+            "run_screen",
+            return_value=RET_CODE__SD_REMOVED,
+        ):
+            microsd = MagicMock()
+            microsd.is_inserted = True
+            mock_get.return_value = microsd
+
+            dest = RemoveMicroSDWarningView().run()
+            assert dest.View_cls == MainMenuView
+            assert dest.clear_history is True
+
+
+class TestMicroSDBootPromptFlow(FlowTest):
+    def test_can_disable_boot_prompt_from_advanced_settings(self):
+        """Settings → Advanced → MicroSD boot prompt → Disabled."""
+        settings_entry = SettingsDefinition.get_settings_entry(
+            SettingsConstants.SETTING__MICROSD_BOOT_PROMPT
+        )
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(
+                settings_views.SettingsMenuView,
+                button_data_selection=settings_views.SettingsMenuView.ADVANCED,
+            ),
+            FlowStep(
+                settings_views.SettingsMenuView,
+                button_data_selection=ButtonOption(settings_entry.display_name),
+            ),
+            FlowStep(
+                settings_views.SettingsEntryUpdateSelectionView,
+                button_data_selection=ButtonOption(
+                    settings_entry.get_selection_option_display_name_by_value(
+                        SettingsConstants.OPTION__DISABLED
+                    )
+                ),
+            ),
+            FlowStep(
+                settings_views.SettingsEntryUpdateSelectionView,
+                screen_return_value=RET_CODE__BACK_BUTTON,
+            ),
+            FlowStep(settings_views.SettingsMenuView),
+        ])
+
+        assert (
+            self.settings.get_value(SettingsConstants.SETTING__MICROSD_BOOT_PROMPT)
+            == SettingsConstants.OPTION__DISABLED
+        )


### PR DESCRIPTION
AI Disclosure: Used Grok for this, all reviewed and working on a home-made Seedsigner, all tests pass.

## Description

Explained here -> https://github.com/SeedSigner/seedsigner/issues/546

### Solution

Explained here -> https://github.com/SeedSigner/seedsigner/issues/546#issuecomment-5376743935

### Additional Information

Can be annoying if you don't care about the SD card being in once you add a seed, but you can turn that off as a persistent setting after dismissing the prompt.

### Screenshots

<img width="970" height="778" alt="image" src="https://github.com/user-attachments/assets/2d228a16-c77e-430e-a2b3-f626dffe03a4" />

---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.