### PR TITLE
Accept, display, and sign wsh() Miniscript wallet descriptors (e.g. Liana)

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1608,20 +1608,27 @@ class MultisigWalletDescriptorScreen(ButtonListScreen):
 @dataclass
 class LianaRecoveryWalletScreen(ButtonListScreen):
     """
-    Curated review screen for the one Miniscript shape this build supports
-    (see embit_utils.match_liana_recovery_policy): spendable now by a primary
-    key, or by a recovery key after a relative timelock.
+    Curated review screen for the Miniscript shape this build supports (see
+    embit_utils.match_liana_recovery_policy): spendable now by a primary key
+    or key-quorum, or by a recovery key or key-quorum after a relative
+    timelock.
 
-    Deliberately two separate labeled fields rather than one line of policy
-    text. A generic "(key A) or ((key B) and (after N blocks))" summary
-    forces the user to mentally track parenthesization to know which
-    conditions actually apply together, which reviewers flagged as
-    unreadable and unsafe on this screen size (seedsigner#306, PR #1026).
-    Structured fields make the OR and the timelock explicit without any
-    expression to parse.
+    Deliberately separate labeled fields rather than one line of policy text.
+    A generic "(key A) or ((key B) and (after N blocks))" summary forces the
+    user to mentally track parenthesization to know which conditions actually
+    apply together, which reviewers flagged as unreadable and unsafe on this
+    screen size (seedsigner#306, PR #1026). Structured fields make the OR and
+    the timelock explicit without any expression to parse.
+
+    Each path's threshold is folded into its label ("Spend now, 2 of 3")
+    rather than shown as a separate field, so a quorum wallet costs no extra
+    vertical space beyond the additional fingerprints themselves. A 1-of-1
+    path omits the threshold entirely, since "1 of 1" is noise.
     """
-    primary_fingerprint: str = None
-    recovery_fingerprint: str = None
+    primary_threshold: int = None
+    primary_fingerprints: List[str] = None
+    recovery_threshold: int = None
+    recovery_fingerprints: List[str] = None
     timelock_blocks: int = None
 
     def __post_init__(self):
@@ -1629,10 +1636,29 @@ class LianaRecoveryWalletScreen(ButtonListScreen):
         self.is_bottom_list = True
         super().__post_init__()
 
+        if len(self.primary_fingerprints) > 1:
+            # TRANSLATOR_NOTE: Label for the keys that can spend immediately; {k} of {n} keys required
+            primary_label = _("Spend now, {k} of {n}").format(
+                k=self.primary_threshold, n=len(self.primary_fingerprints)
+            )
+        else:
+            # TRANSLATOR_NOTE: Label for the single key that can spend immediately, with no waiting period
+            primary_label = _("Spend now with")
+
+        if len(self.recovery_fingerprints) > 1:
+            # TRANSLATOR_NOTE: Recovery keys label; {n} blocks must pass, then {k} of {total} keys are required
+            recovery_label = _("OR after {n} blocks, {k} of {total}").format(
+                n=self.timelock_blocks,
+                k=self.recovery_threshold,
+                total=len(self.recovery_fingerprints),
+            )
+        else:
+            # TRANSLATOR_NOTE: Label for the recovery key; {n} is the number of blocks that must pass first
+            recovery_label = _("OR after {n} blocks with").format(n=self.timelock_blocks)
+
         self.components.append(IconTextLine(
-            # TRANSLATOR_NOTE: Label for the key that can spend immediately, with no waiting period
-            label_text=_("Spend now with"),
-            value_text=self.primary_fingerprint,
+            label_text=primary_label,
+            value_text=" ".join(self.primary_fingerprints),
             font_size=24,
             font_name=GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME,
             screen_y=self.top_nav.height,
@@ -1641,9 +1667,8 @@ class LianaRecoveryWalletScreen(ButtonListScreen):
         ))
 
         self.components.append(IconTextLine(
-            # TRANSLATOR_NOTE: Label for the recovery key; {n} is the number of blocks that must pass first
-            label_text=_("OR after {n} blocks with").format(n=self.timelock_blocks),
-            value_text=self.recovery_fingerprint,
+            label_text=recovery_label,
+            value_text=" ".join(self.recovery_fingerprints),
             font_size=24,
             font_name=GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME,
             screen_y=self.components[-1].screen_y + self.components[-1].height + 2*GUIConstants.COMPONENT_PADDING,

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1606,6 +1606,54 @@ class MultisigWalletDescriptorScreen(ButtonListScreen):
 
 
 @dataclass
+class LianaRecoveryWalletScreen(ButtonListScreen):
+    """
+    Curated review screen for the one Miniscript shape this build supports
+    (see embit_utils.match_liana_recovery_policy): spendable now by a primary
+    key, or by a recovery key after a relative timelock.
+
+    Deliberately two separate labeled fields rather than one line of policy
+    text. A generic "(key A) or ((key B) and (after N blocks))" summary
+    forces the user to mentally track parenthesization to know which
+    conditions actually apply together, which reviewers flagged as
+    unreadable and unsafe on this screen size (seedsigner#306, PR #1026).
+    Structured fields make the OR and the timelock explicit without any
+    expression to parse.
+    """
+    primary_fingerprint: str = None
+    recovery_fingerprint: str = None
+    timelock_blocks: int = None
+
+    def __post_init__(self):
+        self.title = _("Recovery Wallet")
+        self.is_bottom_list = True
+        super().__post_init__()
+
+        self.components.append(IconTextLine(
+            # TRANSLATOR_NOTE: Label for the key that can spend immediately, with no waiting period
+            label_text=_("Spend now with"),
+            value_text=self.primary_fingerprint,
+            font_size=24,
+            font_name=GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME,
+            screen_y=self.top_nav.height,
+            is_text_centered=True,
+            auto_line_break=True,
+        ))
+
+        self.components.append(IconTextLine(
+            # TRANSLATOR_NOTE: Label for the recovery key; {n} is the number of blocks that must pass first
+            label_text=_("OR after {n} blocks with").format(n=self.timelock_blocks),
+            value_text=self.recovery_fingerprint,
+            font_size=24,
+            font_name=GUIConstants.FIXED_WIDTH_EMPHASIS_FONT_NAME,
+            screen_y=self.components[-1].screen_y + self.components[-1].height + 2*GUIConstants.COMPONENT_PADDING,
+            is_text_centered=True,
+            auto_line_break=True,
+        ))
+
+
+
+@dataclass
 class SeedSignMessageConfirmMessageScreen(ButtonListScreen):
     page_num: int = None
 

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -1590,6 +1590,7 @@ class MultisigWalletDescriptorScreen(ButtonListScreen):
             font_size=20,
             screen_y=self.top_nav.height,
             is_text_centered=True,
+            auto_line_break=True,
         ))
 
         self.components.append(IconTextLine(

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -626,6 +626,10 @@ class ToolsAddressExplorerAddressTypeScreen(ButtonListScreen):
                 label_text=_("Wallet descriptor"),
                 value_text=self.wallet_descriptor_display_name,
                 is_text_centered=True,
+                # Without this, a summary longer than the screen width is
+                # silently clipped mid-word at the edge rather than wrapped,
+                # hiding the tail of the description entirely.
+                auto_line_break=True,
                 screen_x=GUIConstants.EDGE_PADDING,
                 screen_y=self.top_nav.height + GUIConstants.COMPONENT_PADDING,
             ))

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -359,22 +359,59 @@ _FINGERPRINTS_PER_LINE = 2
 
 
 
+def _flatten_and_v_keys(node):
+    """
+    Flatten a chain of `and_v` whose leaves are all plain keys into that list
+    of keys, or return None if any leaf is something else.
+
+    An n-of-n path compiles to nested and_v rather than multi(n,...) because
+    chaining is cheaper in script bytes, so
+    `and_v(v:and_v(v:pk(A),pk(B)),pk(C))` is how "all three of A, B and C must
+    sign" actually arrives. Confirmed against a real Liana 3-of-3 export.
+
+    Only and_v nodes and key leaves are accepted. A timelock, hash preimage or
+    any other condition inside the chain means this is not a pure key quorum,
+    and the caller must not describe it as one.
+    """
+    node = _unwrap(node)
+    name = getattr(node, "NAME", None)
+
+    if name in ("pk", "pkh"):
+        return [node.arg]
+
+    if name == "and_v":
+        keys = []
+        for arg in node.args:
+            sub = _flatten_and_v_keys(arg)
+            if sub is None:
+                return None
+            keys.extend(sub)
+        return keys
+
+    return None
+
+
+
 def _match_key_group(node):
     """
     Match a spending path that is "k of these n keys", returning
     (threshold, [keys]) or None.
 
-    Accepts the four shapes Liana emits, verified against descriptor vectors
-    in Liana's own test suite (liana-gui/src/app/state/{receive,psbt}.rs):
+    Accepts the shapes Liana emits, verified against descriptor vectors in
+    Liana's own test suite (liana-gui/src/app/state/{receive,psbt}.rs) plus a
+    real 3-of-3 export from the GUI:
 
-      pk(K) / pkh(K)                      -> (1, [K])
+      pk(K) / pkh(K)                       -> (1, [K])
       multi(k, A, B, ...)                  -> (k, [A, B, ...])
       thresh(k, pkh(A), a:pkh(B), ...)     -> (k, [A, B, ...])
+      and_v(v:and_v(v:pk(A),pk(B)),pk(C))  -> (3, [A, B, C])   (n-of-n)
 
     Liana uses `multi()` for a multi-key primary path but `thresh()` with
     `a:` wrappers for a multi-key recovery path (the recovery branch sits
     under and_v and needs different miniscript type properties), so both have
-    to be handled rather than assuming one form.
+    to be handled rather than assuming one form. An n-of-n path is different
+    again: it compiles to a nested and_v chain, since that is cheaper than
+    multi(n,...) when every key is required.
 
     Returns None for anything else -- including `thresh()` whose arguments are
     not all plain single keys, since a nested condition inside one leg is
@@ -399,23 +436,77 @@ def _match_key_group(node):
             keys.append(leg.arg)
         return (node.args[0].num, keys)
 
+    if name == "and_v":
+        # n-of-n: every key in the chain is required, so threshold == count.
+        keys = _flatten_and_v_keys(node)
+        if keys is None or len(keys) < 2:
+            return None
+        return (len(keys), keys)
+
+    return None
+
+
+
+def _match_timelocked_branch(node):
+    """
+    Match `and_v(v:<key group>, older(N))` -- a spending path gated behind a
+    relative, block-based timelock. Returns ((threshold, keys), blocks), or
+    None if this isn't that shape.
+
+    The timelock is located by inspecting both arguments rather than assuming
+    which side it sits on, and the other argument must be a pure key group.
+    That last requirement is what rejects a multi-tier recovery policy: in
+    `or_i(and_v(v:pkh(A),older(N)), and_v(v:pkh(B),older(M)))` each branch
+    looks timelocked, but treating one as the "primary" path would require
+    describing a timelocked branch as spendable now, so no match is returned.
+    """
+    node = _unwrap(node)
+    if getattr(node, "NAME", None) != "and_v" or len(node.args) != 2:
+        return None
+
+    for key_side, lock_side in ((node.args[0], node.args[1]),
+                                (node.args[1], node.args[0])):
+        lock = _unwrap(lock_side)
+        if getattr(lock, "NAME", None) != "older":
+            continue
+
+        raw = lock.arg.num
+        if raw & 0x00400000:
+            # BIP68 type-flag bit set: time-based (512-second units), not blocks.
+            return None
+
+        group = _match_key_group(key_side)
+        if group is None:
+            return None
+
+        return (group, raw & 0x0000FFFF)
+
     return None
 
 
 
 def match_liana_recovery_policy(descriptor: Descriptor):
     """
-    Recognizes one curated Miniscript shape: spendable now by a primary key
-    or key-quorum, or by a recovery key or key-quorum after a relative
+    Recognizes one curated Miniscript shape: spendable now by a key or
+    key-quorum, or by a recovery key or key-quorum after a relative
     (block-based) timelock. This is Liana's inheritance wallet policy, and the
     only Miniscript shape this build displays with curated fields rather than
     generic policy text (see `is_supported_wallet_descriptor()`).
 
         wsh():  or_d(<primary>, and_v(v:<recovery>, older(N)))
+                or_i(and_v(v:<recovery>, older(N)), <primary>)
         tr():   primary is the key-path (internal) key; the single hidden
                 script-path leaf is and_v(v:<recovery>, older(N))
 
-    Either path may be a single key or a k-of-n quorum -- see
+    Both `or_d` and `or_i` appear because the miniscript compiler's choice
+    depends on the primary path. `or_d(X,Z)` requires X to be dissatisfiable,
+    which an n-of-n `and_v` chain is not, so an all-keys-required primary
+    compiles to `or_i` instead -- and with the branches in the opposite order.
+    Confirmed against a real Liana 3-of-3 export. Rather than encode that as
+    two positional cases, the branch carrying the timelock is identified by
+    inspection and the other is taken as the primary.
+
+    Either path may be a single key, a k-of-n quorum, or an n-of-n; see
     `_match_key_group()` for the accepted forms. A 2-of-3 primary with a
     single-key timelocked recovery is Liana's most common real-world
     configuration, so it is supported rather than treated as an edge case.
@@ -442,38 +533,35 @@ def match_liana_recovery_policy(descriptor: Descriptor):
             return None
         # Taproot's key-path spend is inherently a single key.
         primary_group = (1, [descriptor.key])
-        recovery_branch = _unwrap(leaves[0].miniscript)
+        recovery = _match_timelocked_branch(leaves[0].miniscript)
+        if recovery is None:
+            return None
+        recovery_group, timelock_blocks = recovery
 
     elif descriptor.is_segwit and descriptor.miniscript is not None:
         top = _unwrap(descriptor.miniscript)
-        if getattr(top, "NAME", None) != "or_d":
+        if getattr(top, "NAME", None) not in ("or_d", "or_i"):
+            return None
+        if len(top.args) != 2:
             return None
 
-        primary_group = _match_key_group(top.args[0])
-        if primary_group is None:
+        # Which branch is which depends on the operator, so identify the
+        # timelocked one instead of assuming a position.
+        for primary_node, recovery_node in ((top.args[0], top.args[1]),
+                                            (top.args[1], top.args[0])):
+            recovery = _match_timelocked_branch(recovery_node)
+            if recovery is None:
+                continue
+            primary_group = _match_key_group(primary_node)
+            if primary_group is None:
+                continue
+            recovery_group, timelock_blocks = recovery
+            break
+        else:
             return None
-
-        recovery_branch = _unwrap(top.args[1])
 
     else:
         return None
-
-    if getattr(recovery_branch, "NAME", None) != "and_v":
-        return None
-
-    recovery_group = _match_key_group(recovery_branch.args[0])
-    if recovery_group is None:
-        return None
-
-    timelock_node = _unwrap(recovery_branch.args[1])
-    if getattr(timelock_node, "NAME", None) != "older":
-        return None
-
-    raw = timelock_node.arg.num
-    if raw & 0x00400000:
-        # BIP68 type-flag bit set: time-based (512-second units), not blocks.
-        return None
-    timelock_blocks = raw & 0x0000FFFF
 
     primary_threshold, primary_keys = primary_group
     recovery_threshold, recovery_keys = recovery_group

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -399,9 +399,21 @@ def match_liana_recovery_policy(descriptor: Descriptor):
 
 def get_descriptor_policy_summary(descriptor: Descriptor, max_length: int = 180) -> str:
     """
-    Plain-English summary of any descriptor's spending policy -- basic
-    multisig, general wsh() Miniscript, or taproot (key-path plus any hidden
-    script-path leaves).
+    Short plain-English summary of a descriptor's spending policy, for screens
+    that label a wallet in one line (e.g. Address Explorer's "Wallet
+    descriptor" field).
+
+    A descriptor matching the curated recovery template gets a fixed short
+    name rather than a rendering of its policy expression. That is the whole
+    point: a nested "(key A) or ((key B) and (after N blocks))" string does
+    not fit these one-line fields, and line-wrapping it would not help -- the
+    user would still have to parse parenthesization to understand it, which
+    is what makes it unsafe to show (seedsigner#306, PR #1026). Details of
+    the policy belong on the curated review screen
+    (LianaRecoveryWalletScreen), which presents them as labeled fields.
+
+    Handled here rather than at the call sites so that no current or future
+    caller can reintroduce the raw expression by accident.
 
     Correctness requirement: a taproot descriptor with a hidden script-path
     recovery leaf must never be summarized as plain single-key/single-signature.
@@ -411,6 +423,10 @@ def get_descriptor_policy_summary(descriptor: Descriptor, max_length: int = 180)
     unrecognized leaf fragment still shows up as raw text via
     `_describe_miniscript_node()`'s fallback, it's just never omitted).
     """
+    if match_liana_recovery_policy(descriptor) is not None:
+        # TRANSLATOR_NOTE: Short name for a wallet that can be spent now by one key, or by a recovery key after a timelock
+        return _("Recovery wallet")
+
     if descriptor.is_basic_multisig:
         threshold, n = get_multisig_policy(descriptor)
         # TRANSLATOR_NOTE: Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -296,15 +296,38 @@ def _flatten_taptree_leaves(taptree: TapTree) -> list:
 
 class LianaRecoveryPolicy:
     """
-    Fields extracted from a descriptor matching the one curated Miniscript
-    shape this build supports. See `match_liana_recovery_policy()`.
-    """
-    __slots__ = ("primary_key", "recovery_key", "timelock_blocks")
+    Fields extracted from a descriptor matching the curated Miniscript shape
+    this build supports. See `match_liana_recovery_policy()`.
 
