### PR TITLE
Resolves issue 621 - Verify Address for exported Xpub Option

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1051,6 +1051,14 @@ class WarningScreen(WarningEdgesMixin, LargeIconStatusScreen):
 
 
 @dataclass
+class AdviceScreen(WarningEdgesMixin, LargeIconStatusScreen):
+    title: str = _mft("Advice")
+    status_icon_name: str = SeedSignerIconConstants.WARNING
+    status_color: str = "yellow"
+
+
+
+@dataclass
 class DireWarningScreen(WarningScreen):
     """
     Exclamation point icon + orange DIRE_WARNING color

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -142,6 +142,7 @@ class ScanView(View):
                         "address": address,
                         "script_type": script_type,
                         "network": network,
+                        **({"seed": self.seed} if "seed" in self.__dict__ and self.seed is not None else {}) #If the subclass is ScanAddressView, the 'seed' member may be present as an additional argument.
                     }
                 )
             
@@ -203,6 +204,10 @@ class ScanWalletDescriptorView(ScanView):
 class ScanAddressView(ScanView):
     instructions_text = _mft("Scan address QR")
     invalid_qr_type_message = _mft("Expected an address QR")
+
+    def __init__(self, seed=None):
+        super().__init__()
+        self.seed = seed
 
     @property
     def is_valid_qr_type(self):

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -9,7 +9,7 @@ from embit.descriptor import Descriptor
 
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
-    WarningScreen, DireWarningScreen, seed_screens)
+    WarningScreen, DireWarningScreen, seed_screens, AdviceScreen)
 from seedsigner.gui.screens.screen import ButtonOption, ButtonOptionWithoutTranslation
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterLegacyXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
@@ -81,9 +81,15 @@ class SeedSelectSeedView(View):
     def __init__(self, flow: str):
         super().__init__()
         self.flow = flow
+        self.seed = seed
 
 
     def run(self):
+        # If a seed was already provided (e.g. coming from xpub export), skip selection UI
+        if self.seed is not None:
+            if self.flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR:
+                return Destination(SeedAddressVerificationView, view_args={"seed": self.seed})
+    
         from seedsigner.controller import Controller
         seeds = self.controller.storage.seeds
 
@@ -965,6 +971,7 @@ class SeedExportXpubQRDisplayView(View):
     def __init__(self, seed: Seed, xpub_qr_format: str, derivation_path: str, sig_type: str = SettingsConstants.SINGLE_SIG):
         super().__init__()
         self.seed = seed
+        self.sig_type = sig_type
 
         encoder_args = dict(
             seed=self.seed,
@@ -992,7 +999,45 @@ class SeedExportXpubQRDisplayView(View):
             qr_encoder=self.qr_encoder
         )
 
-        return Destination(MainMenuView)
+        if self.sig_type == SettingsConstants.SINGLE_SIG:
+            return Destination(SeedExportXpubQRAskVerifyAddView, view_args={"seed": self.seed})
+        else:
+            return Destination(MainMenuView)
+
+
+
+class SeedExportXpubQRAskVerifyAddView(View):
+    """
+    After exporting a single-sig xpub, ask the user if they want to verify a wallet
+    address against the exported xpub.
+    """
+    VERIFY = ButtonOption("Scan an address", SeedSignerIconConstants.QRCODE)
+    DONE = ButtonOption("Done")
+
+    def __init__(self, seed: Seed):
+        super().__init__()
+        self.seed = seed
+
+
+    def run(self):
+        from seedsigner.views.scan_views import ScanAddressView
+        button_data = [self.VERIFY, self.DONE]
+
+        selected_menu_num = self.run_screen(
+            AdviceScreen,
+            title="Wallet Verification",
+            status_headline="",
+            text=_("Scan a wallet address to verify the exported xpub?"),
+            is_button_text_centered=True,
+            show_back_button=False,
+            button_data=button_data
+        )
+
+        if button_data[selected_menu_num] == self.VERIFY:
+            return Destination(ScanAddressView, view_args={"seed": self.seed}, clear_history=True)
+
+        elif button_data[selected_menu_num] == self.DONE:
+            return Destination(MainMenuView)
 
 
 
@@ -1726,13 +1771,14 @@ class SeedTranscribeSeedQRConfirmSuccessView(View):
     Address verification
 ****************************************************************************"""
 class AddressVerificationStartView(View):
