### PR TITLE
Clarify supported Python versions (fix #978)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 description = "Build an offline, airgapped Bitcoin signing device for less than $50!"
 name = "seedsigner"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 version = "0.8.7"
 
 [project.urls]


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Closes #978.

`pyproject.toml` currently declares:

```toml
requires-python = ">=3.10"
```

That implies any Python ≥ 3.10 is supported. In practice, a fresh developer setup on Python **3.13+** (reported on **3.14.6**) fails when installing dependencies because `Pillow==10.3.0` in `requirements.txt` has no wheels for those versions, so pip falls back to building from source and errors with a vague wheel-build failure.

CI already treats **3.12** as the upper test bound (`.github/workflows/tests.yml` matrix: `3.10` and `3.12` only), and `tests/requirements.txt` pins tooling that predates 3.13. So the packaging metadata was advertising a wider Python range than the project actually exercises or can reliably install.

### Solution

Update the packaging constraint to match reality:

```toml
requires-python = ">=3.10,<3.13"
```

This does **not** change runtime behavior on supported versions. It makes tooling (`pip`, installers, editors) reject unsupported interpreters early with a clear message, instead of a cryptic Pillow build failure after a long install attempt.

Approach rationale:
- Matches the issue author's recommended fix and the existing CI matrix.
- Keeps the change minimal and scoped to metadata only (no dependency upgrades, no CI matrix expansion).
- Leaves a clear path for a follow-up if/when maintainers want to support 3.13+ (bump Pillow / test deps and extend CI).

### Additional Information

**What this PR intentionally does *not* do:**
- Does not bump `Pillow` or other pinned deps.
- Does not add Python 3.13/3.14 to CI.
- Does not change `docs/raspberry_pi_os_build_instructions.md` (that path already targets Python 3.10 for device builds).

**Follow-ups (out of scope here):**
- If SeedSigner wants 3.13+ support later: upgrade Pillow (and verify pytest/other pins), then expand the CI matrix and relax this upper bound.
- Optionally add explicit `Programming Language :: Python :: 3.10` / `3.11` / `3.12` classifiers for PyPI clarity.

**Local verification performed for this PR:**
- Confirmed `requires-python = ">=3.10,<3.13"` accepts 3.10–3.12 and rejects 3.9 / 3.13 / 3.14.6 via `packaging.specifiers.SpecifierSet`.
- Fresh Python **3.12** venv: installed `requirements.txt`, `tests/requirements.txt`, `l10n/requirements-l10n.txt`, `pip install -e .`, compiled catalogs (`python setup.py compile_catalog`), then ran full suite: **`209 passed`**.
- Diff remains one-line packaging metadata; no application code paths changed.

### Screenshots

N/A — packaging metadata only; no UI changes.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I’m a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

N/A — packaging-metadata-only change; no device/emulator UI or hardware behavior to exercise. Validated via Python 3.12 local pytest + `requires-python` specifier checks instead.

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.