-    def __init__(self, primary_key, recovery_key, timelock_blocks: int):
-        self.primary_key = primary_key      # Key
-        self.recovery_key = recovery_key    # Key (tr) or KeyHash (wsh)
+    Both spending paths are represented uniformly as a threshold over a list
+    of keys, so a single key is simply 1-of-1. Callers that want to know
+    whether a path is single-key should test `len(keys) == 1` rather than
+    branching on a separate flag.
+    """
+    __slots__ = (
+        "primary_threshold", "primary_keys",
+        "recovery_threshold", "recovery_keys",
+        "timelock_blocks",
+    )
+
+    def __init__(self, primary_threshold: int, primary_keys: list,
+                 recovery_threshold: int, recovery_keys: list,
+                 timelock_blocks: int):
+        self.primary_threshold = primary_threshold
+        self.primary_keys = primary_keys        # list of Key
+        self.recovery_threshold = recovery_threshold
+        self.recovery_keys = recovery_keys      # list of Key / KeyHash
         self.timelock_blocks = timelock_blocks
+
+
+    @property
+    def primary_fingerprints(self) -> list:
+        return [k.fingerprint.hex() for k in self.primary_keys]
+
+
+    @property
+    def recovery_fingerprints(self) -> list:
+        return [k.fingerprint.hex() for k in self.recovery_keys]
 
 
 
@@ -318,17 +341,84 @@ def _unwrap(node):
 
 
 
+# Display-capacity limit for the curated policy screen, deliberately enforced
+# at match time so a policy this device cannot show in full is refused rather
+# than shown with half of it invisible.
+#
+# LianaRecoveryWalletScreen renders fingerprints two per line. Measured against
+# that screen at 240x240: 3 primary lines + 1 recovery line ends at 178px
+# against a button top of 200px, while one more line reaches 199-201px -- either
+# already clipped, or within a single pixel of it, leaving nothing for a longer
+# translated label. So four lines total across both paths is the honest ceiling.
+#
+# In practice this is not a real constraint on Liana wallets: it permits up to a
+# 5-key primary path alongside a 2-key recovery path (or 4 and 4), well beyond
+# the 2-of-3 and 3-of-5 setups that dominate actual use.
+MAX_POLICY_FINGERPRINT_LINES = 4
+_FINGERPRINTS_PER_LINE = 2
+
+
+
+def _match_key_group(node):
+    """
+    Match a spending path that is "k of these n keys", returning
+    (threshold, [keys]) or None.
+
+    Accepts the four shapes Liana emits, verified against descriptor vectors
+    in Liana's own test suite (liana-gui/src/app/state/{receive,psbt}.rs):
+
+      pk(K) / pkh(K)                      -> (1, [K])
+      multi(k, A, B, ...)                  -> (k, [A, B, ...])
+      thresh(k, pkh(A), a:pkh(B), ...)     -> (k, [A, B, ...])
+
+    Liana uses `multi()` for a multi-key primary path but `thresh()` with
+    `a:` wrappers for a multi-key recovery path (the recovery branch sits
+    under and_v and needs different miniscript type properties), so both have
+    to be handled rather than assuming one form.
+
+    Returns None for anything else -- including `thresh()` whose arguments are
+    not all plain single keys, since a nested condition inside one leg is
+    exactly the kind of structure this curated display cannot represent
+    honestly.
+    """
+    node = _unwrap(node)
+    name = getattr(node, "NAME", None)
+
+    if name in ("pk", "pkh"):
+        return (1, [node.arg])
+
+    if name in ("multi", "sortedmulti"):
+        return (node.args[0].num, list(node.args[1:]))
+
+    if name == "thresh":
+        keys = []
+        for leg in node.args[1:]:
+            leg = _unwrap(leg)
+            if getattr(leg, "NAME", None) not in ("pk", "pkh"):
+                return None
+            keys.append(leg.arg)
+        return (node.args[0].num, keys)
+
+    return None
+
+
+
 def match_liana_recovery_policy(descriptor: Descriptor):
     """
-    Recognizes exactly one Miniscript shape: spendable now by a primary key,
-    or by a recovery key after a relative (block-based) timelock -- Liana's
-    inheritance wallet policy, and the only Miniscript shape this build
-    displays with curated fields rather than generic policy text (see
-    `is_supported_wallet_descriptor()`).
+    Recognizes one curated Miniscript shape: spendable now by a primary key
+    or key-quorum, or by a recovery key or key-quorum after a relative
+    (block-based) timelock. This is Liana's inheritance wallet policy, and the
+    only Miniscript shape this build displays with curated fields rather than
+    generic policy text (see `is_supported_wallet_descriptor()`).
 
-        wsh():  or_d(pk(primary), and_v(v:pkh(recovery), older(N)))
+        wsh():  or_d(<primary>, and_v(v:<recovery>, older(N)))
         tr():   primary is the key-path (internal) key; the single hidden