-    def __init__(self, address: str, script_type: str, network: str):
+    def __init__(self, address: str, script_type: str, network: str, seed: Seed = None):
         super().__init__()
         self.controller.unverified_address = dict(
             address=address,
             script_type=script_type,
             network=network
         )
+        self.seed = seed
 
 
     def run(self):
@@ -1742,11 +1788,11 @@ class AddressVerificationStartView(View):
         if self.controller.unverified_address["script_type"] == SettingsConstants.LEGACY_P2PKH:
             # Legacy P2PKH addresses are always singlesig
             sig_type = SettingsConstants.SINGLE_SIG
-            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
+            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR, seed=self.seed), skip_current_view=True)
 
         if self.controller.unverified_address["script_type"] == SettingsConstants.NESTED_SEGWIT:
             # No way to differentiate single sig from multisig
-            return Destination(AddressVerificationSigTypeView, skip_current_view=True)
+            return Destination(AddressVerificationSigTypeView, view_args={"seed": self.seed}, skip_current_view=True)
 
         if self.controller.unverified_address["script_type"] == SettingsConstants.NATIVE_SEGWIT:
             if len(self.controller.unverified_address["address"]) >= 62:
@@ -1761,11 +1807,11 @@ class AddressVerificationStartView(View):
 
             else:
                 sig_type = SettingsConstants.SINGLE_SIG
-                destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
+                destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR, seed=self.seed), skip_current_view=True)
 
         elif self.controller.unverified_address["script_type"] == SettingsConstants.TAPROOT:
             sig_type = SettingsConstants.SINGLE_SIG
-            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR), skip_current_view=True)
+            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR, seed=self.seed), skip_current_view=True)
 
         derivation_path = embit_utils.get_standard_derivation_path(
             network=self.controller.unverified_address["network"],
@@ -1783,6 +1829,11 @@ class AddressVerificationStartView(View):
 class AddressVerificationSigTypeView(View):
     SINGLE_SIG = ButtonOption("Single Sig")
     MULTISIG = ButtonOption("Multisig")
+
+    def __init__(self, seed: Seed = None):
+        super().__init__()
+        self.seed = seed
+      
 
     def run(self):
         from seedsigner.helpers import embit_utils
@@ -1802,7 +1853,7 @@ class AddressVerificationSigTypeView(View):
         
         elif button_data[selected_menu_num] == self.SINGLE_SIG:
             sig_type = SettingsConstants.SINGLE_SIG
-            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR))
+            destination = Destination(SeedSelectSeedView, view_args=dict(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR, seed=self.seed))
 
         elif button_data[selected_menu_num] == self.MULTISIG:
             sig_type = SettingsConstants.MULTISIG

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -85,12 +85,12 @@ class SeedSelectSeedView(View):
 
 
     def run(self):
+        from seedsigner.controller import Controller
         # If a seed was already provided (e.g. coming from xpub export), skip selection UI
         if self.seed is not None:
             if self.flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR:
                 return Destination(SeedAddressVerificationView, view_args={"seed": self.seed})
     
-        from seedsigner.controller import Controller
         seeds = self.controller.storage.seeds
 
         if self.flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -78,7 +78,7 @@ class SeedSelectSeedView(View):
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
 
 
-    def __init__(self, flow: str):
+    def __init__(self, flow: str, seed: Seed = None):
         super().__init__()
         self.flow = flow
         self.seed = seed

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -197,6 +197,7 @@ class TestSeedFlows(FlowTest):
                     FlowStep(seed_views.SeedExportXpubWarningView, screen_return_value=0),
                     FlowStep(seed_views.SeedExportXpubDetailsView, screen_return_value=0),
                     FlowStep(seed_views.SeedExportXpubQRDisplayView, screen_return_value=0),