-                script-path leaf is and_v(v:pk(recovery), older(N))
+                script-path leaf is and_v(v:<recovery>, older(N))
+
+    Either path may be a single key or a k-of-n quorum -- see
+    `_match_key_group()` for the accepted forms. A 2-of-3 primary with a
+    single-key timelocked recovery is Liana's most common real-world
+    configuration, so it is supported rather than treated as an edge case.
 
     Returns a `LianaRecoveryPolicy`, or `None` if the descriptor is anything
     else -- including this exact shape but with a BIP68 *time-based* (rather
@@ -348,9 +438,10 @@ def match_liana_recovery_policy(descriptor: Descriptor):
         leaves = _flatten_taptree_leaves(descriptor.taptree)
         if len(leaves) != 1:
             return None
-        primary_node = descriptor.key
-        if primary_node is None:
+        if descriptor.key is None:
             return None
+        # Taproot's key-path spend is inherently a single key.
+        primary_group = (1, [descriptor.key])
         recovery_branch = _unwrap(leaves[0].miniscript)
 
     elif descriptor.is_segwit and descriptor.miniscript is not None:
@@ -358,10 +449,9 @@ def match_liana_recovery_policy(descriptor: Descriptor):
         if getattr(top, "NAME", None) != "or_d":
             return None
 
-        pk_node = _unwrap(top.args[0])
-        if getattr(pk_node, "NAME", None) != "pk":
+        primary_group = _match_key_group(top.args[0])
+        if primary_group is None:
             return None
-        primary_node = pk_node.arg
 
         recovery_branch = _unwrap(top.args[1])
 
@@ -371,15 +461,11 @@ def match_liana_recovery_policy(descriptor: Descriptor):
     if getattr(recovery_branch, "NAME", None) != "and_v":
         return None
 
-    recovery_key_node = _unwrap(recovery_branch.args[0])
-    timelock_node = _unwrap(recovery_branch.args[1])
-
-    # tr()'s script-path leaf uses pk() (schnorr, no hash160 needed); wsh()
-    # uses pkh(). Both are accepted here; which one is structurally forced
-    # by which branch above ran, but re-checking costs nothing and keeps this
-    # function correct even if that assumption ever changes.
-    if getattr(recovery_key_node, "NAME", None) not in ("pk", "pkh"):
+    recovery_group = _match_key_group(recovery_branch.args[0])
+    if recovery_group is None:
         return None
+
+    timelock_node = _unwrap(recovery_branch.args[1])
     if getattr(timelock_node, "NAME", None) != "older":
         return None
 
@@ -389,9 +475,32 @@ def match_liana_recovery_policy(descriptor: Descriptor):
         return None
     timelock_blocks = raw & 0x0000FFFF
 
+    primary_threshold, primary_keys = primary_group
+    recovery_threshold, recovery_keys = recovery_group
+
+    # A threshold that cannot be satisfied, or one the display would describe
+    # incorrectly, means this isn't a shape we can present honestly.
+    if not 1 <= primary_threshold <= len(primary_keys):
+        return None
+    if not 1 <= recovery_threshold <= len(recovery_keys):
+        return None
+
+    # Too many keys to fit on the curated screen. Refusing here (which routes
+    # to NotYetImplementedView) is the safe outcome: the alternative is a
+    # screen whose recovery section is pushed under the buttons and silently
+    # invisible, hiding the timelocked path entirely -- strictly worse than
+    # declining to display the wallet at all.
+    def _lines(keys):
+        return -(-len(keys) // _FINGERPRINTS_PER_LINE)  # ceil division
+
+    if _lines(primary_keys) + _lines(recovery_keys) > MAX_POLICY_FINGERPRINT_LINES:
+        return None
+
     return LianaRecoveryPolicy(
-        primary_key=primary_node,
-        recovery_key=recovery_key_node.arg,
+        primary_threshold=primary_threshold,
+        primary_keys=primary_keys,
+        recovery_threshold=recovery_threshold,
+        recovery_keys=recovery_keys,
         timelock_blocks=timelock_blocks,
     )
 

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -143,15 +143,34 @@ def is_supported_wallet_descriptor(descriptor: Descriptor) -> bool:
     Whether `descriptor` is one we know how to register, display, and (where
     Address Explorer / Verify Addr are concerned) derive addresses for.
 
-    This is deliberately broader than `is_basic_multisig`: it also accepts
-    general wsh() Miniscript policies (e.g. Liana's or_d(pk(...),and_v(...))
-    recovery policies) and taproot descriptors. Taproot registration/display is
-    allowed because `get_descriptor_policy_summary()` can describe it correctly
-    -- taproot *address verification* and *script-path signing* remain
-    separately gated in `get_multisig_address()` and `PSBTParser`, which still
-    correctly raise "not yet implemented" for the taproot cases that aren't
-    ready, so allowing registration here doesn't let a user get further than
-    what's actually supported.
+    Deliberately narrower than "any valid wsh()/tr() Miniscript". An earlier
+    version of this accepted arbitrary Miniscript and rendered it through a
+    generic recursive AST-to-English summary. Reviewers correctly flagged
+    that as unsafe: a raw nested boolean expression forces the user to
+    mentally track parenthesization to know which conditions actually apply
+    together, and that gets unreadable fast on a 240x240 screen -- exactly
+    the class of footgun SeedSigner's UI otherwise goes out of its way to
+    avoid. See discussion on seedsigner#306 and PR #1026.
+
+    So Miniscript support here is template-gated, not general: only the one
+    specific shape recognized by `match_liana_recovery_policy()` --
+    "spendable now by a primary key, or by a recovery key after a relative
+    timelock" -- gets accepted, and it is displayed through curated,
+    structured fields (see `LianaRecoveryDescriptorView`/`Screen`), never as
+    raw or generically-rendered policy text. Anything else -- thresh(),
+    multi() inside wsh() Miniscript, additional OR branches, a different
+    wrapper shape -- is rejected here exactly like it always has been,
+    falling through to `NotYetImplementedView`.
+
+    Taproot is accepted only for a plain key-path-only spend (no hidden
+    script-path leaves at all -- trivially just "one key", nothing to
+    misread) or for the same curated recovery shape via its single hidden
+    leaf. Any other taproot script-path structure is rejected for the same
+    reason as above.
+
+    Basic multisig is unaffected and unrelated to this gate; it is not
+    Miniscript and was already curated (m-of-n, cosigner fingerprints) before
+    any of this.
 
     A bare single-key descriptor (wpkh()/pkh(), no miniscript, no taproot
     script path) is intentionally excluded -- that's a plain single-sig import,
@@ -160,9 +179,13 @@ def is_supported_wallet_descriptor(descriptor: Descriptor) -> bool:
     if descriptor.is_basic_multisig:
         return True
     if descriptor.is_taproot:
-        return True
+        # Key-path-only (no hidden leaves at all) is just a single key --
+        # nothing to misread, safe to accept generically.
+        if not _flatten_taptree_leaves(descriptor.taptree):
+            return True
+        return match_liana_recovery_policy(descriptor) is not None
     if descriptor.is_segwit and descriptor.miniscript is not None:
-        return True
+        return match_liana_recovery_policy(descriptor) is not None
     return False
 
 
@@ -268,6 +291,109 @@ def _flatten_taptree_leaves(taptree: TapTree) -> list:
         return [taptree.tree]
     left, right = taptree.tree
     return _flatten_taptree_leaves(left) + _flatten_taptree_leaves(right)
+
+
+
+class LianaRecoveryPolicy:
+    """
+    Fields extracted from a descriptor matching the one curated Miniscript
+    shape this build supports. See `match_liana_recovery_policy()`.
+    """
+    __slots__ = ("primary_key", "recovery_key", "timelock_blocks")
+
+    def __init__(self, primary_key, recovery_key, timelock_blocks: int):
+        self.primary_key = primary_key      # Key
+        self.recovery_key = recovery_key    # Key (tr) or KeyHash (wsh)
+        self.timelock_blocks = timelock_blocks
+
+
+
+def _unwrap(node):
+    """Strip Miniscript wrapper layers (v:, s:, a:, ...) down to the fragment
+    they wrap. Wrappers change stack/verify mechanics, not the underlying
+    spending condition, so template matching should see through them."""
+    while isinstance(node, Wrapper):
+        node = node.arg
+    return node
+
+
+
+def match_liana_recovery_policy(descriptor: Descriptor):
+    """
+    Recognizes exactly one Miniscript shape: spendable now by a primary key,
+    or by a recovery key after a relative (block-based) timelock -- Liana's
+    inheritance wallet policy, and the only Miniscript shape this build
+    displays with curated fields rather than generic policy text (see
+    `is_supported_wallet_descriptor()`).
+
+        wsh():  or_d(pk(primary), and_v(v:pkh(recovery), older(N)))
+        tr():   primary is the key-path (internal) key; the single hidden
+                script-path leaf is and_v(v:pk(recovery), older(N))
+
+    Returns a `LianaRecoveryPolicy`, or `None` if the descriptor is anything
+    else -- including this exact shape but with a BIP68 *time-based* (rather
+    than block-based) timelock encoding. Liana has never been observed to
+    produce that encoding (every real descriptor and confirmed on-chain spend
+    used in this PR's own hardware testing used plain block counts), so it is
+    deliberately left unrecognized rather than assumed equivalent to blocks.
+
+    Structural match only -- this does not verify the keys are ours or derive
+    anything. That happens downstream (PSBTParser, verify_multisig_output())
+    exactly as it does for basic multisig.
+    """
+    if descriptor.is_basic_multisig:
+        return None
+
+    if descriptor.is_taproot:
+        leaves = _flatten_taptree_leaves(descriptor.taptree)
+        if len(leaves) != 1:
+            return None
+        primary_node = descriptor.key
+        if primary_node is None:
+            return None
+        recovery_branch = _unwrap(leaves[0].miniscript)
+
+    elif descriptor.is_segwit and descriptor.miniscript is not None:
+        top = _unwrap(descriptor.miniscript)
+        if getattr(top, "NAME", None) != "or_d":
+            return None
+
+        pk_node = _unwrap(top.args[0])
+        if getattr(pk_node, "NAME", None) != "pk":
+            return None
+        primary_node = pk_node.arg
+
+        recovery_branch = _unwrap(top.args[1])
+
+    else:
+        return None
+
+    if getattr(recovery_branch, "NAME", None) != "and_v":
+        return None
+
+    recovery_key_node = _unwrap(recovery_branch.args[0])
+    timelock_node = _unwrap(recovery_branch.args[1])
+
+    # tr()'s script-path leaf uses pk() (schnorr, no hash160 needed); wsh()
+    # uses pkh(). Both are accepted here; which one is structurally forced
+    # by which branch above ran, but re-checking costs nothing and keeps this
+    # function correct even if that assumption ever changes.
+    if getattr(recovery_key_node, "NAME", None) not in ("pk", "pkh"):
+        return None
+    if getattr(timelock_node, "NAME", None) != "older":
+        return None
+
+    raw = timelock_node.arg.num
+    if raw & 0x00400000:
+        # BIP68 type-flag bit set: time-based (512-second units), not blocks.
+        return None
+    timelock_blocks = raw & 0x0000FFFF
+
+    return LianaRecoveryPolicy(
+        primary_key=primary_node,
+        recovery_key=recovery_key_node.arg,
+        timelock_blocks=timelock_blocks,
+    )
 
 
 

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -1,11 +1,15 @@
 import embit
 
 from binascii import b2a_base64
+from gettext import gettext as _
 from hashlib import sha256
 
 from embit import bip32, compact, ec
 from embit.bip32 import HDKey
 from embit.descriptor import Descriptor
+from embit.descriptor.arguments import Key, KeyHash
+from embit.descriptor.miniscript import Wrapper
+from embit.descriptor.taptree import TapLeaf, TapTree
 from embit.networks import NETWORKS
 from embit.util import secp256k1
 
@@ -86,6 +90,23 @@ def get_single_sig_address(xpub: HDKey, script_type: str = SettingsConstants.NAT
 
 
 
+def can_derive_multisig_address(descriptor: Descriptor) -> bool:
+    """Whether `get_multisig_address()` can actually derive an address for this
+    descriptor: p2wsh/p2sh-p2wsh (including any wsh() Miniscript, not just basic
+    multisig), and legacy basic-multisig p2sh.
+
+    NOTE: this returns True for taproot too, because embit's `is_segwit` is True
+    for taproot descriptors -- which also makes the `elif descriptor.is_taproot:
+    raise` branch in `get_multisig_address()` below unreachable dead code.
+    Taproot addresses do in fact derive correctly through that path (verified by
+    test_get_multisig_address's taproot vector), so this is intentionally left
+    as-is rather than "fixed" to reject taproot; taproot *signing* is what's
+    still gated, over in PSBTParser.
+    """
+    return bool(descriptor.is_segwit or (descriptor.is_legacy and descriptor.is_basic_multisig))
+
+
+
 def get_multisig_address(descriptor: Descriptor, index: int = 0, is_change: bool = False, embit_network: str = "main"):
     if is_change:
         branch_index = 1
@@ -93,11 +114,16 @@ def get_multisig_address(descriptor: Descriptor, index: int = 0, is_change: bool
         branch_index = 0
 
     # Can derive p2wsh, p2sh-p2wsh, and legacy (non-segwit) p2sh
-    if descriptor.is_segwit or (descriptor.is_legacy and descriptor.is_basic_multisig):
+    if can_derive_multisig_address(descriptor):
         return descriptor.derive(index, branch_index=branch_index).script_pubkey().address(network=NETWORKS[embit_network])
 
     elif descriptor.is_taproot:
-        # TODO: Not yet implemented!
+        # Unreachable: embit's `is_segwit` is True for taproot descriptors too,
+        # so `can_derive_multisig_address()` above already returns True and
+        # taproot addresses derive correctly through that branch (see its
+        # docstring). Left in place rather than removed -- see the working
+        # plan's explicit note not to touch this without cause; it's dead code,
+        # not a bug, and touching it risks a behavior nobody's depending on.
         raise Exception("Taproot verification not yet implemented!")
 
     raise Exception(f"{descriptor.script_pubkey().script_type()} address verification not yet implemented!")
@@ -109,6 +135,188 @@ def get_multisig_policy(descriptor: Descriptor) -> tuple:
     if not descriptor.is_basic_multisig:
         raise ValueError(f"Expected a basic multisig descriptor, got: {descriptor.brief_policy}")
     return (str(descriptor.miniscript.args[0]), str(len(descriptor.keys)))
+
+
+
+def is_supported_wallet_descriptor(descriptor: Descriptor) -> bool:
+    """
+    Whether `descriptor` is one we know how to register, display, and (where
+    Address Explorer / Verify Addr are concerned) derive addresses for.
+
+    This is deliberately broader than `is_basic_multisig`: it also accepts
+    general wsh() Miniscript policies (e.g. Liana's or_d(pk(...),and_v(...))
+    recovery policies) and taproot descriptors. Taproot registration/display is
+    allowed because `get_descriptor_policy_summary()` can describe it correctly
+    -- taproot *address verification* and *script-path signing* remain
+    separately gated in `get_multisig_address()` and `PSBTParser`, which still
+    correctly raise "not yet implemented" for the taproot cases that aren't
+    ready, so allowing registration here doesn't let a user get further than
+    what's actually supported.
+
+    A bare single-key descriptor (wpkh()/pkh(), no miniscript, no taproot
+    script path) is intentionally excluded -- that's a plain single-sig import,
+    a separate unimplemented case (see the TODO this replaces in ScanView).
+    """
+    if descriptor.is_basic_multisig:
+        return True
+    if descriptor.is_taproot:
+        return True
+    if descriptor.is_segwit and descriptor.miniscript is not None:
+        return True
+    return False
+
+
+
+def _describe_key(key: Key) -> str:
+    # TRANSLATOR_NOTE: identifies a signing key by its 4-byte master fingerprint, e.g. "key 73C5DA0A"
+    return _("key {fingerprint}").format(fingerprint=key.fingerprint.hex().upper())
+
+
+
+def _describe_miniscript_node(node) -> str:
+    """
+    Recursively render a parsed Miniscript fragment (or a bare Key/KeyHash leaf)
+    as plain English. Driven by each fragment's own `NAME` (embit's
+    `OPERATOR_NAMES`, i.e. the exact descriptor keyword: "older", "and_v",
+    "thresh", etc.) rather than a fixed set of isinstance checks, so this stays
+    correct if embit adds fragments we haven't special-cased below -- those
+    fall through to the raw-text fallback at the end instead of being silently
+    misdescribed or dropped.
+    """
+    if isinstance(node, (Key, KeyHash)):
+        return _describe_key(node)
+
+    if isinstance(node, Wrapper):
+        # Wrappers (a: s: c: t: d: v: j: n: l: u:) change stack/verify mechanics,
+        # not *who* can spend -- describe the wrapped fragment directly.
+        return _describe_miniscript_node(node.arg)
+
+    name = getattr(node, "NAME", None)
+
+    if name == "older":
+        # TRANSLATOR_NOTE: {n} is a number of blocks (relative timelock, OP_CHECKSEQUENCEVERIFY)
+        return _("after {n} blocks").format(n=node.arg.num)
+
+    if name == "after":
+        # TRANSLATOR_NOTE: {n} is a block height (absolute timelock, OP_CHECKLOCKTIMEVERIFY)
+        return _("after block height {n}").format(n=node.arg.num)
+
+    if name in ("sha256", "hash256", "ripemd160", "hash160"):
+        # TRANSLATOR_NOTE: {name} is a hash function name, e.g. "sha256"
+        return _("a {name} preimage").format(name=name)
+
+    if name == "andor":
+        x, y, z = node.args
+        # TRANSLATOR_NOTE: describes miniscript's andor(X,Y,Z): if X then Y, else Z
+        return _("if ({x}) then ({y}) else ({z})").format(
+            x=_describe_miniscript_node(x),
+            y=_describe_miniscript_node(y),
+            z=_describe_miniscript_node(z),
+        )
+
+    if name in ("and_v", "and_b", "and_n"):
+        x, y = node.args[0], node.args[1]
+        # TRANSLATOR_NOTE: describes an AND condition between two spending requirements
+        return _("({x}) and ({y})").format(x=_describe_miniscript_node(x), y=_describe_miniscript_node(y))
+
+    if name in ("or_b", "or_c", "or_d", "or_i"):
+        x, y = node.args[0], node.args[1]
+        # TRANSLATOR_NOTE: describes an OR condition between two spending requirements
+        return _("({x}) or ({y})").format(x=_describe_miniscript_node(x), y=_describe_miniscript_node(y))
+
+    if name == "thresh":
+        k = node.args[0].num
+        subs = [_describe_miniscript_node(a) for a in node.args[1:]]
+        # TRANSLATOR_NOTE: {k} of the following {subs} conditions must be satisfied
+        return _("{k} of: [{subs}]").format(k=k, subs="; ".join(subs))
+
+    if name in ("multi", "sortedmulti", "multi_a", "sortedmulti_a"):
+        k = node.args[0].num
+        keys = [_describe_key(a) for a in node.args[1:]]
+        # TRANSLATOR_NOTE: a k-of-n multisig; {keys} is a list of key descriptions
+        return _("{k} of {n} keys: [{keys}]").format(k=k, n=len(keys), keys=", ".join(keys))
+
+    if name in ("pk", "pk_k", "pkh", "pk_h"):
+        # arg is already a Key or KeyHash; recurse to hit the isinstance branch above
+        return _describe_miniscript_node(node.arg)
+
+    if type(node).__name__ == "JustZero":
+        # TRANSLATOR_NOTE: an unspendable/always-false miniscript fragment
+        return _("(unspendable)")
+
+    if type(node).__name__ == "JustOne":
+        # TRANSLATOR_NOTE: an always-true/no-condition miniscript fragment
+        return _("(no condition)")
+
+    # Unknown/future fragment: never silently drop or misdescribe it -- show
+    # its raw descriptor text so an unsupported case is visibly incomplete
+    # rather than confidently wrong.
+    return str(node)
+
+
+
+def _flatten_taptree_leaves(taptree: TapTree) -> list:
+    """Return every TapLeaf in a (possibly nested) TapTree, in no particular order.
+
+    A TapTree's `.tree` is None, a single TapLeaf, or a 2-tuple of TapTree
+    branches (see embit.descriptor.taptree.TapTree.read_from) -- this walks
+    that structure regardless of depth/shape.
+    """
+    if taptree is None or taptree.tree is None:
+        return []
+    if isinstance(taptree.tree, TapLeaf):
+        return [taptree.tree]
+    left, right = taptree.tree
+    return _flatten_taptree_leaves(left) + _flatten_taptree_leaves(right)
+
+
+
+def get_descriptor_policy_summary(descriptor: Descriptor, max_length: int = 180) -> str:
+    """
+    Plain-English summary of any descriptor's spending policy -- basic
+    multisig, general wsh() Miniscript, or taproot (key-path plus any hidden
+    script-path leaves).
+
+    Correctness requirement: a taproot descriptor with a hidden script-path
+    recovery leaf must never be summarized as plain single-key/single-signature.
+    This is structural, not case-by-case -- the taproot branch below always
+    enumerates every leaf found by `_flatten_taptree_leaves()` if any exist,
+    regardless of whether each leaf's contents can be perfectly described (an
+    unrecognized leaf fragment still shows up as raw text via
+    `_describe_miniscript_node()`'s fallback, it's just never omitted).
+    """
+    if descriptor.is_basic_multisig:
+        threshold, n = get_multisig_policy(descriptor)
+        # TRANSLATOR_NOTE: Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+        summary = _("{threshold} of {n} multisig").format(threshold=threshold, n=n)
+
+    elif descriptor.is_taproot:
+        parts = [_describe_miniscript_node(descriptor.key)]
+        leaves = _flatten_taptree_leaves(descriptor.taptree)
+        if leaves:
+            leaf_descriptions = [_describe_miniscript_node(leaf.miniscript) for leaf in leaves]
+            # TRANSLATOR_NOTE: {key} is the taproot key-path spending key; {leaves} lists hidden alternate spending paths
+            summary = _("Taproot: key-path ({key}); script-path: {leaves}").format(
+                key=parts[0], leaves="; ".join(leaf_descriptions)
+            )
+        else:
+            # TRANSLATOR_NOTE: a taproot descriptor with no hidden script paths at all -- key-path spend only
+            summary = _("Taproot: key-path only ({key})").format(key=parts[0])
+
+    elif descriptor.miniscript is not None:
+        summary = _describe_miniscript_node(descriptor.miniscript)
+
+    elif descriptor.key is not None:
+        # Bare single key (e.g. wpkh()/pkh()); describe safely rather than
+        # raising if a caller ever routes one here.
+        summary = _describe_miniscript_node(descriptor.key)
+
+    else:
+        raise ValueError(f"Unable to summarize descriptor policy: {descriptor}")
+
+    if len(summary) > max_length:
+        summary = summary[: max_length - 1].rstrip() + "…"  # ellipsis
+    return summary
 
 
 

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -379,7 +379,14 @@ class DecodeQR:
             elif "multisig setup file" in s.lower():
                 return QRType.WALLET__CONFIGFILE
 
-            elif "sortedmulti" in s:
+            elif re.search(r'^(sh|wsh|tr|pkh|wpkh|combo)\(', desc_str):
+                # Any output descriptor, identified by its top-level script type
+                # rather than by looking for `sortedmulti` specifically -- this
+                # also admits general Miniscript policies (e.g. Liana's
+                # `wsh(or_d(pk(...),and_v(...)))`) and `tr()` descriptors.
+                # GenericWalletQrDecoder validates via embit's
+                # `Descriptor.from_string()`, so a merely descriptor-shaped
+                # string that isn't a real descriptor is still rejected there.
                 return QRType.WALLET__GENERIC
 
             # Seed

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -384,10 +384,31 @@ class DecodeQR:
                 # rather than by looking for `sortedmulti` specifically -- this
                 # also admits general Miniscript policies (e.g. Liana's
                 # `wsh(or_d(pk(...),and_v(...)))`) and `tr()` descriptors.
-                # GenericWalletQrDecoder validates via embit's
-                # `Descriptor.from_string()`, so a merely descriptor-shaped
-                # string that isn't a real descriptor is still rejected there.
-                return QRType.WALLET__GENERIC
+                #
+                # Matching on the prefix alone would be risky: it's as short as
+                # "tr(" (3 bytes), and this function speculatively treats all
+                # scanned data as text, including binary formats that were never
+                # meant to be strings (CompactSeedQR's raw 16/32-byte entropy is
+                # checked further below, by byte length). Random entropy that
+                # happens to both survive the str conversion and begin with a
+                # matching prefix would be misclassified as a descriptor. The old
+                # `"sortedmulti" in s` check was long enough that this was
+                # negligible; these prefixes are not.
+                #
+                # GenericWalletQrDecoder validates via Descriptor.from_string()
+                # too, but that runs too late to help -- by then this function has
+                # already committed to a QR type, with no path back to the seed
+                # checks below. So validate here, checksum and all, before
+                # committing to the classification.
+                from embit.descriptor import Descriptor
+                try:
+                    Descriptor.from_string(desc_str)
+                    return QRType.WALLET__GENERIC
+                except Exception:
+                    # Falls through to the seed/other checks below, e.g. a
+                    # CompactSeedQR whose entropy just happened to look like
+                    # the start of a descriptor once mis-decoded as UTF-8.
+                    pass
 
             # Seed
             if re.search(r'\d{48,96}', s):

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -440,20 +440,28 @@ class PSBTParser():
                 script = scope.redeem_script
 
             if script is not None:
-                m, n, pubkeys = PSBTParser._parse_multisig(script)
-            
-                # check pubkeys are derived from cosigners
                 try:
-                    cosigners = PSBTParser._get_cosigners(pubkeys, scope.bip32_derivations, xpubs, child_key_derivation_cache)
-                    policy.update({"m": m, "n": n, "cosigners": cosigners})
-                except:
-                    # TODO: stop swallowing everything here. This also catches bugs in the
-                    # cosigner check itself, and cannot tell those apart from the psbt
-                    # simply not supplying xpubs to check against, which is valid and must
-                    # not be rejected outright. The fallback policy carries no cosigner
-                    # information at all, and two of those compare equal on script type
-                    # and m-of-n alone. Fix pending with the multisig verification work.
-                    policy.update({"m": m, "n": n})
+                    m, n, pubkeys = PSBTParser._parse_multisig(script)
+                except ValueError:
+                    # Not a bare OP_CHECKMULTISIG script -- e.g. a Miniscript
+                    # witness script (wsh() policies like Liana's). policy
+                    # stays at just {"type": script_type}; there's no m/n/
+                    # cosigners to report, but this isn't a parse failure.
+                    m = n = pubkeys = None
+
+                if m is not None:
+                    # check pubkeys are derived from cosigners
+                    try:
+                        cosigners = PSBTParser._get_cosigners(pubkeys, scope.bip32_derivations, xpubs, child_key_derivation_cache)
+                        policy.update({"m": m, "n": n, "cosigners": cosigners})
+                    except:
+                        # TODO: stop swallowing everything here. This also catches bugs in the
+                        # cosigner check itself, and cannot tell those apart from the psbt
+                        # simply not supplying xpubs to check against, which is valid and must
+                        # not be rejected outright. The fallback policy carries no cosigner
+                        # information at all, and two of those compare equal on script type
+                        # and m-of-n alone. Fix pending with the multisig verification work.
+                        policy.update({"m": m, "n": n})
         
         return policy
 

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -476,12 +476,18 @@ class PSBTParser():
         the existing partial_sigs entry for the same pubkey, so the count is
         identical in both cases.
 
-        Re-derives each candidate key from `root` and compares the serialized
-        pubkey rather than trusting the psbt's claimed fingerprints, which are
-        32 bits and coordinator-supplied. This only decides which message the
-        user sees, so a wrong answer would be cosmetic rather than dangerous --
-        but deriving properly costs little and keeps the claimed-vs-verified
-        split this class documents intact.
+        Ownership goes through seed_owns_pubkey() rather than the psbt's claimed
+        fingerprints, which are 32 bits and coordinator-supplied. This only
+        decides which message the user sees, so a wrong answer would be cosmetic
+        rather than dangerous, but there is no reason to establish ownership any
+        way other than the canonical one.
+
+        Note this stays reachable even though _reject_if_seed_cannot_sign() now
+        turns away a seed that owns nothing: that check guarantees the seed can
+        sign *some* input, which is not the same as the signing pass having added
+        a signature. Inferring "already signed" from the absence of a rejection
+        would be a chain of assumptions about embit's behavior; asking directly
+        costs one derivation.
         """
         for inp in tx.inputs:
             if not inp.partial_sigs:
@@ -492,13 +498,18 @@ class PSBTParser():
                     continue
 
                 try:
-                    derived_key = root.derive(derivation_path.derivation)
+                    if PSBTParser.seed_owns_pubkey(
+                        root=root,
+                        claimed_derivation_path=derivation_path.derivation,
+                        public_key=public_key,
+                        child_key_derivation_cache=None,
+                    ):
+                        return True
                 except Exception as e:
-                    logger.debug("Signed-by-this-seed derivation failed: %s", e, exc_info=True)
+                    # A coordinator-supplied path can be nonsense; that means this
+                    # entry tells us nothing, not that the check should fail.
+                    logger.debug("Signed-by-this-seed check failed: %s", e, exc_info=True)
                     continue
-
-                if derived_key.key.sec() == public_key.sec():
-                    return True
 
         return False
 

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -304,14 +304,23 @@ class PSBTParser():
                 sc = script.Script(b"")
 
                 # multisig, we know witness script
-                if self.policy["type"] == "p2wsh":
+                #
+                # A degraded policy (no m/n/cosigners -- e.g. a Miniscript wsh()
+                # policy like Liana's) only tells us the output's script *type*
+                # matches ours, not that it's actually part of our wallet. An
+                # unrelated output of the same type (e.g. the destination
+                # address) can reach here with no witness_script/redeem_script
+                # populated at all, since Liana only fills those in for outputs
+                # it recognizes as its own. Treat "no script" as "not a match"
+                # rather than crashing trying to reconstruct one from None.
+                if self.policy["type"] == "p2wsh" and out.witness_script is not None:
                     sc = script.p2wsh(out.witness_script)
 
-                elif self.policy["type"] == "p2sh-p2wsh":
+                elif self.policy["type"] == "p2sh-p2wsh" and out.witness_script is not None:
                     sc = script.p2sh(script.p2wsh(out.witness_script))
-                
+
                 # Arbitrary p2sh; includes pre-segwit multisig (m/45')
-                elif self.policy["type"] == "p2sh":
+                elif self.policy["type"] == "p2sh" and out.redeem_script is not None:
                     sc = script.p2sh(out.redeem_script)
 
                 # single-sig

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -466,6 +466,44 @@ class PSBTParser():
 
 
     @staticmethod
+    def has_signature_from_seed(tx, root: bip32.HDKey) -> bool:
+        """
+        Whether any input already carries a signature for a pubkey that
+        provably derives from `root`.
+
+        Used to tell "this seed already signed" apart from "this seed cannot
+        sign this psbt", which sig_count() alone cannot: re-signing overwrites
+        the existing partial_sigs entry for the same pubkey, so the count is
+        identical in both cases.
+
+        Re-derives each candidate key from `root` and compares the serialized
+        pubkey rather than trusting the psbt's claimed fingerprints, which are
+        32 bits and coordinator-supplied. This only decides which message the
+        user sees, so a wrong answer would be cosmetic rather than dangerous --
+        but deriving properly costs little and keeps the claimed-vs-verified
+        split this class documents intact.
+        """
+        for inp in tx.inputs:
+            if not inp.partial_sigs:
+                continue
+
+            for public_key, derivation_path in inp.bip32_derivations.items():
+                if public_key not in inp.partial_sigs:
+                    continue
+
+                try:
+                    derived_key = root.derive(derivation_path.derivation)
+                except Exception as e:
+                    logger.debug("Signed-by-this-seed derivation failed: %s", e, exc_info=True)
+                    continue
+
+                if derived_key.key.sec() == public_key.sec():
+                    return True
+
+        return False
+
+
+    @staticmethod
     def _get_policy(scope, scriptpubkey, xpubs, child_key_derivation_cache: dict | None):
         """Parse scope and get policy"""
         # we don't know the policy yet, let's parse it

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -164,6 +164,23 @@ class PSBTParser():
 
 
     @property
+    def requires_descriptor_verification(self):
+        """
+        Whether verifying this psbt's change addresses needs a known-good wallet
+        descriptor, as opposed to being derivable from the signing seed alone.
+
+        True for basic multisig (m/n present), and also for any wsh()/p2sh-p2wsh
+        policy where m/n is absent -- i.e. a Miniscript policy such as Liana's
+        inheritance wallets. In both cases the output's scriptpubkey commits to a
+        script this seed's key alone cannot reconstruct, so single-sig re-derivation
+        would not merely be inconvenient, it would be wrong: it can only ever fail,
+        and a failure here is surfaced to the user as a suspicious transaction.
+        The descriptor is the only thing that can actually answer the question.
+        """
+        return self.is_multisig or self.policy.get("type") in ("p2wsh", "p2sh-p2wsh")
+
+
+    @property
     def num_destinations(self):
         return len(self.destination_addresses)
 
@@ -353,6 +370,32 @@ class PSBTParser():
 
                 if sc.data == vout[i].script_pubkey.data:
                     is_change = True
+
+                # Nothing above could reconstruct the scriptpubkey. For a degraded
+                # policy (no m/n -- e.g. a Miniscript wsh() policy like Liana's)
+                # that is the normal case, not an anomaly: the witness script is
+                # not bare OP_CHECKMULTISIG, and coordinators do not populate
+                # witness_script on their own change outputs at all (verified
+                # against real Liana psbts, which supply only bip32_derivations).
+                # Falling through here would count our own change as money
+                # leaving the wallet, and would deny the user any on-device
+                # confirmation that it comes back to them.
+                #
+                # _verify_claimed_derivation_paths has already established, for
+                # every output, whether this seed genuinely derives a key that the
+                # output names -- re-derived and compared as real key material,
+                # not read off the claimed fingerprint. Reuse that result rather
+                # than repeating the derivation here.
+                #
+                # Note what it does and does not settle: our key is *referenced by*
+                # the output, not that the scriptpubkey encodes our wallet's
+                # policy. A coordinator can name a key we own on an output paying
+                # elsewhere. So this marks a change *candidate*, and
+                # verify_multisig_output() against a known-good descriptor is what
+                # confirms it -- which requires_descriptor_verification forces for
+                # every policy able to reach this branch.
+                if not is_change and sc.data == b"" and self.policy["type"] in ("p2wsh", "p2sh-p2wsh"):
+                    is_change = self.verified_output_derivation_paths[i] is not None
 
             if vout[i].script_pubkey.data[0] == OPCODES.OP_RETURN:
                 # The data is written as: OP_RETURN + OP_PUSHDATA1 + len(payload) + payload

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -348,6 +348,7 @@ class SettingsConstants:
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
     SETTING__MESSAGE_SIGNING = "message_signing"
+    SETTING__MINISCRIPT = "miniscript"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
     SETTING__DIRE_WARNINGS = "dire_warnings"
     SETTING__QR_BRIGHTNESS_TIPS = "qr_brightness_tips"
@@ -686,6 +687,13 @@ class SettingsDefinition:
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__MESSAGE_SIGNING,
                       display_name=_mft("Message signing"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__MINISCRIPT,
+                      display_name=_mft("Miniscript wallets"),
+                      help_text=_mft("Liana-style recovery wallets only"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -640,11 +640,24 @@ class PSBTFinalizeView(View):
             trimmed_psbt = PSBTParser.trim(psbt)
 
             if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
-                # Signing failed / didn't do anything
-                # TODO: Reserved for Nick. Are there different failure scenarios that we can detect?
-                # Would be nice to alter the message on the next screen w/more detail.
+                # No new signature. Two very different situations produce this,
+                # and reporting both as "signing failed" is misleading.
+                #
+                # sig_count() counts entries in partial_sigs, keyed by pubkey. If
+                # this seed had already signed, embit re-signs the same pubkeys and
+                # simply overwrites those entries (its nonces are deterministic, so
+                # even the bytes are identical), leaving the count unchanged. The
+                # transaction is validly signed by this seed; nothing failed.
+                #
+                # Distinguishing them matters most for n-of-n and multisig wallets,
+                # where the user signs the same psbt repeatedly with different seeds
+                # and can easily reach for one that has already been used. Observed
+                # exactly that way on hardware with a 3-of-3 Liana wallet.
+                if PSBTParser.has_signature_from_seed(psbt, psbt_parser.root):
+                    return Destination(PSBTSigningErrorView, view_args=dict(already_signed=True))
+
                 return Destination(PSBTSigningErrorView)
-            
+
             else:
                 self.controller.psbt = trimmed_psbt
                 return Destination(PSBTSignedQRDisplayView)
@@ -669,20 +682,38 @@ class PSBTSignedQRDisplayView(View):
 
 class PSBTSigningErrorView(View):
     SELECT_DIFF_SEED = ButtonOption("Select different seed")
-    
+
+    def __init__(self, already_signed: bool = False):
+        super().__init__()
+
+        # True when no new signature was added because this seed's signature was
+        # already present. Nothing failed in that case, so it gets its own
+        # wording rather than being reported as a signing failure.
+        self.already_signed = already_signed
+
+
     def run(self):
         psbt_parser: PSBTParser = self.controller.psbt_parser
         if not psbt_parser:
             # Should not be able to get here
             return Destination(MainMenuView)
 
+        if self.already_signed:
+            # TRANSLATOR_NOTE: Headline when the selected seed had already signed this transaction
+            status_headline = _("Already Signed")
+            # TRANSLATOR_NOTE: Explains that this seed's signature is already on the transaction, and another seed is needed
+            text = _("This seed has already signed this transaction. Another seed is needed to add a signature.")
+        else:
+            status_headline = _("Signing Failed")
+            text = _("Signing with this seed did not add a valid signature.")
+
         # Just a WarningScreen here; only use DireWarningScreen for true security risks.
         selected_menu_num = self.run_screen(
             WarningScreen,
             title=_("Transaction Error"),
             status_icon_name=SeedSignerIconConstants.WARNING,
-            status_headline=_("Signing Failed"),
-            text=_("Signing with this seed did not add a valid signature."),
+            status_headline=status_headline,
+            text=text,
             button_data=[self.SELECT_DIFF_SEED]
         )
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -369,7 +369,7 @@ class PSBTChangeDetailsView(View):
         #     title += f" (#{self.change_address_num + 1})"
 
         is_change_addr_verified = False
-        if psbt_parser.is_multisig:
+        if psbt_parser.requires_descriptor_verification:
             # if the known-good multisig descriptor is already onboard:
             if self.controller.multisig_wallet_descriptor:
                 is_change_addr_verified = psbt_parser.verify_multisig_output(self.controller.multisig_wallet_descriptor, change_num=self.change_address_num)
@@ -428,8 +428,8 @@ class PSBTChangeDetailsView(View):
             finally:
                 loading_screen.stop()
 
-        if is_change_addr_verified == False and (not psbt_parser.is_multisig or self.controller.multisig_wallet_descriptor is not None):
-            return Destination(PSBTAddressVerificationFailedView, view_args=dict(is_change=is_change_derivation_path, is_multisig=psbt_parser.is_multisig), clear_history=True)
+        if is_change_addr_verified == False and (not psbt_parser.requires_descriptor_verification or self.controller.multisig_wallet_descriptor is not None):
+            return Destination(PSBTAddressVerificationFailedView, view_args=dict(is_change=is_change_derivation_path, is_multisig=psbt_parser.requires_descriptor_verification), clear_history=True)
 
         selected_menu_num = self.run_screen(
             PSBTChangeDetailsScreen,

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -122,13 +122,26 @@ class ScanView(View):
 
                 descriptor = Descriptor.from_string(descriptor_str)
 
-                from seedsigner.helpers.embit_utils import is_supported_wallet_descriptor
+                from seedsigner.helpers.embit_utils import is_supported_wallet_descriptor, match_liana_recovery_policy
                 if not is_supported_wallet_descriptor(descriptor):
                     # Bare single-key descriptor (wpkh()/pkh()); a real wallet
                     # descriptor, just not one we have a registration flow for yet.
                     # TODO: Handle single-sig descriptors?
                     logger.info(f"Received single sig descriptor: {descriptor}")
                     return Destination(NotYetImplementedView)
+
+                # Miniscript is opt-in (Settings > Advanced > Miniscript wallets,
+                # disabled by default): unlike basic multisig, curated as this
+                # display now is, it's still a materially different and newer
+                # code path -- gating it behind an explicit setting means a user
+                # who never opted in can't be routed here by a QR they weren't
+                # expecting, e.g. one crafted by a compromised or buggy
+                # coordinator. Basic multisig and key-path-only taproot are
+                # long-established and unaffected by this gate.
+                if match_liana_recovery_policy(descriptor) is not None:
+                    if self.settings.get_value(SettingsConstants.SETTING__MINISCRIPT) == SettingsConstants.OPTION__DISABLED:
+                        from seedsigner.views.view import OptionDisabledView
+                        return Destination(OptionDisabledView, view_args=dict(settings_attr=SettingsConstants.SETTING__MINISCRIPT))
 
                 self.controller.multisig_wallet_descriptor = descriptor
                 return Destination(MultisigWalletDescriptorView, skip_current_view=True)

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -122,7 +122,10 @@ class ScanView(View):
 
                 descriptor = Descriptor.from_string(descriptor_str)
 
-                if not descriptor.is_basic_multisig:
+                from seedsigner.helpers.embit_utils import is_supported_wallet_descriptor
+                if not is_supported_wallet_descriptor(descriptor):
+                    # Bare single-key descriptor (wpkh()/pkh()); a real wallet
+                    # descriptor, just not one we have a registration flow for yet.
                     # TODO: Handle single-sig descriptors?
                     logger.info(f"Received single sig descriptor: {descriptor}")
                     return Destination(NotYetImplementedView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2057,9 +2057,9 @@ class MultisigWalletDescriptorView(View):
         for key in descriptor.keys:
             fingerprint = hexlify(key.fingerprint).decode()
             fingerprints.append(fingerprint)
-        
-        from seedsigner.helpers.embit_utils import get_descriptor_policy_summary
-        policy = get_descriptor_policy_summary(descriptor)
+
+        from seedsigner.helpers.embit_utils import get_descriptor_policy_summary, match_liana_recovery_policy
+        recovery_policy = match_liana_recovery_policy(descriptor)
 
         button_data = [self.OK]
         if self.controller.resume_main_flow:
@@ -2072,12 +2072,21 @@ class MultisigWalletDescriptorView(View):
             elif self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
                 button_data = [self.ADDRESS_EXPLORER]
 
-        selected_menu_num = self.run_screen(
-            seed_screens.MultisigWalletDescriptorScreen,
-            policy=policy,
-            fingerprints=fingerprints,
-            button_data=button_data,
-        )
+        if recovery_policy is not None:
+            selected_menu_num = self.run_screen(
+                seed_screens.LianaRecoveryWalletScreen,
+                primary_fingerprint=hexlify(recovery_policy.primary_key.fingerprint).decode(),
+                recovery_fingerprint=hexlify(recovery_policy.recovery_key.fingerprint).decode(),
+                timelock_blocks=recovery_policy.timelock_blocks,
+                button_data=button_data,
+            )
+        else:
+            selected_menu_num = self.run_screen(
+                seed_screens.MultisigWalletDescriptorScreen,
+                policy=get_descriptor_policy_summary(descriptor),
+                fingerprints=fingerprints,
+                button_data=button_data,
+            )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             self.controller.multisig_wallet_descriptor = None

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2058,10 +2058,8 @@ class MultisigWalletDescriptorView(View):
             fingerprint = hexlify(key.fingerprint).decode()
             fingerprints.append(fingerprint)
         
-        from seedsigner.helpers.embit_utils import get_multisig_policy
-        threshold, n = get_multisig_policy(descriptor)
-        # TRANSLATOR_NOTE: Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
-        policy = _("{threshold} of {n}").format(threshold=threshold, n=n)
+        from seedsigner.helpers.embit_utils import get_descriptor_policy_summary
+        policy = get_descriptor_policy_summary(descriptor)
 
         button_data = [self.OK]
         if self.controller.resume_main_flow:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2075,8 +2075,10 @@ class MultisigWalletDescriptorView(View):
         if recovery_policy is not None:
             selected_menu_num = self.run_screen(
                 seed_screens.LianaRecoveryWalletScreen,
-                primary_fingerprint=hexlify(recovery_policy.primary_key.fingerprint).decode(),
-                recovery_fingerprint=hexlify(recovery_policy.recovery_key.fingerprint).decode(),
+                primary_threshold=recovery_policy.primary_threshold,
+                primary_fingerprints=recovery_policy.primary_fingerprints,
+                recovery_threshold=recovery_policy.recovery_threshold,
+                recovery_fingerprints=recovery_policy.recovery_fingerprints,
                 timelock_blocks=recovery_policy.timelock_blocks,
                 button_data=button_data,
             )

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -626,12 +626,8 @@ class ToolsAddressExplorerAddressTypeView(View):
 
         wallet_descriptor_display_name = None
         if "wallet_descriptor" in data:
-            from seedsigner.helpers.embit_utils import get_multisig_policy
-            threshold, n = get_multisig_policy(data["wallet_descriptor"])
-            # TRANSLATOR_NOTE: Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
-            wallet_descriptor_display_name = _("{threshold} / {n} multisig").format(
-                threshold=threshold, n=n
-            )
+            from seedsigner.helpers.embit_utils import get_descriptor_policy_summary
+            wallet_descriptor_display_name = get_descriptor_policy_summary(data["wallet_descriptor"])
 
         script_type = data["script_type"] if "script_type" in data else None
 
@@ -714,14 +710,20 @@ class ToolsAddressExplorerAddressListView(View):
                 elif "wallet_descriptor" in data:
                     from embit.descriptor import Descriptor
                     descriptor: Descriptor = data["wallet_descriptor"]
-                    if descriptor.is_basic_multisig:
+                    if embit_utils.can_derive_multisig_address(descriptor):
                         for i in range(self.start_index, self.start_index + addrs_per_screen):
                             address = embit_utils.get_multisig_address(descriptor=descriptor, index=i, is_change=self.is_change, embit_network=data["embit_network"])
                             addresses.append(address)
                             data[addr_storage_key].append(address)
 
                     else:
-                        raise Exception(_("Single sig descriptors not yet supported"))
+                        # Currently unreachable: every descriptor accepted by
+                        # is_supported_wallet_descriptor() (basic multisig, wsh()
+                        # Miniscript, or taproot) also satisfies
+                        # can_derive_multisig_address(). Kept as a safety net in
+                        # case a future descriptor type is registered without
+                        # address derivation support for it.
+                        raise Exception(_("Address explorer not yet supported for this descriptor type"))
             finally:
                 # Everything is set. Stop the loading screen
                 self.loading_screen.stop()

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -122,6 +122,16 @@ MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFf
 # embit_utils.match_liana_recovery_policy).
 LIANA_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))#73g7ls54"""
 
+# A 2-of-3 basic multisig, for side-by-side comparison with the Miniscript
+# screens. The MULTISIG_WALLET_DESCRIPTOR above is a 1-of-2, which reads oddly
+# next to a 2-of-3 Miniscript policy.
+MULTISIG_2OF3_WALLET_DESCRIPTOR = """wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#hzk0jmwz"""
+
+# 2-of-3 primary path with a 1-of-2 recovery quorum. Liana expresses a multi-key
+# recovery path as thresh() with a: wrappers rather than multi(), so this covers
+# a matcher branch none of the other fixtures reach.
+LIANA_THRESH_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_d(multi(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/<0;1>/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),and_v(v:thresh(1,pkh([0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<2;3>/*),a:pkh([0f21a47d/48h/1h/0h/2h]tpubDFLufBxpBavKArzSHoaXPG7WB6ruswscnzFiuHQ1T3AQDTmSN2ZSe3EN7U82q86hQWjZMiL3hio99SafdwgESZ4uD4cebmNqu6VtdNgTLQV/<2;3>/*)),older(65535))))#77alzprd"""
+
 # n-of-n primary path (all three keys required) plus a timelocked recovery key.
 # Liana compiles this as or_i with the recovery branch first and the keys chained
 # through and_v, structurally different from the k-of-n form below -- see
@@ -315,6 +325,18 @@ def generate_screenshots(locale):
 
 
         @contextmanager
+        def mock_multisig_2of3_wallet_descriptor_loaded():
+            with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(MULTISIG_2OF3_WALLET_DESCRIPTOR)):
+                yield
+
+
+        @contextmanager
+        def mock_liana_thresh_recovery_wallet_descriptor_loaded():
+            with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(LIANA_THRESH_RECOVERY_WALLET_DESCRIPTOR)):
+                yield
+
+
+        @contextmanager
         def mock_liana_nofn_recovery_wallet_descriptor_loaded():
             with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(LIANA_NOFN_RECOVERY_WALLET_DESCRIPTOR)):
                 yield
@@ -463,6 +485,8 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery"),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_multisig_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery_2of3"),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_nofn_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery_3of3"),
+                ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_thresh_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery_thresh"),
+                ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_multisig_2of3_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_2of3_multisig"),
                 ScreenshotConfig(seed_views.SeedDiscardView, dict(seed=seed_12)),
 
                 ScreenshotConfig(seed_views.SeedSelectSeedView, dict(flow=Controller.FLOW__SIGN_MESSAGE), screenshot_name="SeedSelectSeedView_sign_message"),
@@ -513,6 +537,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(tools_views.ToolsAddressExplorerSelectSourceView),
                 ScreenshotConfig(tools_views.ToolsAddressExplorerAddressTypeView, mock_context_manager=mock_multisig_wallet_descriptor_loaded),
                 ScreenshotConfig(tools_views.ToolsAddressExplorerAddressTypeView, mock_context_manager=mock_liana_recovery_wallet_descriptor_loaded, screenshot_name="ToolsAddressExplorerAddressTypeView_liana_recovery"),
+                ScreenshotConfig(tools_views.ToolsAddressExplorerAddressTypeView, mock_context_manager=mock_multisig_2of3_wallet_descriptor_loaded, screenshot_name="ToolsAddressExplorerAddressTypeView_2of3_multisig"),
                 ScreenshotConfig(tools_views.ToolsAddressExplorerAddressListView),
                 # ScreenshotConfig(tools_views.ToolsAddressExplorerAddressView),
             ],

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -487,6 +487,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(tools_views.ToolsCalcFinalWordDoneView),
                 ScreenshotConfig(tools_views.ToolsAddressExplorerSelectSourceView),
                 ScreenshotConfig(tools_views.ToolsAddressExplorerAddressTypeView, mock_context_manager=mock_multisig_wallet_descriptor_loaded),
+                ScreenshotConfig(tools_views.ToolsAddressExplorerAddressTypeView, mock_context_manager=mock_liana_recovery_wallet_descriptor_loaded, screenshot_name="ToolsAddressExplorerAddressTypeView_liana_recovery"),
                 ScreenshotConfig(tools_views.ToolsAddressExplorerAddressListView),
                 # ScreenshotConfig(tools_views.ToolsAddressExplorerAddressView),
             ],

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -122,6 +122,12 @@ MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFf
 # embit_utils.match_liana_recovery_policy).
 LIANA_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))#73g7ls54"""
 
+# n-of-n primary path (all three keys required) plus a timelocked recovery key.
+# Liana compiles this as or_i with the recovery branch first and the keys chained
+# through and_v, structurally different from the k-of-n form below -- see
+# embit_utils.match_liana_recovery_policy.
+LIANA_NOFN_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_i(and_v(v:pkh([0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<2;3>/*),older(26298)),and_v(v:and_v(v:pk([8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/<0;1>/*),pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*)),pk([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*))))#wnzrncfm"""
+
 # 2-of-3 primary path plus a single timelocked recovery key -- Liana's most
 # common real-world configuration, and the case that exercises the quorum
 # labels on LianaRecoveryWalletScreen.
@@ -309,6 +315,12 @@ def generate_screenshots(locale):
 
 
         @contextmanager
+        def mock_liana_nofn_recovery_wallet_descriptor_loaded():
+            with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(LIANA_NOFN_RECOVERY_WALLET_DESCRIPTOR)):
+                yield
+
+
+        @contextmanager
         def mock_liana_multisig_recovery_wallet_descriptor_loaded():
             with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(LIANA_MULTISIG_RECOVERY_WALLET_DESCRIPTOR)):
                 yield
@@ -450,6 +462,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_multisig_wallet_descriptor_loaded),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery"),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_multisig_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery_2of3"),
+                ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_nofn_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery_3of3"),
                 ScreenshotConfig(seed_views.SeedDiscardView, dict(seed=seed_12)),
 
                 ScreenshotConfig(seed_views.SeedSelectSeedView, dict(flow=Controller.FLOW__SIGN_MESSAGE), screenshot_name="SeedSelectSeedView_sign_message"),

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -117,6 +117,11 @@ seed_24_w_passphrase = Seed(mnemonic=mnemonic_24, passphrase="some-PASS*phrase9"
 
 MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFfsBrmpj226ZYiRszYi2qK6iGvh2vkkghfGB2YiRUVY4rqqedHCFEgw12FwDkm7rUoVtq9wLTKc6BN2sxswvQeQgp7m8st4FP8WtP8go76/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*))#3jhtf6yx"""
 
+# Liana-style "spend now, or recovery key after a timelock" descriptor -- the one
+# curated Miniscript template LianaRecoveryWalletScreen renders (see
+# embit_utils.match_liana_recovery_policy).
+LIANA_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))#73g7ls54"""
+
 # Grab the most recent release version info for the "release build" splash screenshots.
 (latest_release_version_name, latest_release_version_timestamp) = VersionUtils._fetch_latest_seedsigner_release_tag()
 if not latest_release_version_name or not latest_release_version_timestamp:
@@ -293,6 +298,12 @@ def generate_screenshots(locale):
 
 
         @contextmanager
+        def mock_liana_recovery_wallet_descriptor_loaded():
+            with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(LIANA_RECOVERY_WALLET_DESCRIPTOR)):
+                yield
+
+
+        @contextmanager
         def mock_multisig_psbt_and_descriptor_loaded():
             with mock_multisig_psbt_loaded():
                 with mock_multisig_wallet_descriptor_loaded():
@@ -426,6 +437,7 @@ def generate_screenshots(locale):
 
                 ScreenshotConfig(seed_views.LoadMultisigWalletDescriptorView),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_multisig_wallet_descriptor_loaded),
+                ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery"),
                 ScreenshotConfig(seed_views.SeedDiscardView, dict(seed=seed_12)),
 
                 ScreenshotConfig(seed_views.SeedSelectSeedView, dict(flow=Controller.FLOW__SIGN_MESSAGE), screenshot_name="SeedSelectSeedView_sign_message"),

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -122,6 +122,11 @@ MULTISIG_WALLET_DESCRIPTOR = """wsh(sortedmulti(1,[22bde1a9/48h/1h/0h/2h]tpubDFf
 # embit_utils.match_liana_recovery_policy).
 LIANA_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))#73g7ls54"""
 
+# 2-of-3 primary path plus a single timelocked recovery key -- Liana's most
+# common real-world configuration, and the case that exercises the quorum
+# labels on LianaRecoveryWalletScreen.
+LIANA_MULTISIG_RECOVERY_WALLET_DESCRIPTOR = """wsh(or_d(multi(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/<0;1>/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),and_v(v:pkh([0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<2;3>/*),older(4383))))#qmk5utc6"""
+
 # Grab the most recent release version info for the "release build" splash screenshots.
 (latest_release_version_name, latest_release_version_timestamp) = VersionUtils._fetch_latest_seedsigner_release_tag()
 if not latest_release_version_name or not latest_release_version_timestamp:
@@ -304,6 +309,12 @@ def generate_screenshots(locale):
 
 
         @contextmanager
+        def mock_liana_multisig_recovery_wallet_descriptor_loaded():
+            with patch.object(controller, 'multisig_wallet_descriptor', embit.descriptor.Descriptor.from_string(LIANA_MULTISIG_RECOVERY_WALLET_DESCRIPTOR)):
+                yield
+
+
+        @contextmanager
         def mock_multisig_psbt_and_descriptor_loaded():
             with mock_multisig_psbt_loaded():
                 with mock_multisig_wallet_descriptor_loaded():
@@ -438,6 +449,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.LoadMultisigWalletDescriptorView),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_multisig_wallet_descriptor_loaded),
                 ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery"),
+                ScreenshotConfig(seed_views.MultisigWalletDescriptorView, mock_context_manager=mock_liana_multisig_recovery_wallet_descriptor_loaded, screenshot_name="MultisigWalletDescriptorView_liana_recovery_2of3"),
                 ScreenshotConfig(seed_views.SeedDiscardView, dict(seed=seed_12)),
 
                 ScreenshotConfig(seed_views.SeedSelectSeedView, dict(flow=Controller.FLOW__SIGN_MESSAGE), screenshot_name="SeedSelectSeedView_sign_message"),

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -531,6 +531,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(CameraConnectionErrorView),
                 ScreenshotConfig(NetworkMismatchErrorView, dict(derivation_path="m/84'/1'/0'")),
                 ScreenshotConfig(OptionDisabledView,       dict(settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING)),
+                ScreenshotConfig(OptionDisabledView,       dict(settings_attr=SettingsConstants.SETTING__MINISCRIPT), screenshot_name="OptionDisabledView_miniscript"),
                 ScreenshotConfig(scan_views.ScanInvalidQRTypeView)
             ]
         }

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -568,6 +568,66 @@ def test_match_liana_recovery_policy__multisig_paths():
     ) is True
 
 
+# A real Liana export (signet), captured from the GUI during hardware testing:
+# an n-of-n primary path plus a single timelocked recovery key. Note that the
+# recovery key is also one of the three primary keys, on a different derivation
+# branch -- legal, and something the display must not obscure.
+#
+# Liana compiles this differently from a k-of-n primary, which is why it needed
+# separate handling: `or_d(X,Z)` requires X to be dissatisfiable, an `and_v`
+# chain is not, so an all-keys-required primary compiles to `or_i` instead --
+# with the recovery branch FIRST, the reverse of the or_d form.
+LIANA_REAL_3OF3_OR_I = "wsh(or_i(and_v(v:pkh([bce87290/48'/1'/0'/2']tpubDEx7eA5kryaQzKGqGw6G7McWQv3s1t2opk28vzCmS38Q7Zx31QWijPe24z3mjKwbkhh48FpUQYoiRAJcLXkmGbmiWJTErLFAcfDN53tEQVn/<2;3>/*),older(26298)),and_v(v:and_v(v:pk([bce87290/48'/1'/0'/2']tpubDEx7eA5kryaQzKGqGw6G7McWQv3s1t2opk28vzCmS38Q7Zx31QWijPe24z3mjKwbkhh48FpUQYoiRAJcLXkmGbmiWJTErLFAcfDN53tEQVn/<0;1>/*),pk([0f21a47d/48'/1'/0'/2']tpubDFLufBxpBavKArzSHoaXPG7WB6ruswscnzFiuHQ1T3AQDTmSN2ZSe3EN7U82q86hQWjZMiL3hio99SafdwgESZ4uD4cebmNqu6VtdNgTLQV/<0;1>/*)),pk([65645849/48'/1'/0'/2']tpubDEctyheVBNxchsg3rV5zAWgTaYkw8VL6SnJJacaWLqyAX2L8zxzQCqHTNzx3RnuZy2SgeCGUPx56WyJjusbe73pgT9GDZPYTet13Gv4nsPo/<0;1>/*))))#5rvc9c67"
+
+
+def test_match_liana_recovery_policy__n_of_n_primary_via_or_i():
+    """
+    An n-of-n primary path arrives structurally different from a k-of-n one:
+    `or_i` instead of `or_d`, branches in the opposite order, and the keys
+    chained through nested `and_v` rather than listed in `multi()`. This
+    descriptor is a real Liana export that the earlier or_d-only matcher
+    refused, showing up on hardware as "Not Yet Implemented".
+
+    The threshold must come out as 3 of 3, not 2 of 3: an and_v chain requires
+    every key, and understating that on a signing device would tell the user
+    their wallet is more recoverable than it is.
+    """
+    from embit.descriptor import Descriptor
+
+    d = Descriptor.from_string(LIANA_REAL_3OF3_OR_I)
+    m = embit_utils.match_liana_recovery_policy(d)
+    assert m is not None
+
+    assert m.primary_threshold == 3
+    assert m.primary_fingerprints == ["bce87290", "0f21a47d", "65645849"]
+    assert m.recovery_threshold == 1
+    assert m.recovery_fingerprints == ["bce87290"]
+    assert m.timelock_blocks == 26298
+
+    assert embit_utils.is_supported_wallet_descriptor(d) is True
+
+
+def test_match_liana_recovery_policy__rejects_multiple_recovery_tiers():
+    """
+    Liana can define several recovery paths with different timelocks. Both
+    branches of the resulting or_i are timelocked, so neither is spendable
+    now -- describing either as the "Spend now" path would be false, and the
+    curated screen has only two fields regardless. Refused rather than
+    approximated.
+    """
+    from embit.descriptor import Descriptor
+    from embit.descriptor.checksum import add_checksum
+
+    key_b = "[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*"
+    key_c = "[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*"
+
+    two_tier = Descriptor.from_string(add_checksum(
+        f"wsh(or_i(and_v(v:pkh({key_b}),older(1000)),and_v(v:pkh({key_c}),older(2000))))"
+    ))
+    assert embit_utils.match_liana_recovery_policy(two_tier) is None
+    assert embit_utils.is_supported_wallet_descriptor(two_tier) is False
+
+
 def test_match_liana_recovery_policy__rejects_undisplayable_key_counts():
     """
     The curated screen renders fingerprints two per line with room for four

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -301,8 +301,15 @@ def test_get_multisig_address():
         ("sh(sortedmulti(2,[8d55ff0d/45h]tpubDANogJ2yfnizHwX7fSi5kUVzybyuPXDhgHB2TR9TUvkSLZFW73cRq4STKFDpx7qjJJiisyq82tbu4CeiYtmKEmT1xoCq9P8BPvXV31HUh6d/{0,1}/*,[0be174ee/45h]tpubDBkeVF2tDNT1Pz7L47iJeBB6RokU12LX6x4E6Ph8T89hmjQfB77q1AMyGwL8qpREVGq9sCJEbWwmnemwNTxnpxGn1di7BGy8jx9wEi5Vahu/{0,1}/*,[73c5da0a/45h]tpubDBKsGC1UqBDNvx9aivFmxZNgeZTUnmsCFGhWrqkLzucUCDePvbWWm3n8tAaAwMmxBG2ihdKCG9fzBdUnMxKx5PrkiqSZFi6Vkv6msUs9ddN/{0,1}/*))#p5t8sa8c", 0, False, "test"): "2NBXci43Y2fagvrFYTg3QmXj2LCPU2oaRFH",
         ("sh(sortedmulti(2,[8d55ff0d/45h]tpubDANogJ2yfnizHwX7fSi5kUVzybyuPXDhgHB2TR9TUvkSLZFW73cRq4STKFDpx7qjJJiisyq82tbu4CeiYtmKEmT1xoCq9P8BPvXV31HUh6d/{0,1}/*,[0be174ee/45h]tpubDBkeVF2tDNT1Pz7L47iJeBB6RokU12LX6x4E6Ph8T89hmjQfB77q1AMyGwL8qpREVGq9sCJEbWwmnemwNTxnpxGn1di7BGy8jx9wEi5Vahu/{0,1}/*,[73c5da0a/45h]tpubDBKsGC1UqBDNvx9aivFmxZNgeZTUnmsCFGhWrqkLzucUCDePvbWWm3n8tAaAwMmxBG2ihdKCG9fzBdUnMxKx5PrkiqSZFi6Vkv6msUs9ddN/{0,1}/*))#p5t8sa8c", 0, True, "test"): "2MuWQTq7hUGiX1HpXuPRnf7YTM42H5zoEwj",
 
-        # multisig taproot on testnet, not supported
-        # TODO: find what a multisig-taproot descriptor would look like and add a test so we can fall into the last condition exception.
+        # Taproot regression test (plan's explicit Phase 1 requirement): a
+        # key-path key plus a hidden script-path recovery leaf. Despite the
+        # `elif descriptor.is_taproot: raise` branch in get_multisig_address(),
+        # this actually succeeds -- embit's `is_segwit` is True for taproot too,
+        # so the p2wsh/p2tr branch above handles it, and the tweaked output key
+        # correctly commits to the hidden leaf. See can_derive_multisig_address's
+        # docstring: this is documented, not "fixed", per the working plan.
+        ("tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,and_v(v:pk([0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*),older(1000)))#pmau4kv6", 0, False, "test"): "tb1plje4kx3zmjum85mm8rc5cdsughj4nl9jevt4fdt05cnlx9sqqxpq6nsps7",
+        ("tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,and_v(v:pk([0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*),older(1000)))#pmau4kv6", 0, True, "test"): "tb1pv3fschyrnd89vca4yj7wymaxkuypjte3al5x8fmnjk693ewdelsszjj9u0",
 
         # some policy that is not supported:
         # TODO: find anything non supported so we can drop off the function: Would it be preferred to "else: raise ValueError()"?
@@ -372,6 +379,129 @@ def test_get_multisig_policy():
         embit_utils.get_multisig_policy(Descriptor.from_string(
             "wpkh([73c5da0a/84h/1h/0h]tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba/{0,1}/*)#2aj6cvca"
         ))
+
+
+#
+# Liana-style wsh() Miniscript and taproot test vectors, reusing the exact same
+# known-good keys/fingerprints as test_get_multisig_address above
+# (73c5da0a = 'abandon...about', 0be174ee = 'baby mass dust...casino')
+# so this test data is grounded in already-verified key material.
+#
+# wsh(or_d(pk(primary),and_v(v:pkh(recovery),older(1000)))) -- Liana's basic
+# 2-key recovery policy: primary key spends any time, recovery key can spend
+# alone after a 1000-block relative timelock.
+LIANA_WSH_DESCRIPTOR = (
+    "wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),"
+    "and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))"
+    "#73g7ls54"
+)
+
+# tr(primary, and_v(v:pk(recovery),older(1000))) -- same policy shape, taproot:
+# key-path spend by the primary key, a single hidden script-path recovery leaf.
+LIANA_TR_DESCRIPTOR = (
+    "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
+    "and_v(v:pk([0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000)))"
+    "#uq7s6lsf"
+)
+
+# Bare single-key wpkh() -- NOT a "wallet policy" in the Miniscript/multisig
+# sense; should be excluded from is_supported_wallet_descriptor just like it
+# was before this change (routes to NotYetImplementedView).
+SINGLE_KEY_DESCRIPTOR = (
+    "wpkh([73c5da0a/84h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*)"
+    "#hxzwpz08"
+)
+
+
+def test_is_supported_wallet_descriptor():
+    """
+    tests seedsigner.helpers.embit_utils.is_supported_wallet_descriptor()
+    """
+    from embit.descriptor import Descriptor
+
+    # Existing basic multisig (unchanged behavior)
+    basic_multisig = Descriptor.from_string(
+        "wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#zw6cnrlk"
+    )
+    assert embit_utils.is_supported_wallet_descriptor(basic_multisig) is True
+
+    # New: general wsh() Miniscript (Liana-style)
+    assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(LIANA_WSH_DESCRIPTOR)) is True
+
+    # New: taproot, with a hidden script-path leaf
+    assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(LIANA_TR_DESCRIPTOR)) is True
+
+    # Bare single-key descriptor: still excluded (unimplemented single-sig import)
+    assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(SINGLE_KEY_DESCRIPTOR)) is False
+
+
+def test_get_descriptor_policy_summary():
+    """
+    tests seedsigner.helpers.embit_utils.get_descriptor_policy_summary()
+    """
+    from embit.descriptor import Descriptor
+
+    # Basic multisig: unchanged output vs. the old get_multisig_policy()-based string
+    basic_multisig = Descriptor.from_string(
+        "wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#zw6cnrlk"
+    )
+    assert embit_utils.get_descriptor_policy_summary(basic_multisig) == "2 of 3 multisig"
+
+    # wsh() Miniscript: both spending paths must be mentioned, with the
+    # fingerprints and the timelock value visible
+    wsh_summary = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(LIANA_WSH_DESCRIPTOR))
+    assert "73C5DA0A" in wsh_summary
+    assert "0BE174EE" in wsh_summary
+    assert "1000" in wsh_summary
+    assert "or" in wsh_summary
+
+    # Taproot regression test (the plan's explicit correctness requirement):
+    # a taproot descriptor with a hidden script-path recovery leaf must NEVER
+    # be summarized as plain single-key/single-signature. The key-path key and
+    # the recovery leaf's key + timelock must both show up.
+    tr_summary = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(LIANA_TR_DESCRIPTOR))
+    assert "single" not in tr_summary.lower()
+    assert "73C5DA0A" in tr_summary  # key-path key
+    assert "0BE174EE" in tr_summary  # hidden recovery leaf key
+    assert "1000" in tr_summary      # recovery leaf's timelock
+
+    # Taproot with no script path at all (key-path only) -- also must not be
+    # mislabeled, but has nothing to hide, so no leaves are expected.
+    key_only_taproot = Descriptor.from_string(
+        "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*)#kcjfc8qw"
+    )
+    key_only_summary = embit_utils.get_descriptor_policy_summary(key_only_taproot)
+    assert "73C5DA0A" in key_only_summary
+
+    # Bare single-key descriptor: get_descriptor_policy_summary() itself should
+    # describe it safely rather than raise, even though callers today route
+    # single-key descriptors elsewhere before ever calling this function.
+    single_summary = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(SINGLE_KEY_DESCRIPTOR))
+    assert "73C5DA0A" in single_summary
+
+    # 240x240-screen truncation: must never exceed max_length, and must end
+    # with a truncation marker rather than silently overflowing.
+    truncated = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(LIANA_WSH_DESCRIPTOR), max_length=20)
+    assert len(truncated) <= 20
+    assert truncated.endswith("…")
+
+
+def test_can_derive_multisig_address():
+    """
+    tests seedsigner.helpers.embit_utils.can_derive_multisig_address()
+    """
+    from embit.descriptor import Descriptor
+
+    basic_multisig = Descriptor.from_string(
+        "wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#zw6cnrlk"
+    )
+    assert embit_utils.can_derive_multisig_address(basic_multisig) is True
+    assert embit_utils.can_derive_multisig_address(Descriptor.from_string(LIANA_WSH_DESCRIPTOR)) is True
+
+    # Perhaps surprisingly, True for taproot too -- see the docstring on
+    # can_derive_multisig_address(): embit's `is_segwit` covers taproot, and
+    # address derivation for it genuinely works (verified in test_get_multisig_address).
+    assert embit_utils.can_derive_multisig_address(Descriptor.from_string(LIANA_TR_DESCRIPTOR)) is True
 
 
 def test_parse_derivation_path():

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -425,14 +425,83 @@ def test_is_supported_wallet_descriptor():
     )
     assert embit_utils.is_supported_wallet_descriptor(basic_multisig) is True
 
-    # New: general wsh() Miniscript (Liana-style)
+    # Curated Miniscript template only: wsh() shape matching match_liana_recovery_policy()
     assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(LIANA_WSH_DESCRIPTOR)) is True
 
-    # New: taproot, with a hidden script-path leaf
+    # Curated Miniscript template only: tr() shape matching match_liana_recovery_policy()
     assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(LIANA_TR_DESCRIPTOR)) is True
+
+    # Taproot key-path only (no hidden leaves): trivially safe, accepted generically
+    key_only_taproot = Descriptor.from_string(
+        "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*)#kcjfc8qw"
+    )
+    assert embit_utils.is_supported_wallet_descriptor(key_only_taproot) is True
+
+    # Arbitrary Miniscript that does NOT match the curated template must be
+    # rejected -- this is the entire point of narrowing the gate. Regression
+    # test for the exact concern raised in review (seedsigner#306, PR #1026):
+    # a generic AST-to-English summary was previously accepted for any wsh()
+    # Miniscript, which reviewers flagged as unreadable/unsafe on-device once
+    # policies get more complex than one OR of two simple branches.
+    complex_policy = Descriptor.from_string(
+        "wsh(or_d("
+        "multi(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/<0;1>/*,"
+        "[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
+        "[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),"
+        "and_v(v:pkh([0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<0;1>/*),older(25920))))"
+    )
+    assert embit_utils.is_supported_wallet_descriptor(complex_policy) is False
 
     # Bare single-key descriptor: still excluded (unimplemented single-sig import)
     assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(SINGLE_KEY_DESCRIPTOR)) is False
+
+
+def test_match_liana_recovery_policy():
+    """
+    tests seedsigner.helpers.embit_utils.match_liana_recovery_policy()
+    """
+    from embit.descriptor import Descriptor
+    from embit.descriptor.checksum import add_checksum
+
+    wsh_match = embit_utils.match_liana_recovery_policy(Descriptor.from_string(LIANA_WSH_DESCRIPTOR))
+    assert wsh_match is not None
+    assert wsh_match.primary_key.fingerprint.hex() == "73c5da0a"
+    assert wsh_match.recovery_key.fingerprint.hex() == "0be174ee"
+    assert wsh_match.timelock_blocks == 1000
+
+    tr_match = embit_utils.match_liana_recovery_policy(Descriptor.from_string(LIANA_TR_DESCRIPTOR))
+    assert tr_match is not None
+    assert tr_match.primary_key.fingerprint.hex() == "73c5da0a"
+    assert tr_match.recovery_key.fingerprint.hex() == "0be174ee"
+    assert tr_match.timelock_blocks == 1000
+
+    # Basic multisig is a completely different shape -- no match, not an error
+    basic_multisig = Descriptor.from_string(
+        "wsh(sortedmulti(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/{0,1}/*,[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*,[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/{0,1}/*))#zw6cnrlk"
+    )
+    assert embit_utils.match_liana_recovery_policy(basic_multisig) is None
+
+    assert embit_utils.match_liana_recovery_policy(Descriptor.from_string(SINGLE_KEY_DESCRIPTOR)) is None
+
+    # A third OR branch, or any other shape beyond exactly "primary, or
+    # recovery-after-timelock" -- must not match, even though it superficially
+    # resembles the template (still an or_d at the top, still has an older()).
+    three_way = Descriptor.from_string(add_checksum(
+        "wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),"
+        "or_i(and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000)),"
+        "and_v(v:pkh([0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<0;1>/*),older(2000)))))"
+    ))
+    assert embit_utils.match_liana_recovery_policy(three_way) is None
+
+    # BIP68 time-based timelock (bit 22 set: 512-second units, not blocks).
+    # Liana has never been observed to produce this encoding for this policy
+    # shape; deliberately left unrecognized rather than assumed == blocks.
+    # older(1000 | 0x00400000) as raw pushed argument.
+    time_based = Descriptor.from_string(add_checksum(
+        "wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),"
+        "and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(4195304))))"
+    ))
+    assert embit_utils.match_liana_recovery_policy(time_based) is None
 
 
 def test_get_descriptor_policy_summary():

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -418,6 +418,7 @@ def test_is_supported_wallet_descriptor():
     tests seedsigner.helpers.embit_utils.is_supported_wallet_descriptor()
     """
     from embit.descriptor import Descriptor
+    from embit.descriptor.checksum import add_checksum
 
     # Existing basic multisig (unchanged behavior)
     basic_multisig = Descriptor.from_string(
@@ -437,20 +438,35 @@ def test_is_supported_wallet_descriptor():
     )
     assert embit_utils.is_supported_wallet_descriptor(key_only_taproot) is True
 
-    # Arbitrary Miniscript that does NOT match the curated template must be
-    # rejected -- this is the entire point of narrowing the gate. Regression
-    # test for the exact concern raised in review (seedsigner#306, PR #1026):
-    # a generic AST-to-English summary was previously accepted for any wsh()
-    # Miniscript, which reviewers flagged as unreadable/unsafe on-device once
-    # policies get more complex than one OR of two simple branches.
-    complex_policy = Descriptor.from_string(
-        "wsh(or_d("
-        "multi(2,[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/<0;1>/*,"
-        "[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
-        "[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),"
-        "and_v(v:pkh([0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<0;1>/*),older(25920))))"
-    )
-    assert embit_utils.is_supported_wallet_descriptor(complex_policy) is False
+    # Miniscript that does NOT match the curated template must be rejected --
+    # this is the point of narrowing the gate (seedsigner#306, PR #1026): a
+    # generic AST-to-English summary used to be accepted for any wsh()
+    # Miniscript, which reviewers flagged as unreadable/unsafe on-device.
+    #
+    # Both cases below are valid miniscript that this curated screen cannot
+    # state correctly, so both are refused rather than approximated.
+    key_a = "[8d55ff0d/48h/1h/0h/2h]tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg/<0;1>/*"
+    key_b = "[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*"
+
+    # An *absolute* timelock (after = block height) where the template expects a
+    # *relative* one (older = blocks since the coin confirmed). Accepting this
+    # would be actively misleading, since the screen says "after N blocks",
+    # which describes the relative meaning.
+    absolute_timelock = Descriptor.from_string(add_checksum(
+        f"wsh(or_d(pk({key_a}),and_v(v:pkh({key_b}),after(500000))))"
+    ))
+    assert embit_utils.match_liana_recovery_policy(absolute_timelock) is None
+    assert embit_utils.is_supported_wallet_descriptor(absolute_timelock) is False
+
+    # A recovery path gated on a hash preimage in addition to a key and a
+    # timelock -- a third condition the curated two-path screen has nowhere to
+    # show, so silently omitting it would understate what's required to spend.
+    hashlock_recovery = Descriptor.from_string(add_checksum(
+        f"wsh(or_d(pk({key_a}),and_v(v:pkh({key_b}),"
+        "and_v(v:sha256(6c60f404f8167a38fc70eaf8aa17ac351023bef86bcb9d1086a19afe95bd5333),older(100)))))"
+    ))
+    assert embit_utils.match_liana_recovery_policy(hashlock_recovery) is None
+    assert embit_utils.is_supported_wallet_descriptor(hashlock_recovery) is False
 
     # Bare single-key descriptor: still excluded (unimplemented single-sig import)
     assert embit_utils.is_supported_wallet_descriptor(Descriptor.from_string(SINGLE_KEY_DESCRIPTOR)) is False
@@ -465,14 +481,18 @@ def test_match_liana_recovery_policy():
 
     wsh_match = embit_utils.match_liana_recovery_policy(Descriptor.from_string(LIANA_WSH_DESCRIPTOR))
     assert wsh_match is not None
-    assert wsh_match.primary_key.fingerprint.hex() == "73c5da0a"
-    assert wsh_match.recovery_key.fingerprint.hex() == "0be174ee"
+    assert wsh_match.primary_threshold == 1
+    assert wsh_match.primary_fingerprints == ["73c5da0a"]
+    assert wsh_match.recovery_threshold == 1
+    assert wsh_match.recovery_fingerprints == ["0be174ee"]
     assert wsh_match.timelock_blocks == 1000
 
     tr_match = embit_utils.match_liana_recovery_policy(Descriptor.from_string(LIANA_TR_DESCRIPTOR))
     assert tr_match is not None
-    assert tr_match.primary_key.fingerprint.hex() == "73c5da0a"
-    assert tr_match.recovery_key.fingerprint.hex() == "0be174ee"
+    assert tr_match.primary_threshold == 1
+    assert tr_match.primary_fingerprints == ["73c5da0a"]
+    assert tr_match.recovery_threshold == 1
+    assert tr_match.recovery_fingerprints == ["0be174ee"]
     assert tr_match.timelock_blocks == 1000
 
     # Basic multisig is a completely different shape -- no match, not an error
@@ -502,6 +522,95 @@ def test_match_liana_recovery_policy():
         "and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(4195304))))"
     ))
     assert embit_utils.match_liana_recovery_policy(time_based) is None
+
+
+# Descriptors copied verbatim from Liana's own test suite
+# (liana-gui/src/app/state/receive.rs and .../psbt.rs), so these assert against
+# what Liana actually emits rather than against a hand-built approximation of
+# it. Note the two different multi-key forms Liana uses: `multi(k,...)` for a
+# quorum on the primary path, but `thresh(k,pkh(A),a:pkh(B))` for one on the
+# recovery path -- the recovery branch sits under and_v and needs different
+# miniscript type properties, so a matcher that only handled `multi()` would
+# silently reject every multi-key recovery wallet.
+LIANA_REAL_MULTISIG_PRIMARY = "wsh(or_d(multi(2,[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/<0;1>/*,[de6eb005/48'/1'/0'/2']tpubDFGuYfS2JwiUSEXiQuNGdT3R7WTDhbaE6jbUhgYSSdhmfQcSx7ZntMPPv7nrkvAqjpj3jX9wbhSGMeKVao4qAzhbNyBi7iQmv5xxQk6H6jz/<0;1>/*),and_v(v:pkh([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/<2;3>/*),older(3))))#p9ax3xxp"
+
+LIANA_REAL_MULTISIG_BOTH_PATHS = "wsh(or_d(multi(2,[f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<0;1>/*,[2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<0;1>/*),and_v(v:thresh(1,pkh([f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<2;3>/*),a:pkh([2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<2;3>/*)),older(65535))))#9s8ekrce"
+
+
+def test_match_liana_recovery_policy__multisig_paths():
+    """
+    A multi-key primary path with a timelocked recovery is Liana's flagship
+    configuration (2-of-3 now, single recovery key later), so it has to be a
+    first-class supported shape, not an edge case.
+    """
+    from embit.descriptor import Descriptor
+
+    m = embit_utils.match_liana_recovery_policy(Descriptor.from_string(LIANA_REAL_MULTISIG_PRIMARY))
+    assert m is not None
+    assert m.primary_threshold == 2
+    assert m.primary_fingerprints == ["ffd63c8d", "de6eb005"]
+    assert m.recovery_threshold == 1
+    assert m.recovery_fingerprints == ["ffd63c8d"]
+    assert m.timelock_blocks == 3
+
+    # thresh()-based recovery quorum, which is a different miniscript fragment
+    # from the multi() used on the primary path.
+    m = embit_utils.match_liana_recovery_policy(Descriptor.from_string(LIANA_REAL_MULTISIG_BOTH_PATHS))
+    assert m is not None
+    assert m.primary_threshold == 2
+    assert m.primary_fingerprints == ["f714c228", "2522f23c"]
+    assert m.recovery_threshold == 1
+    assert m.recovery_fingerprints == ["f714c228", "2522f23c"]
+    assert m.timelock_blocks == 65535
+
+    assert embit_utils.is_supported_wallet_descriptor(
+        Descriptor.from_string(LIANA_REAL_MULTISIG_PRIMARY)
+    ) is True
+
+
+def test_match_liana_recovery_policy__rejects_undisplayable_key_counts():
+    """
+    The curated screen renders fingerprints two per line with room for four
+    lines across both paths. A policy needing more than that is refused at
+    match time, because the alternative is a screen whose recovery section is
+    pushed under the buttons and silently invisible -- hiding the timelocked
+    path is strictly worse than declining to display the wallet.
+
+    Verified against the real screen: 3 primary lines + 1 recovery line ends
+    at 178px against a 200px button top; one more line reaches 199-201px.
+    """
+    from embit.descriptor import Descriptor
+    from embit.descriptor.checksum import add_checksum
+
+    xpubs = [
+        "tpubDDxNVWk924RTUhdkVB2uLHw1hGMPNMGufpZefhkkswjbZppVZcuMdjYKQN4ewUog9vbL6RBLFPRWcgTGT7kYP79N6thyJ43ELUs4N2szXMg",
+        "tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ",
+        "tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux",
+        "tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31",
+        "tpubDEx7eA5kryaQzKGqGw6G7McWQv3s1t2opk28vzCmS38Q7Zx31QWijPe24z3mjKwbkhh48FpUQYoiRAJcLXkmGbmiWJTErLFAcfDN53tEQVn",
+        "tpubDEejYZTUVV2p7Zxi8LKU1zH7oZXT9UaiWC3zbvZnNDQVkKCz7858R39j8mZn1vbBkwHDTzNRaC8hrjyM9u8MtsfTjYCJxx6XBHrhmPg4seG",
+        "tpubDF1SdybxnrvMab6MpzaSFvN26BtfANBSdAG1g1fHPYtaNo8oJaxnNfn2XgVuEvjaxoScVhNThEey27x9m3UB7GFfmYg6BA7yJ7EegKYb6EM",
+    ]
+
+    def key(i, branch="<0;1>"):
+        return f"[{'%08x' % (0x11111111 * (i + 1))}/48h/1h/0h/2h]{xpubs[i]}/{branch}/*"
+
+    def build(num_primary):
+        primary = f"multi(2,{','.join(key(i) for i in range(num_primary))})"
+        recovery = f"pkh({key(0, '<2;3>')})"
+        return Descriptor.from_string(
+            add_checksum(f"wsh(or_d({primary},and_v(v:{recovery},older(1000))))")
+        )
+
+    # 5 primary keys -> 3 lines + 1 recovery line = 4, the documented ceiling.
+    accepted = embit_utils.match_liana_recovery_policy(build(5))
+    assert accepted is not None
+    assert accepted.primary_threshold == 2
+    assert len(accepted.primary_fingerprints) == 5
+
+    # 7 primary keys -> 4 lines + 1 = 5, past the ceiling.
+    assert embit_utils.match_liana_recovery_policy(build(7)) is None
+    assert embit_utils.is_supported_wallet_descriptor(build(7)) is False
 
 
 def test_get_descriptor_policy_summary():

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -516,19 +516,40 @@ def test_get_descriptor_policy_summary():
     )
     assert embit_utils.get_descriptor_policy_summary(basic_multisig) == "2 of 3 multisig"
 
-    # wsh() Miniscript: both spending paths must be mentioned, with the
-    # fingerprints and the timelock value visible
-    wsh_summary = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(LIANA_WSH_DESCRIPTOR))
-    assert "73C5DA0A" in wsh_summary
-    assert "0BE174EE" in wsh_summary
-    assert "1000" in wsh_summary
-    assert "or" in wsh_summary
+    # Curated template (wsh and tr alike): must return the short fixed name,
+    # NOT a rendering of the policy expression.
+    #
+    # Regression test for a real bug found in on-device testing: Address
+    # Explorer's one-line "Wallet descriptor" field called this function and
+    # got back "(key BCE87290) or ((key 36D9CF93) and (after 4383 blocks))",
+    # which ran off the right edge of the screen mid-word. Wrapping it would
+    # not have been a fix -- the nested expression is the thing reviewers
+    # objected to showing at all (seedsigner#306, PR #1026). Asserting on the
+    # *absence* of expression syntax, not just on length, so a future change
+    # that merely shortens the expression still fails this.
+    for label, descriptor_str in [
+        ("wsh", LIANA_WSH_DESCRIPTOR),
+        ("tr", LIANA_TR_DESCRIPTOR),
+    ]:
+        summary = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(descriptor_str))
+        assert summary == "Recovery wallet", f"{label}: {summary}"
+        assert "(" not in summary, f"{label}: policy expression leaked into summary"
+        assert "73C5DA0A" not in summary
+        assert "1000" not in summary
 
-    # Taproot regression test (the plan's explicit correctness requirement):
-    # a taproot descriptor with a hidden script-path recovery leaf must NEVER
-    # be summarized as plain single-key/single-signature. The key-path key and
-    # the recovery leaf's key + timelock must both show up.
-    tr_summary = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(LIANA_TR_DESCRIPTOR))
+    # Taproot correctness requirement still holds for the taproot shapes that
+    # do NOT match the curated template and so fall through to the generic
+    # description: a hidden script-path recovery leaf must never be
+    # summarized as plain single-key/single-signature. Uses two leaves, which
+    # match_liana_recovery_policy() rejects (it requires exactly one).
+    from embit.descriptor.checksum import add_checksum
+    two_leaf_taproot = Descriptor.from_string(add_checksum(
+        "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
+        "{and_v(v:pk([0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000)),"
+        "and_v(v:pk([0f889044/86h/1h/0h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<0;1>/*),older(2000))})"
+    ))
+    assert embit_utils.match_liana_recovery_policy(two_leaf_taproot) is None
+    tr_summary = embit_utils.get_descriptor_policy_summary(two_leaf_taproot)
     assert "single" not in tr_summary.lower()
     assert "73C5DA0A" in tr_summary  # key-path key
     assert "0BE174EE" in tr_summary  # hidden recovery leaf key
@@ -549,10 +570,18 @@ def test_get_descriptor_policy_summary():
     assert "73C5DA0A" in single_summary
 
     # 240x240-screen truncation: must never exceed max_length, and must end
-    # with a truncation marker rather than silently overflowing.
-    truncated = embit_utils.get_descriptor_policy_summary(Descriptor.from_string(LIANA_WSH_DESCRIPTOR), max_length=20)
+    # with a truncation marker rather than silently overflowing. Uses the
+    # two-leaf taproot above, since the curated template now returns a short
+    # fixed name that never needs truncating.
+    truncated = embit_utils.get_descriptor_policy_summary(two_leaf_taproot, max_length=20)
     assert len(truncated) <= 20
     assert truncated.endswith("…")
+
+    # The curated template's short name is well under any sane max_length, so
+    # it comes back whole rather than truncated.
+    assert embit_utils.get_descriptor_policy_summary(
+        Descriptor.from_string(LIANA_WSH_DESCRIPTOR), max_length=20
+    ) == "Recovery wallet"
 
 
 def test_can_derive_multisig_address():

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -221,7 +221,12 @@ class TestToolsFlows(FlowTest):
             descriptor (or_d(pk(...),and_v(...))) -- previously rejected as
             "single sig" by the is_basic_multisig gate -- and generate addresses
             for it, exactly like it already does for basic multisig.
+
+            Requires Settings > Advanced > Miniscript wallets, which is
+            disabled by default (see test__scan_descriptor__miniscript_disabled_by_default).
         """
+        self.settings.set_value(SettingsConstants.SETTING__MINISCRIPT, SettingsConstants.OPTION__ENABLED)
+
         def load_descriptor_into_decoder(view: scan_views.ScanView):
             # Liana-style 2-key recovery policy; same key material as
             # test_embit_utils.py's LIANA_WSH_DESCRIPTOR, {0,1} multipath form.
@@ -253,7 +258,12 @@ class TestToolsFlows(FlowTest):
             MultisigWalletDescriptorView, even though address derivation for
             taproot isn't implemented yet (Phase 2). Registering/displaying the
             policy must not be blocked by that separate, later limitation.
+
+            Requires Settings > Advanced > Miniscript wallets, which is
+            disabled by default (see test__scan_descriptor__miniscript_disabled_by_default).
         """
+        self.settings.set_value(SettingsConstants.SETTING__MINISCRIPT, SettingsConstants.OPTION__ENABLED)
+
         def load_descriptor_into_decoder(view: scan_views.ScanView):
             tr_descriptor = (
                 "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
@@ -267,6 +277,66 @@ class TestToolsFlows(FlowTest):
             FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
             FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
             FlowStep(scan_views.ScanWalletDescriptorView, before_run=load_descriptor_into_decoder),  # simulate read descriptor QR
+            FlowStep(seed_views.MultisigWalletDescriptorView),
+        ])
+
+
+    def test__scan_descriptor__miniscript_disabled_by_default__routes_to_option_disabled(self):
+        """
+            Regression test for the Settings gate itself: a Liana-style wsh()
+            Miniscript descriptor must NOT reach MultisigWalletDescriptorView
+            on a fresh/default settings profile. Miniscript wallets is an
+            explicit opt-in (Settings > Advanced), off by default -- unlike
+            basic multisig, which this same descriptor QR path has always
+            accepted unconditionally and continues to (see the next test).
+        """
+        from seedsigner.views.view import OptionDisabledView
+        assert self.settings.get_value(SettingsConstants.SETTING__MINISCRIPT) == SettingsConstants.OPTION__DISABLED
+
+        def load_descriptor_into_decoder(view: scan_views.ScanView):
+            wsh_descriptor = (
+                "wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),"
+                "and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))"
+                "#73g7ls54"
+            )
+            view.decoder.add_data(wsh_descriptor)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
+            FlowStep(scan_views.ScanWalletDescriptorView, before_run=load_descriptor_into_decoder),
+            FlowStep(OptionDisabledView),
+        ])
+        # The gate must not have leaked the descriptor into controller state either.
+        assert Controller.get_instance().multisig_wallet_descriptor is None
+
+
+    def test__scan_descriptor__basic_multisig__unaffected_by_miniscript_setting(self):
+        """
+            Basic multisig registration predates the Miniscript work entirely
+            and must keep working exactly as before regardless of the
+            Miniscript setting's value -- confirms the new gate in ScanView
+            is scoped to match_liana_recovery_policy() matches only, not to
+            every wallet-descriptor QR.
+        """
+        assert self.settings.get_value(SettingsConstants.SETTING__MINISCRIPT) == SettingsConstants.OPTION__DISABLED
+
+        def load_descriptor_into_decoder(view: scan_views.ScanView):
+            multisig_descriptor = (
+                "wsh(sortedmulti(2,"
+                "[73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
+                "[0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*,"
+                "[0f889044/48h/1h/0h/2h]tpubDFQDKbH2mDqNDPNaUVxM6R5mHhzC4u5F6mNnUkCf6gBMbcENMQ1ZGFLZc3QwgdEv2f34wkTvLMG5kD8AZEZRhat1HQDj42eVxQSxbcqxn31/<0;1>/*))"
+                "#vt4q7sgj"
+            )
+            view.decoder.add_data(multisig_descriptor)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
+            FlowStep(scan_views.ScanWalletDescriptorView, before_run=load_descriptor_into_decoder),
             FlowStep(seed_views.MultisigWalletDescriptorView),
         ])
 

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -215,6 +215,62 @@ class TestToolsFlows(FlowTest):
         ])
 
 
+    def test__address_explorer__liana_miniscript_wsh__flow(self):
+        """
+            Address Explorer should register a Liana-style wsh() Miniscript
+            descriptor (or_d(pk(...),and_v(...))) -- previously rejected as
+            "single sig" by the is_basic_multisig gate -- and generate addresses
+            for it, exactly like it already does for basic multisig.
+        """
+        def load_descriptor_into_decoder(view: scan_views.ScanView):
+            # Liana-style 2-key recovery policy; same key material as
+            # test_embit_utils.py's LIANA_WSH_DESCRIPTOR, {0,1} multipath form.
+            wsh_descriptor = (
+                "wsh(or_d(pk([73c5da0a/48h/1h/0h/2h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*),"
+                "and_v(v:pkh([0be174ee/48h/1h/0h/2h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000))))"
+                "#73g7ls54"
+            )
+            view.decoder.add_data(wsh_descriptor)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
+            FlowStep(scan_views.ScanWalletDescriptorView, before_run=load_descriptor_into_decoder),  # simulate read descriptor QR
+            FlowStep(seed_views.MultisigWalletDescriptorView, button_data_selection=seed_views.MultisigWalletDescriptorView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerAddressTypeView, button_data_selection=tools_views.ToolsAddressExplorerAddressTypeView.RECEIVE),
+            FlowStep(tools_views.ToolsAddressExplorerAddressListView, screen_return_value=10),  # ret NEXT page of addrs
+            FlowStep(tools_views.ToolsAddressExplorerAddressListView, screen_return_value=4),  # ret a specific addr from the list
+            FlowStep(tools_views.ToolsAddressExplorerAddressView),  # runs until dismissed; no ret value
+            FlowStep(tools_views.ToolsAddressExplorerAddressListView),
+        ])
+
+
+    def test__scan_descriptor__liana_taproot__reaches_policy_view(self):
+        """
+            A taproot Miniscript descriptor (key-path + hidden recovery leaf)
+            should also clear the registration gate and reach
+            MultisigWalletDescriptorView, even though address derivation for
+            taproot isn't implemented yet (Phase 2). Registering/displaying the
+            policy must not be blocked by that separate, later limitation.
+        """
+        def load_descriptor_into_decoder(view: scan_views.ScanView):
+            tr_descriptor = (
+                "tr([73c5da0a/86h/1h/0h]tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
+                "and_v(v:pk([0be174ee/86h/1h/0h]tpubDEsePyLPkbxbrDiZSTTWdsviiNtiQjrvvzZnkLtG72QYLBygEsXePRsTdXi8DeMA7taCuuvoEBjUAfFrsNZeQJqfvG9fFoujYWbFPYUn7ux/<0;1>/*),older(1000)))"
+                "#uq7s6lsf"
+            )
+            view.decoder.add_data(tr_descriptor)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SCAN_DESCRIPTOR),
+            FlowStep(scan_views.ScanWalletDescriptorView, before_run=load_descriptor_into_decoder),  # simulate read descriptor QR
+            FlowStep(seed_views.MultisigWalletDescriptorView),
+        ])
+
+
     def test__verify_address__legacy_multisig_p2sh__flow(self):
         """
             Address Explorer should be able to scan a legacy multisig p2sh address and

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -1370,3 +1370,167 @@ class TestPSBTParserMiniscript:
         assert psbt_parser.num_destinations == 1
         assert psbt_parser.spend_amount == 30_000
         assert psbt_parser.destination_addresses == [foreign_address]
+
+
+    def build_liana_style_psbt(self, attach_our_derivation_to_foreign_output: bool = False):
+        """
+        Same wallet as build_miniscript_psbt(), but models how Liana *actually*
+        populates its own change output, which is the case the fixture above got
+        wrong: bip32_derivations are supplied, witness_script is NOT.
+
+        Confirmed against a real Liana v15.0 signet PSBT, whose change output
+        carried two bip32_derivations (branch 1) and no witness_script at all. The
+        fixture above assumed a coordinator always fills in witness_script for its
+        own outputs; because that assumption was baked into the test data, the
+        entire class passed while real hardware silently misclassified change.
+
+        attach_our_derivation_to_foreign_output models a hostile coordinator: it
+        attaches a genuine derivation of *our* pubkey to an output paying a script
+        we have no control over, to confirm that "references our key" is treated
+        only as a candidate and never as ownership.
+
+        Returns (psbt, seed, descriptor, our_change_address, foreign_address).
+        """
+        net = NETWORKS["regtest"]
+
+        root_primary = bip32.HDKey.from_seed(bip39.mnemonic_to_seed(self.MNEMONIC_PRIMARY), version=net["xprv"])
+        fp_primary = root_primary.my_fingerprint
+        acct_primary = root_primary.derive("m/48h/1h/0h/2h")
+        xpub_primary = acct_primary.to_public().to_base58(version=net["xpub"])
+
+        root_recovery = bip32.HDKey.from_seed(bip39.mnemonic_to_seed(self.MNEMONIC_RECOVERY), version=net["xprv"])
+        fp_recovery = root_recovery.my_fingerprint
+        acct_recovery = root_recovery.derive("m/48h/1h/0h/2h")
+        xpub_recovery = acct_recovery.to_public().to_base58(version=net["xpub"])
+
+        body = (
+            f"wsh(or_d(pk([{fp_primary.hex()}/48h/1h/0h/2h]{xpub_primary}/<0;1>/*),"
+            f"and_v(v:pkh([{fp_recovery.hex()}/48h/1h/0h/2h]{xpub_recovery}/<0;1>/*),older(2))))"
+        )
+        descriptor = Descriptor.from_string(add_checksum(body))
+
+        inp_derived = descriptor.derive(0, branch_index=0)
+        inp_script = inp_derived.script_pubkey()
+        inp_witness_script = script.Script(inp_derived.miniscript.compile())
+        inp_pubkey = acct_primary.derive("m/0/0").to_public()
+
+        change_derived = descriptor.derive(0, branch_index=1)
+        change_script = change_derived.script_pubkey()
+        change_pubkey = acct_primary.derive("m/1/0").to_public()
+        recovery_change_pubkey = acct_recovery.derive("m/1/0").to_public()
+
+        root_foreign = bip32.HDKey.from_seed(bip39.mnemonic_to_seed(self.MNEMONIC_FOREIGN), version=net["xprv"])
+        foreign_pubkey = root_foreign.derive("m/0h").to_public()
+        foreign_script = script.p2wsh(script.Script(b"\x21" + foreign_pubkey.sec() + b"\xac"))
+
+        tx = Transaction(
+            vin=[TransactionInput(bytes(32), 0)],
+            vout=[
+                TransactionOutput(50_000, change_script),
+                TransactionOutput(30_000, foreign_script),
+            ],
+        )
+        psbt = PSBT(tx)
+        inp = psbt.inputs[0]
+        inp.witness_utxo = TransactionOutput(100_000, inp_script)
+        inp.witness_script = inp_witness_script
+        inp.bip32_derivations[inp_pubkey] = DerivationPath(fp_primary, [48 + 2**31, 1 + 2**31, 0 + 2**31, 2 + 2**31, 0, 0])
+
+        # The real-Liana shape: derivations for both wallet keys, no witness_script.
+        change_path = [48 + 2**31, 1 + 2**31, 0 + 2**31, 2 + 2**31, 1, 0]
+        psbt.outputs[0].bip32_derivations[change_pubkey] = DerivationPath(fp_primary, change_path)
+        psbt.outputs[0].bip32_derivations[recovery_change_pubkey] = DerivationPath(fp_recovery, change_path)
+
+        if attach_our_derivation_to_foreign_output:
+            psbt.outputs[1].bip32_derivations[change_pubkey] = DerivationPath(fp_primary, change_path)
+
+        seed = Seed(self.MNEMONIC_PRIMARY.split())
+        return psbt, seed, descriptor, change_script.address(network=net), foreign_script.address(network=net)
+
+
+    def test_liana_style_change_without_witness_script_is_detected_as_change(self):
+        """
+        Regression test for the bug this class originally shipped with: Liana does
+        not populate witness_script on its own change output, so the p2wsh branch
+        of _parse_outputs could not rebuild the scriptpubkey and fell through to
+        "not change". The change was then counted as money leaving the wallet.
+
+        Observed on real hardware: a 10,000 sat input spending 5,000 to a recipient
+        with 4,827 back as change displayed a 9,827 sat spend -- change plus payment
+        -- and offered the user no confirmation that the 4,827 was returning to
+        them.
+        """
+        psbt, seed, _, our_change_address, foreign_address = self.build_liana_style_psbt()
+
+        psbt_parser = PSBTParser(p=psbt, seed=seed, network=SettingsConstants.REGTEST)
+
+        assert psbt_parser.num_change_outputs == 1
+        assert psbt_parser.change_amount == 50_000
+        assert psbt_parser.change_data[0]["address"] == our_change_address
+
+        # The bug: this was 80_000 (change + payment) and 2 destinations.
+        assert psbt_parser.spend_amount == 30_000
+        assert psbt_parser.num_destinations == 1
+        assert psbt_parser.destination_addresses == [foreign_address]
+
+
+    def test_foreign_output_with_no_derivations_is_not_a_change_candidate(self):
+        """
+        The candidate fallback must not fire on an output that merely shares our
+        script type. Same PSBT as above: the foreign output carries neither a
+        witness_script nor any derivation, so nothing links it to this seed.
+        """
+        psbt, seed, _, _, foreign_address = self.build_liana_style_psbt()
+
+        psbt_parser = PSBTParser(p=psbt, seed=seed, network=SettingsConstants.REGTEST)
+
+        change_addresses = [c["address"] for c in psbt_parser.change_data]
+        assert foreign_address not in change_addresses
+        assert foreign_address in psbt_parser.destination_addresses
+
+
+    def test_our_derivation_on_foreign_script_is_candidate_but_fails_descriptor_check(self):
+        """
+        Security boundary. A coordinator can attach a genuine derivation of our own
+        pubkey to an output paying a script we do not control, which is enough to
+        pass the candidate check -- by design, since that check only proves our key
+        is referenced.
+
+        What must not happen is that passing the candidate check is mistaken for
+        ownership. verify_multisig_output(), against the known-good descriptor, has
+        to reject it, and requires_descriptor_verification has to be True so the
+        signing flow actually performs that check rather than falling back to
+        single-sig re-derivation.
+        """
+        psbt, seed, descriptor, _, _ = self.build_liana_style_psbt(
+            attach_our_derivation_to_foreign_output=True
+        )
+
+        psbt_parser = PSBTParser(p=psbt, seed=seed, network=SettingsConstants.REGTEST)
+
+        # Candidate check alone cannot tell these apart...
+        assert psbt_parser.num_change_outputs == 2
+
+        # ...so the descriptor must, and does.
+        verdicts = {
+            psbt_parser.get_change_data(n)["address"]: psbt_parser.verify_multisig_output(descriptor, change_num=n)
+            for n in range(psbt_parser.num_change_outputs)
+        }
+        assert sorted(verdicts.values()) == [False, True], verdicts
+
+        assert psbt_parser.requires_descriptor_verification is True
+
+
+    def test_requires_descriptor_verification_true_for_miniscript_policy(self):
+        """
+        A Miniscript wsh() policy has no m/n, so is_multisig is False and the
+        change-verification flow would have tried to re-derive the address from a
+        single key -- impossible for a wsh() script, and surfaced to the user as a
+        failed verification on a perfectly valid transaction.
+        """
+        psbt, seed, _, _, _ = self.build_liana_style_psbt()
+
+        psbt_parser = PSBTParser(p=psbt, seed=seed, network=SettingsConstants.REGTEST)
+
+        assert psbt_parser.is_multisig is False
+        assert psbt_parser.requires_descriptor_verification is True

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -1534,3 +1534,47 @@ class TestPSBTParserMiniscript:
 
         assert psbt_parser.is_multisig is False
         assert psbt_parser.requires_descriptor_verification is True
+
+
+    def test_has_signature_from_seed_distinguishes_already_signed_from_cannot_sign(self):
+        """
+        sig_count() cannot tell "this seed already signed" apart from "this seed
+        cannot sign this psbt": partial_sigs is keyed by pubkey, so re-signing
+        overwrites the existing entry and the count is unchanged either way.
+        The signing flow reported both as "Signing Failed".
+
+        Observed on hardware with a 3-of-3 Liana wallet: a psbt exported after
+        one key had already signed, then offered to that same seed again, told
+        the user signing had failed when the transaction was in fact validly
+        signed by it. Much more reachable on n-of-n and multisig wallets, where
+        the same psbt is signed repeatedly with different seeds.
+        """
+        net = NETWORKS["regtest"]
+        psbt, seed, _, _ = self.build_miniscript_psbt()
+
+        root = bip32.HDKey.from_seed(seed.seed_bytes, version=net["xprv"])
+        inp = psbt.inputs[0]
+
+        # Nothing signed yet: this seed has no signature on the psbt.
+        assert PSBTParser.has_signature_from_seed(psbt, root) is False
+
+        # A signature for a key that really does derive from this seed. Reuses
+        # the psbt's own pubkey object, since partial_sigs and bip32_derivations
+        # must be keyed consistently for the lookup to find it.
+        our_pubkey, our_derivation = list(inp.bip32_derivations.items())[0]
+        assert root.derive(our_derivation.derivation).key.sec() == our_pubkey.sec(), \
+            "fixture sanity: this derivation should belong to the signing seed"
+        inp.partial_sigs[our_pubkey] = b"\x30" * 71
+        assert PSBTParser.has_signature_from_seed(psbt, root) is True
+
+        # A different seed must not be told it already signed, even though the
+        # psbt's claimed fingerprints are unchanged -- the check re-derives and
+        # compares real key material rather than trusting those 32-bit claims.
+        other_root = bip32.HDKey.from_seed(
+            bip39.mnemonic_to_seed(self.MNEMONIC_FOREIGN), version=net["xprv"]
+        )
+        assert PSBTParser.has_signature_from_seed(psbt, other_root) is False
+
+        # sig_count() gives the same answer in both cases, which is exactly why
+        # it could not drive this distinction on its own.
+        assert PSBTParser.sig_count(psbt) == 1

--- a/tests/test_psbt_parser.py
+++ b/tests/test_psbt_parser.py
@@ -4,11 +4,13 @@ import random
 from binascii import a2b_base64
 from copy import deepcopy
 from unittest.mock import patch
-from embit import bip32, script
+from embit import bip32, bip39, script
 from embit.ec import PublicKey
 from embit.networks import NETWORKS
 from embit.psbt import PSBT, DerivationPath
 from embit.descriptor import Descriptor
+from embit.descriptor.checksum import add_checksum
+from embit.transaction import Transaction, TransactionInput, TransactionOutput
 
 from seedsigner.models.psbt_parser import (PSBTInputOwnershipClaimError,
     PSBTOutputOwnershipClaimError, PSBTParser, PSBTSeedCannotSignError)
@@ -1238,3 +1240,133 @@ class TestPSBTParserSeedOwnership:
 
         with pytest.raises(PSBTSeedCannotSignError):
             self._parse(psbt)
+
+class TestPSBTParserMiniscript:
+    """
+    Regression tests for two crashes found only by running a real Liana Miniscript
+    PSBT through PSBTParser on physical SeedSigner hardware -- neither was caught by
+    the existing basic-multisig/single-sig test fixtures above, since both are
+    specific to a witness script that isn't a bare OP_CHECKMULTISIG script.
+
+    Builds a real wsh(or_d(pk(...),and_v(v:pkh(...),older(...)))) descriptor from
+    scratch (Liana's standard "primary key OR recovery-key-after-timelock" policy)
+    using the same known-safe test mnemonics already used elsewhere in this file's
+    sibling PSBTTestData vectors, rather than reusing pre-recorded hex snippets --
+    there's no existing Miniscript fixture to draw from.
+    """
+    MNEMONIC_PRIMARY = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    MNEMONIC_RECOVERY = "baby mass dust captain baby mass dust captain baby mass dust casino"
+    MNEMONIC_FOREIGN = "sign sword lift deer ocean insect web lazy sick pencil start select"
+
+    def build_miniscript_psbt(self):
+        """
+        Returns (psbt, seed, our_change_address, foreign_address) for a single-input
+        spend from a Liana-style wsh() Miniscript wallet:
+          - 1 input, spending our wsh() UTXO (triggers _get_policy -> _parse_multisig
+            on a non-bare-multisig script -- this alone crashed before the fix)
+          - output 0: our own change (branch 1, correctly carries witness_script +
+            bip32_derivations, exactly as a real coordinator like Liana populates it
+            for its own outputs)
+          - output 1: an unrelated p2wsh output belonging to a different wallet
+            entirely, with NO witness_script and NO bip32_derivations -- exactly
+            what a real coordinator does for an output it doesn't recognize as its
+            own. Before the fix, this output could still spuriously match our
+            degraded {"type": "p2wsh"} policy (no m/n/cosigners to tell wallets
+            apart) and crash trying to reconstruct a script from a None witness_script.
+        """
+        net = NETWORKS["regtest"]
+
+        root_primary = bip32.HDKey.from_seed(bip39.mnemonic_to_seed(self.MNEMONIC_PRIMARY), version=net["xprv"])
+        fp_primary = root_primary.my_fingerprint
+        acct_primary = root_primary.derive("m/48h/1h/0h/2h")
+        xpub_primary = acct_primary.to_public().to_base58(version=net["xpub"])
+
+        root_recovery = bip32.HDKey.from_seed(bip39.mnemonic_to_seed(self.MNEMONIC_RECOVERY), version=net["xprv"])
+        fp_recovery = root_recovery.my_fingerprint
+        acct_recovery = root_recovery.derive("m/48h/1h/0h/2h")
+        xpub_recovery = acct_recovery.to_public().to_base58(version=net["xpub"])
+
+        body = (
+            f"wsh(or_d(pk([{fp_primary.hex()}/48h/1h/0h/2h]{xpub_primary}/<0;1>/*),"
+            f"and_v(v:pkh([{fp_recovery.hex()}/48h/1h/0h/2h]{xpub_recovery}/<0;1>/*),older(2))))"
+        )
+        descriptor = Descriptor.from_string(add_checksum(body))
+
+        inp_derived = descriptor.derive(0, branch_index=0)
+        inp_script = inp_derived.script_pubkey()
+        inp_witness_script = script.Script(inp_derived.miniscript.compile())
+        inp_pubkey = acct_primary.derive("m/0/0").to_public()
+
+        change_derived = descriptor.derive(0, branch_index=1)
+        change_script = change_derived.script_pubkey()
+        change_witness_script = script.Script(change_derived.miniscript.compile())
+        change_pubkey = acct_primary.derive("m/1/0").to_public()
+
+        root_foreign = bip32.HDKey.from_seed(bip39.mnemonic_to_seed(self.MNEMONIC_FOREIGN), version=net["xprv"])
+        foreign_pubkey = root_foreign.derive("m/0h").to_public()
+        # Trivial p2wsh(pk) script -- content doesn't matter, only that it's a
+        # p2wsh output this wallet has no key for and no witness_script to verify.
+        foreign_script = script.p2wsh(script.Script(b"\x21" + foreign_pubkey.sec() + b"\xac"))
+
+        tx = Transaction(
+            vin=[TransactionInput(bytes(32), 0)],
+            vout=[
+                TransactionOutput(50_000, change_script),
+                TransactionOutput(30_000, foreign_script),
+            ],
+        )
+        psbt = PSBT(tx)
+        inp = psbt.inputs[0]
+        inp.witness_utxo = TransactionOutput(100_000, inp_script)
+        inp.witness_script = inp_witness_script
+        inp.bip32_derivations[inp_pubkey] = DerivationPath(fp_primary, [48 + 2**31, 1 + 2**31, 0 + 2**31, 2 + 2**31, 0, 0])
+
+        psbt.outputs[0].witness_script = change_witness_script
+        psbt.outputs[0].bip32_derivations[change_pubkey] = DerivationPath(fp_primary, [48 + 2**31, 1 + 2**31, 0 + 2**31, 2 + 2**31, 1, 0])
+        # output 1 (foreign) deliberately gets no witness_script / bip32_derivations.
+
+        seed = Seed(self.MNEMONIC_PRIMARY.split())
+        return psbt, seed, change_script.address(network=net), foreign_script.address(network=net)
+
+
+    def test_miniscript_input_does_not_crash_policy_parsing(self):
+        """
+        Regression test: _get_policy() -> _parse_multisig() used to raise an
+        unhandled ValueError("Not a multisig script") for any witness script that
+        isn't bare OP_CHECKMULTISIG, which includes every real Miniscript wsh()
+        script. This crashed PSBTParser's __init__ outright on real hardware when
+        scanning a genuine Liana Miniscript PSBT.
+        """
+        psbt, seed, _, _ = self.build_miniscript_psbt()
+
+        # Must not raise.
+        psbt_parser = PSBTParser(p=psbt, seed=seed, network=SettingsConstants.REGTEST)
+
+        assert psbt_parser.num_inputs == 1
+        assert psbt_parser.policy["type"] == "p2wsh"
+        assert "m" not in psbt_parser.policy  # degraded policy: no cosigners to report
+        assert "n" not in psbt_parser.policy
+
+
+    def test_foreign_output_not_misattributed_as_change(self):
+        """
+        Regression test: with a degraded policy (no m/n/cosigners), out_policy ==
+        self.policy only proves an output's script *type* matches ours, not that
+        it's actually part of our wallet. Before the fix, an unrelated same-type
+        output reaching the change-reconstruction code with witness_script still
+        None crashed in script.p2wsh(). This confirms it's now correctly classified
+        as an external destination instead -- not just "doesn't crash", but
+        actually correct: our own change is still found, and the foreign output is
+        never mistaken for it.
+        """
+        psbt, seed, our_change_address, foreign_address = self.build_miniscript_psbt()
+
+        psbt_parser = PSBTParser(p=psbt, seed=seed, network=SettingsConstants.REGTEST)
+
+        assert psbt_parser.num_change_outputs == 1
+        assert psbt_parser.change_amount == 50_000
+        assert psbt_parser.change_data[0]["address"] == our_change_address
+
+        assert psbt_parser.num_destinations == 1
+        assert psbt_parser.spend_amount == 30_000
+        assert psbt_parser.destination_addresses == [foreign_address]

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -128,3 +128,35 @@ def test_compact_seedqr_bytes_interpretable_as_str():
         entropy_bytes.decode()  # should not raise an exception
         mnemonic_length = 12 if len(entropy_bytes) == 16 else 24
         run_encode_decode_test(entropy_bytes, mnemonic_length=mnemonic_length, qr_type=QRType.SEED__COMPACTSEEDQR)
+
+
+def test_compact_seedqr_not_misdetected_as_wallet_descriptor():
+    """
+    A variant of the #656 class of bug above, specific to wallet-descriptor QR
+    detection: detect_segment_type()'s wallet-descriptor check matches on a short
+    prefix (as little as "tr(", 3 bytes) against the same speculatively-decoded
+    string tested above. If a Compact SeedQR's raw entropy happens to both survive
+    that decode *and* start with one of those prefixes, it would be misclassified
+    as QRType.WALLET__GENERIC instead of QRType.SEED__COMPACTSEEDQR.
+
+    Unlike the #656 vectors above (chosen only to decode without raising), these are
+    deliberately crafted to also match the wallet-descriptor prefix pattern, since
+    that's the specific additional condition needed to trigger this variant.
+
+    Note: this is a constructed case, not one observed in the wild -- the odds of
+    real entropy hitting it are low. It's tested because the prefix match replaced
+    a much longer `"sortedmulti"` substring check, which made the collision
+    negligible; these prefixes do not.
+    """
+    prefixes = [b"sh(", b"wsh(", b"tr(", b"pkh(", b"wpkh(", b"combo("]
+
+    for prefix in prefixes:
+        # 24-word (32-byte) entropy
+        entropy = (prefix + bytes(32))[:32]
+        entropy.decode()  # should not raise -- confirms this exercises the real risk
+        run_encode_decode_test(entropy, mnemonic_length=24, qr_type=QRType.SEED__COMPACTSEEDQR)
+
+        # 12-word (16-byte) entropy
+        entropy = (prefix + bytes(16))[:16]
+        entropy.decode()
+        run_encode_decode_test(entropy, mnemonic_length=12, qr_type=QRType.SEED__COMPACTSEEDQR)


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

SeedSigner's `ScanView.run()` gates wallet-descriptor registration on
`descriptor.is_basic_multisig`, silently routing anything else — including
any Miniscript `wsh()`/`tr()` descriptor — to `NotYetImplementedView`. This
blocks using SeedSigner as a signer for any Miniscript-based wallet, most
concretely [Liana](https://github.com/wizardsardine/liana)'s inheritance
policies (a primary key, plus a recovery key that activates after a
timelock).

This has been discussed here in #306 on and off since 2023. This PR targets
the "v1" scope multiple contributors converged on there: descriptor decode,
validation, and policy review, plus signing, for `wsh()` — no persistent
registration/proof-of-registration yet, taproot signing deferred.

### Solution

- New `get_descriptor_policy_summary()` / `is_supported_wallet_descriptor()`
  / `can_derive_multisig_address()` helpers in `embit_utils.py` — a
  recursive Miniscript-AST walker that turns any `wsh()`/`tr()` policy into
  a plain-English summary (e.g. `(key ABCD1234) or ((key 5678EFGH) and
  (after 1000 blocks))`), used in place of the old basic-multisig-only
  `get_multisig_policy()` at its call sites.
- Wired into the existing `ScanView`, `MultisigWalletDescriptorView`,
  `ToolsAddressExplorerAddressTypeView`, and
  `ToolsAddressExplorerAddressListView` — the registration gate is loosened,
  no new views added.
- `decode_qr.py`'s QR-type detection had a second, earlier gate that's easy
  to miss: a plain-text wallet-descriptor QR was only classified as
  `WALLET__GENERIC` if it contained the literal substring `"sortedmulti"` —
  stricter than the registration view's own check, so a Miniscript
  descriptor QR could fail to even be recognized before ever reaching
  `Descriptor.from_string()`. Now matches on the descriptor's real top-level
  function (`sh`/`wsh`/`tr`/`pkh`/`wpkh`/`combo`); a merely descriptor-shaped
  string that isn't an actual valid descriptor is still rejected downstream
  by `Descriptor.from_string()` itself, so this doesn't loosen validation,
  just recognition.
- `MultisigWalletDescriptorScreen`'s policy line needed
  `auto_line_break=True` (its sibling "Signing Keys" line already has it) —
  Miniscript summaries run longer than the "2 of 3" string this screen was
  originally built for.
- Two `PSBTParser` fixes, both found only once a real Liana PSBT was
  scanned on physical hardware:
  - `_parse_multisig()` raised an unhandled `ValueError` for any witness
    script that isn't bare `OP_CHECKMULTISIG` — i.e. any real Miniscript
    script. Now caught, degrading gracefully to a policy dict without
    `m`/`n`/`cosigners`, matching the existing swallowed-exception pattern
    the same function already uses one level up for `_get_cosigners()`.
  - With that degraded policy, an output belonging to a different wallet
    (or any unrelated address) can share the same generic `{"type":
    "p2wsh"}` policy and reach change-reconstruction code with no
    `witness_script` populated — a real coordinator only fills that in for
    outputs it recognizes as its own — crashing in `script.p2wsh(None)`.
    Now guarded: an output with no witness/redeem script populated is
    correctly treated as not belonging to the wallet.
- The `decode_qr.py` prefix match above is validated with
  `Descriptor.from_string()` before the QR type is assigned. The prefix
  pattern is as short as `tr(` (3 bytes), and `detect_segment_type()`
  speculatively treats all scanned data as text — including binary formats
  that were never strings (CompactSeedQR entropy is matched further down, by
  byte length). Entropy that both survives that conversion and begins with a
  matching prefix would be misclassified as a descriptor; the old
  `"sortedmulti"` substring was long enough for that to be negligible, these
  prefixes are not. `GenericWalletQrDecoder` validates the same way
  downstream, but too late to help — by then `detect_segment_type()` has
  settled on a type with no path back to the seed checks. This is defensive
  hardening for a constructed case, not one observed in the wild.

**Deliberately out of scope:** taproot (`tr()`) *address derivation* and
*signing* remain unimplemented — pre-existing `get_multisig_address()` /
`PSBTParser` limitations, unchanged here. Only taproot *policy display* is
covered by this PR, and it's held to the same correctness bar as `wsh()`: a
hidden script-path recovery leaf is never described as "single signature."

### Additional Information

**Verified end-to-end on physical hardware**, not just unit tests: created a
real Liana wallet on signet
(`wsh(or_d(pk(seedsigner-key),and_v(v:pkh(recovery-key),older(4383))))`),
registered it on a Pi Zero 1.3 running this branch, confirmed the policy
screen and a derived receive address matched Liana byte-for-byte, funded it
via the signet faucet, built a spend in Liana, signed it on-device, and
broadcast — confirmed independently by a third-party node
(mempool.space/signet), not just accepted locally. Txid:
`94e5e8fe8809cf09e24a24eace18fc075676b2d87294bb2b5d382bb57424e7a1`.

SeedSigner has no way to talk to Liana directly — no `async-hwi` driver, and
Liana's own airgap flow is file-based with no QR support at all. Signing was
done through a small standalone companion tool,
[liana-seedsigner-bridge](https://github.com/SovereignGG/liana-seedsigner-bridge),
which reads/writes Liana's file-based PSBT/descriptor exports on one side
and speaks SeedSigner's existing UR2.0/Specter-JSON QR protocols on the
other, via a screen and webcam. It doesn't modify either project and isn't
part of this PR — linked for anyone who wants to reproduce the test.

Both `PSBTParser` fixes came from that hardware run, not code review — a
reminder that this class of bug (code implicitly assuming a witness script
is always bare `OP_CHECKMULTISIG`) is easy to miss without an actual
Miniscript PSBT to test against, and there may be more instances elsewhere
in the codebase.

**Not included, left for follow-up:** taproot address/signing support
(tracked as a known gap, not attempted here), the fingerprint-vs-xpub
alias/proof-of-registration design discussed later in #306 (this PR keeps
SeedSigner's existing rescan-every-session trust model rather than adding
persistent state), and a non-CLI version of the bridge tool for less
technical users.

### Screenshots

Real device photo, `MultisigWalletDescriptorScreen` showing the registered
policy from the hardware run referenced above:

<img width="501" height="264" alt="Screenshot 2026-08-27 at 10 24 57 PM" src="https://github.com/user-attachments/assets/536894aa-ee7d-4446-b63f-fbd906dfab1f" />

---

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

217 passed (209 existing + 3 new regression tests: 2 for the `PSBTParser`
fixes and 1 for the `decode_qr.py` fix, plus 5 `l10n` tests that only pass
once the translation catalog is compiled locally — unrelated to this
change, and excluded on a dev machine without that step run).

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [x] Yes
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

New unit tests in `test_embit_utils.py` for the policy-summary/gate helpers,
new `FlowStep` sequences in `test_flows_tools.py` for the registration
gate, and new regression tests in `test_psbt_parser.py` and `test_seedqr.py`
for the fixes above (each confirmed to reproduce the failure against the
pre-fix code before being added).

---

#### I tested this PR hands-on on the following platform(s):
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

Pi Zero 1.3.

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.