+                    *( [FlowStep(seed_views.SeedExportXpubQRAskVerifyAddView, screen_return_value=0), FlowStep(scan_views.ScanAddressView, screen_return_value=0) ] if sig_selection == seed_views.SeedExportXpubSigTypeView.SINGLE_SIG else [] ),
                     FlowStep(MainMenuView),
                 ]
         )
@@ -329,6 +330,8 @@ class TestSeedFlows(FlowTest):
                 FlowStep(seed_views.SeedExportXpubWarningView, screen_return_value=0),
                 FlowStep(seed_views.SeedExportXpubDetailsView, screen_return_value=0),
                 FlowStep(seed_views.SeedExportXpubQRDisplayView, screen_return_value=0),
+                FlowStep(seed_views.SeedExportXpubQRAskVerifyAddView, screen_return_value=0),
+                FlowStep(scan_views.ScanAddressView, screen_return_value=0),
                 FlowStep(MainMenuView),
             ]
         )
@@ -392,6 +395,8 @@ class TestSeedFlows(FlowTest):
                 FlowStep(seed_views.SeedExportXpubWarningView, screen_return_value=0),
                 FlowStep(seed_views.SeedExportXpubDetailsView, screen_return_value=0),
                 FlowStep(seed_views.SeedExportXpubQRDisplayView, screen_return_value=0),
+                FlowStep(seed_views.SeedExportXpubQRAskVerifyAddView, screen_return_value=0),
+                FlowStep(scan_views.ScanAddressView, screen_return_value=0),
                 FlowStep(MainMenuView),
             ]
         )


### PR DESCRIPTION
## Description

### Problem or Issue being addressed
Because workflow of exportpubkey would must to be securely closed verifying addresses obtained on wallet software (Sparrow, for instance), issue reported #621 is conceptual consistent. 

Fixes #621 (and replaces original https://github.com/SeedSigner/seedsigner/pull/629)

### Solution

  ### New flow

  After the user exports their xpub as a QR code (`SeedExportXpubQRDisplayView`), instead of returning directly to
  the main menu, they are presented with a new screen (`SeedExportXpubQRAskVerifyAddressView`) that asks:

  > "Scan a wallet address to verify the exported xpub?"

  From there the user can either:
  - **Scan an address** → routes directly to `ScanAddressView`, skipping the seed selection screen since the seed
  is already known from the export flow
  - **Done** → returns to the main menu as before

  This flow only applies to **single-sig** exports. Multisig exports return to the main menu as before.

  ### Adaptation to upstream refactor

  This version also incorporates the refactor introduced in PR #810 (`[Refactor] use Seed instead of seed_num` by
  @Chaitanya-Keyal), replacing all `seed_num: int` references with direct `Seed` object passing throughout the
  verification chain (`SeedSelectSeedView`, `AddressVerificationStartView`, `AddressVerificationSigTypeView`,
  `ScanAddressView`) and also resolves the conflicts present in the original PR #629, which had become
  many commits behind `SeedSigner/seedsigner:dev` due to the upstream refactor mentioned above.

  ### Changes

  - `screen.py` — adds `AdviceScreen`, a new screen class for flow bifurcation (see inline comment for rationale)
  - `scan_views.py` — `ScanAddressView` optionally accepts a `seed` argument
  - `seed_views.py` — main logic; new `SeedExportXpubQRAskVerifyAddressView` class
  - `tests/screenshot_generator/generator.py` — screenshot for new view
  - `tests/test_flows_seed.py` — flow steps for new view added to relevant test cases
  
  Solved remarks (comments below) from @alvroble (Thank you!)
---

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Documentation
- [X] Other (export XPUB address from seed and verify addresses workflow)

---

## Checklist

#### I ran `pytest` locally
- [X] All tests passed before submitting the PR, they was updated, too.
- [ ] I couldn't run the tests
- [ ] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [X] Yes (same in https://github.com/SeedSigner/seedsigner/pull/629)
- [ ] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [X] Yes
- [ ] No, I’m a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [X] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [X] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [X] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [X] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.